### PR TITLE
Racket: use official url instead of mirror's

### DIFF
--- a/bucket/racket.json
+++ b/bucket/racket.json
@@ -2,6 +2,7 @@
     "version": "7.3",
     "homepage": "https://racket-lang.org",
     "license": "LGPL-3.0",
+    "description": "A general-purpose, feature-rich programming language developed from Scheme Lisp, also the family of the core language and its dialects. It includes an extensive macro system for creating and implementing language constructs and dialects; eventspaces and custodians for resource management; units, modules and classes for programming in the large; paritial continuation; the first contract system for higher-order functions, and more.",
     "architecture": {
         "64bit": {
             "url": "https://mirror.racket-lang.org/installers/7.3/racket-7.3-x86_64-win32.exe#/dl.7z",

--- a/bucket/racket.json
+++ b/bucket/racket.json
@@ -4,11 +4,11 @@
     "license": "LGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://www.cs.utah.edu/plt/installers/7.3/racket-7.3-x86_64-win32.exe#/dl.7z",
+            "url": "https://mirror.racket-lang.org/installers/7.3/racket-7.3-x86_64-win32.exe#/dl.7z",
             "hash": "sha1:bf88276b4f708b00ba60b2524386ca09227048d0"
         },
         "32bit": {
-            "url": "https://www.cs.utah.edu/plt/installers/7.3/racket-7.3-i386-win32.exe#/dl.7z",
+            "url": "https://mirror.racket-lang.org/installers/7.3/racket-7.3-i386-win32.exe#/dl.7z",
             "hash": "sha1:321c230899ed5fbfb7987c50bf07aacf528dd951"
         }
     },
@@ -33,10 +33,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.cs.utah.edu/plt/installers/$version/racket-$version-x86_64-win32.exe#/dl.7z"
+                "url": "https://mirror.racket-lang.org/installers/$version/racket-$version-x86_64-win32.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://www.cs.utah.edu/plt/installers/$version/racket-$version-i386-win32.exe#/dl.7z"
+                "url": "https://mirror.racket-lang.org/installers/$version/racket-$version-i386-win32.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
```
ERROR Download failed! (Error 3) Resource was not found
ERROR https://www.cs.utah.edu/plt/installers/7.3/racket-7.3-x86_64-win32.exe#/dl.7z
    referer=https://www.cs.utah.edu/plt/installers/7.3/racket-7.3-x86_64-win32.exe#/
    dir=C:\Users\foo\scoop\cache
    out=racket#7.3#https_www.cs.utah.edu_plt_installers_7.3_racket-7.3-x86_64-win32.exe_dl.7z

ERROR & 'C:\Users\foo\scoop\apps\aria2\current\aria2c.exe' --input-file='C:\Users\foo\scoop\cache\racket.txt' --user-agent='Scoop/1.0 (+http://scoop.sh/) PowerShell/5.1 (Windows NT 10.0; Win64; x64; Desktop)' --allow-overwrite=true --auto-file-renaming=false --retry-wait=2 --split=5 --max-connection-per-server=16 --min-split-size=5M --console-log-level=warn --enable-color=false --no-conf=true --follow-metalink=true --metalink-preferred-protocol=https --min-tls-version=TLSv1.2 --stop-with-process=6076 --continue

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/scoopinstaller/scoop-main/issues/new?title=racket%407.3%3a+download+via+aria2+failed
```

Mirror seems not always updated in-time