### PR TITLE
adb: Update to version 28.0.3

### DIFF
--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -19,7 +19,7 @@
         "url": "https://dl.google.com/android/repository/platform-tools_r$version-windows.zip",
         "hash": {
             "url": "https://dl.google.com/android/repository/repository2-1.xml",
-            "find": "<checksum>([a-fA-F0-9]{40})</checksum>[\\n\\t.]+<url>platform-tools_r$version-windows.zip"
+            "xpath": "/sdk:sdk-repository/remotePackage/archives/archive/complete[url='$basename']/checksum"
         }
     }
 }

--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -1,6 +1,7 @@
 {
     "version": "28.0.3",
     "homepage": "https://developer.android.com/studio/releases/platform-tools.html",
+    "license": "Apache-2.0",
     "description": "Android SDK platform-tools includes tools that interface with the Android platform, such as adb, fastboot, and systrace",
     "url": "https://dl.google.com/android/repository/platform-tools_r28.0.3-windows.zip",
     "hash": "sha1:6d2db43c69a71bcd7b897b5386e065dfa713b340",

--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -5,6 +5,7 @@
     "description": "Android SDK platform-tools includes tools that interface with the Android platform, such as adb, fastboot, and systrace",
     "url": "https://dl.google.com/android/repository/platform-tools_r28.0.3-windows.zip",
     "hash": "sha1:6d2db43c69a71bcd7b897b5386e065dfa713b340",
+    "extract_dir": "platform-tools",
     "bin": [
         "platform-tools\\adb.exe",
         "platform-tools\\dmtracedump.exe",

--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -3,7 +3,7 @@
     "homepage": "https://developer.android.com/studio/releases/platform-tools.html",
     "description": "Android SDK platform-tools includes tools that interface with the Android platform, such as adb, fastboot, and systrace",
     "url": "https://dl.google.com/android/repository/platform-tools_r28.0.3-windows.zip",
-    "hash": "0fdbc4bcbfcc2b9437f36d7c17cf7bb318532221de54c7e71fc980f05f51bcbf",
+    "hash": "sha1:6d2db43c69a71bcd7b897b5386e065dfa713b340",
     "bin": [
         "platform-tools\\adb.exe",
         "platform-tools\\dmtracedump.exe",
@@ -16,6 +16,10 @@
         "re": "platform-tools_r(?<version>[\\d.]+)-windows.zip"
     },
     "autoupdate": {
-        "url": "https://dl.google.com/android/repository/platform-tools_r$version-windows.zip"
+        "url": "https://dl.google.com/android/repository/platform-tools_r$version-windows.zip",
+        "hash": {
+            "url": "https://dl.google.com/android/repository/repository2-1.xml",
+            "find": "<checksum>([a-fA-F0-9]{40})</checksum>[\\n\\t.]+<url>platform-tools_r$version-windows.zip"
+        }
     }
 }

--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -1,9 +1,9 @@
 {
-    "version": "28.0.2",
+    "version": "28.0.3",
     "homepage": "https://developer.android.com/studio/releases/platform-tools.html",
     "description": "Android SDK platform-tools includes tools that interface with the Android platform, such as adb, fastboot, and systrace",
-    "url": "https://dl.google.com/android/repository/platform-tools_r28.0.2-windows.zip",
-    "hash": "6a721560633babebc74f9330d7184a23d74d18b835cc769f81bbf977575b3800",
+    "url": "https://dl.google.com/android/repository/platform-tools_r28.0.3-windows.zip",
+    "hash": "0fdbc4bcbfcc2b9437f36d7c17cf7bb318532221de54c7e71fc980f05f51bcbf",
     "bin": [
         "platform-tools\\adb.exe",
         "platform-tools\\dmtracedump.exe",
@@ -11,7 +11,10 @@
         "platform-tools\\fastboot.exe",
         "platform-tools\\hprof-conv.exe"
     ],
-    "checkver": "<h4.*>([\\d.]+) \\(.*\\)</h4>",
+    "checkver": {
+        "url": "https://dl.google.com/android/repository/repository2-1.xml",
+        "re": "platform-tools_r(?<version>[\\d.]+)-windows.zip"
+    },
     "autoupdate": {
         "url": "https://dl.google.com/android/repository/platform-tools_r$version-windows.zip"
     }


### PR DESCRIPTION
Update adb to 28.0.3 and fix autoupdate.

Just like sdk manager of android studio, we could use https://dl.google.com/android/repository/repository2-1.xml to check latest sdk tools. 