### PR TITLE
Neovim: Add nightly version.

### DIFF
--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://neovim.io/",
+    "description": "Run the latest master biuld of neovim",
+    "version": "nightly",
+    "license": {
+        "identifier": "Apache-2.0,MIT,Vim,Freeware(Node.js)",
+        "url": "https://github.com/neovim/neovim/blob/master/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
+        },
+        "32bit": {
+            "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win32.zip"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2015"
+    },
+    "bin": [
+        "Neovim\\bin\\nvim.exe",
+        "Neovim\\bin\\nvim-qt.exe"
+    ],
+    "shortcuts": [
+        [
+            "Neovim\\bin\\nvim-qt.exe",
+            "Neovim"
+        ]
+    ]
+}


### PR DESCRIPTION
Add a new neovim-nightly.json to allow users to install the nightly
builds of neovim, instead of just the stable/release builds.