### PR TITLE
aws-iam-authenticator: Fix checkver

### DIFF
--- a/bucket/aws-iam-authenticator.json
+++ b/bucket/aws-iam-authenticator.json
@@ -6,7 +6,7 @@
     "url": "https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/windows/amd64/aws-iam-authenticator.exe",
     "hash": "d6042a54a6be42c34fc9bcad7e07ae0da345b3d9505c14b4dd5f7e25691ff8f4",
     "bin": "aws-iam-authenticator.exe",
-    "checkver": "/(?<kubernetes>[\\d.]+)/(?<version>[\\d-]+)/bin/windows/amd64/aws-iam-authenticator.exe\"",
+    "checkver": "/(?<kubernetes>[\\d.]+)/(?<version>[\\d-]+)/bin/windows/amd64/aws-iam-authenticator.exe",
     "autoupdate": {
         "url": "https://amazon-eks.s3-us-west-2.amazonaws.com/$matchKubernetes/$version/bin/windows/amd64/aws-iam-authenticator.exe",
         "hash": {


### PR DESCRIPTION
Extra quote is causing `checkver` to fail.