### PR TITLE
caddy: Update to version 1.0.0 and fix 32bit URL

### DIFF
--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.11.5",
+    "version": "1.0.0",
     "homepage": "https://caddyserver.com",
     "description": "HTTP/2 web server with automatic HTTPS",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v0.11.5/caddy_v0.11.5_windows_amd64.zip",
-            "hash": "3a43f833c30b63be0b985086e15e545a2f0755ff11ae77297880e566405e6746"
+            "url": "https://github.com/mholt/caddy/releases/download/v1.0.0/caddy_v1.0.0_windows_amd64.zip",
+            "hash": "c8cb7093e427662edc2345baadb9caf868c9b0c2167ec33d831c4f2c8a2ceea2"
         },
         "32bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v0.11.5/caddy_v0.11.5_windows_386.zip",
-            "hash": "754572ca6fbeddde13afb4b8c12f5539fcf61fda4f2a713938f189e46dbdd2a3"
+            "url": "https://caddyserver.com/download/windows/386?license=personal&telemetry=off",
+            "hash": "9ee82912eeeade89044a366ab9feaac3d5cdd8ab9c60e27fc067fabd797fb3e0"
         }
     },
     "bin": "caddy.exe",
@@ -23,7 +23,7 @@
                 "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_v$version_windows_amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_v$version_windows_386.zip"
+                "url": "https://caddyserver.com/download/windows/386?license=personal&telemetry=off"
             }
         }
     }

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -9,7 +9,7 @@
             "hash": "c8cb7093e427662edc2345baadb9caf868c9b0c2167ec33d831c4f2c8a2ceea2"
         },
         "32bit": {
-            "url": "https://caddyserver.com/download/windows/386?license=personal&telemetry=off",
+            "url": "https://caddyserver.com/download/windows/386?license=personal&telemetry=off&version=v1.0.0",
             "hash": "9ee82912eeeade89044a366ab9feaac3d5cdd8ab9c60e27fc067fabd797fb3e0"
         }
     },
@@ -23,7 +23,7 @@
                 "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_v$version_windows_amd64.zip"
             },
             "32bit": {
-                "url": "https://caddyserver.com/download/windows/386?license=personal&telemetry=off"
+                "url": "https://caddyserver.com/download/windows/386?license=personal&telemetry=off&version=v$version"
             }
         }
     }


### PR DESCRIPTION
Upgrade caddy to v1.0.0 from v0.11.5.

Official [github release page](https://github.com/mholt/caddy/releases) don't offer 32-bit caddy, so I changed the download url for 32-bit.
More to see mholt/caddy#2628.