### PR TITLE
neovim: Fix hash

### DIFF
--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -1,23 +1,24 @@
 {
+    "homepage": "https://neovim.io/",
     "version": "0.3.5",
+    "description": "Vim-fork focused on extensibility and usability",
     "license": {
-        "identifier": "Apache-2.0,MIT,Vim,Freeware(Node.js)",
+        "identifier": "Apache-2.0,MIT,Vim",
         "url": "https://github.com/neovim/neovim/blob/master/LICENSE"
     },
     "architecture": {
         "64bit": {
             "url": "https://github.com/neovim/neovim/releases/download/v0.3.5/nvim-win64.zip",
-            "hash": "ecde1d19b7045d785aede4e2f710ac66b987e775676d7c9d537238495eb534b1"
+            "hash": "8ae18bf555433535b6406935f3a8979026034b4981619ff6abceff4358940f66"
         },
         "32bit": {
             "url": "https://github.com/neovim/neovim/releases/download/v0.3.5/nvim-win32.zip",
-            "hash": "cd27975c8ecf3c0edae492fa6e1c40d82fdadd78521fee55c911fd26bfb54a8c"
+            "hash": "a0e33abc79bb30b92aa273fd9c66db54676a9f0136c034861d2a51de58a2f08a"
         }
     },
     "suggest": {
         "vcredist": "extras/vcredist2015"
     },
-    "homepage": "https://neovim.io/",
     "bin": [
         "Neovim\\bin\\nvim.exe",
         "Neovim\\bin\\nvim-qt.exe"


### PR DESCRIPTION
neovim's release 0.3.5 is refreshed at 2019-05-25T20:29:02Z, and hashes change again...

Close #86