### PR TITLE
RedPen: Add version 1.10.1

### DIFF
--- a/bucket/redpen.json
+++ b/bucket/redpen.json
@@ -1,0 +1,27 @@
+{
+    "version": "1.10.1",
+    "description": "A proofreading tool.",
+    "homepage": "http://redpen.cc",
+    "license": "Apache-2.0",
+    "url": "https://github.com/redpen-cc/redpen/releases/download/redpen-1.10.1/redpen-1.10.1.tar.gz",
+    "hash": "39a148d3d89efef0e58ee7250e1bab7e26bf1edf83616934265c603623351fa0",
+    "extract_dir": "redpen-distribution-1.10.1",
+    "bin": [
+        "bin\\redpen.bat",
+        "bin\\redpen-server.bat"
+    ],
+    "suggest": {
+        "Java": [
+            "oraclejdk",
+            "adopt8-hotspot-jre"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/redpen-cc/redpen/",
+        "regex": "Release ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/redpen-cc/redpen/releases/download/redpen-$version/redpen-$version.tar.gz",
+        "extract_dir": "redpen-distribution-$version"
+    }
+}


### PR DESCRIPTION
I added RedPen, which was a proofreading tool for writers or programmers.
According to [the comment](https://github.com/lukesampson/scoop-extras/pull/2159#issuecomment-493436103) by @Ash258 in https://github.com/lukesampson/scoop-extras/pull/2159, I sent this PR to this main bucket.

