### PR TITLE
CMake: Use GitHub urls

### DIFF
--- a/bucket/cmake.json
+++ b/bucket/cmake.json
@@ -43,7 +43,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version-SHA-256.txt"
+            "url": "$baseurl/cmake-$version-SHA-256.txt"
         }
     }
 }


### PR DESCRIPTION
I've been having issues with the binaries not being found sometimes at the current urls. This pr updates the CMake manifest to use the Github release urls which are also used on CMake's download page.