### PR TITLE
git-interactive-rebase-tool: Update to version 1.0.0

### DIFF
--- a/bucket/git-interactive-rebase-tool.json
+++ b/bucket/git-interactive-rebase-tool.json
@@ -1,15 +1,11 @@
 {
     "homepage": "https://gitrebasetool.mitmaro.ca/",
-    "version": "0.7.0",
-    "license": "ISC",
+    "version": "1.0.0",
+    "license": "GPL-3.0",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/MitMaro/git-interactive-rebase-tool/releases/download/0.7.0/git-interactive-rebase-tool-0.7.0-i686-pc-windows-msvc.zip",
-            "hash": "3d0e7e33c03929052830aefb40fdde1644e3cbb72b82c3a54b4308e197949a73"
-        },
         "64bit": {
-            "url": "https://github.com/MitMaro/git-interactive-rebase-tool/releases/download/0.7.0/git-interactive-rebase-tool-0.7.0-x86_64-pc-windows-msvc.zip",
-            "hash": "158d5f5d0549da0d576d3d760c515f6e7c96be5dd451dd312f4090ad0ee5d269"
+            "url": "https://github.com/MitMaro/git-interactive-rebase-tool/releases/download/1.0.0/git-interactive-rebase-tool-1.0.0-x86_64-pc-windows-msvc.zip",
+            "hash": "e89285a49d5bb8dcecb156b981f83260d5117cd4279719f3fb534351593ef872"
         }
     },
     "bin": "interactive-rebase-tool.exe",
@@ -19,9 +15,6 @@
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/MitMaro/git-interactive-rebase-tool/releases/download/$version/git-interactive-rebase-tool-$version-i686-pc-windows-msvc.zip"
-            },
             "64bit": {
                 "url": "https://github.com/MitMaro/git-interactive-rebase-tool/releases/download/$version/git-interactive-rebase-tool-$version-x86_64-pc-windows-msvc.zip"
             }


### PR DESCRIPTION
No 32bit binaries have been provided in the `1.0-RC` or `1.0.x` releases. Dropping support in favor of bumping to the stable `1.0.0` release.

https://github.com/MitMaro/git-interactive-rebase-tool/releases