### PR TITLE
git-annex 7.20190507: fix hash

### DIFF
--- a/bucket/git-annex.json
+++ b/bucket/git-annex.json
@@ -6,7 +6,7 @@
     "notes": "NOTE: Running `git-annex version` may report a slightly older version number",
     "bin": "usr/bin/git-annex.exe",
     "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
-    "hash": "863a77032182121c3a1933e8068388d7c4f4264f49b94907a0716f65ff7109ef",
+    "hash": "22320f6e15c6dc5a9fd1a3407c2eab18b7993c3600ce5fa3a2e789dd61d665dc",
     "checkver": {
         "url": "https://hackage.haskell.org/package/git-annex",
         "re": "/git-annex-([\\d.]+)\\.tar\\.gz"


### PR DESCRIPTION
```
Checking hash of git-annex-installer.exe ... ERROR Hash check failed!
App:         main/git-annex
URL:         https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z
First bytes: 4D 5A 90 00 03 00 00 00
Expected:    863a77032182121c3a1933e8068388d7c4f4264f49b94907a0716f65ff7109ef
Actual:      22320f6e15c6dc5a9fd1a3407c2eab18b7993c3600ce5fa3a2e789dd61d665dc
```

https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe.info

```
GitAnnexDistribution {distributionUrl = "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe", distributionKey = Key {keyName = "22320f6e15c6dc5a9fd1a3407c2eab18b7993c3600ce5fa3a2e789dd61d665dc.exe", keyVariety = SHA2Key (HashSize 256) (HasExt True), keySize = Just 15074004, keyMtime = Nothing, keyChunkSize = Nothing, keyChunkNum = Nothing}, distributionVersion = "7.20190508", distributionReleasedate = 2019-05-07 22:26:22.487053983 UTC, distributionUrgentUpgrade = Just "6.20180626"}
https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe
SHA256E-s15074004--22320f6e15c6dc5a9fd1a3407c2eab18b7993c3600ce5fa3a2e789dd61d665dc.exe
7.20190508
2019-05-07 22:26:22.487053983 UTC
"6.20180626"
```


I don't know why hash autoupdate doesn't work.