### PR TITLE
git-tfs: Update to version 0.30

### DIFF
--- a/bucket/git-tfs.json
+++ b/bucket/git-tfs.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.29.0",
+    "version": "0.30",
     "description": "A Git/TFS bridge, similar to git-svn.",
     "homepage": "https://git-tfs.com",
     "license": "Apache-2.0",
     "depends": "git",
-    "url": "https://github.com/git-tfs/git-tfs/releases/download/v0.29.0/GitTfs-0.29.0.zip",
-    "hash": "029c514e1ce5740ae99ac3a7b30875610b2af9c1ed22e56e0ae9fcb75d11dcf3",
+    "url": "https://github.com/git-tfs/git-tfs/releases/download/v0.30/GitTfs-0.30.0.zip",
+    "hash": "30316FF3EABF8784E47EB3DF87564F68F9E0050AFC9FB20056E3B2D90D4BE99B",
     "bin": "git-tfs.exe",
     "checkver": {
         "github": "https://github.com/git-tfs/git-tfs"


### PR DESCRIPTION
Version deviates from standard naming convention (missing patch version):

https://github.com/git-tfs/git-tfs/releases

Manual update in anticipation of future releases returning to consistent pattern.