### PR TITLE
innounp: Update to 0.49

### DIFF
--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.48",
+    "version": "0.49",
     "description": "Inno Setup Unpacker.",
     "homepage": "http://innounp.sourceforge.net",
     "license": "GPL-3.0-only",
-    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp048.rar",
-    "hash": "sha1:638a8ff3b87c40d12b43ca964e6777baca2176c8",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp049.rar",
+    "hash": "sha1:a3dfd3caf456c301265d9e115e6393059b3f0fad",
     "bin": "innounp.exe",
     "checkver": "Version\\s+([\\d\\.]+)\\s*<br>",
     "autoupdate": {
         "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/innounp/innounp$cleanVersion.rar",
         "hash": {
-            "url": "$baseurl/innounp$cleanVersion.sha1"
+            "url": "$url.sha1"
         }
     }
 }


### PR DESCRIPTION
Merge after https://github.com/ScoopInstaller/Binary/pull/7

https://github.com/lukesampson/scoop-extras/commit/7a8a8438515ebca830f96333b028f1ac7605b0bb should be reverted.