### PR TITLE
helm: Add tiller.exe binary

### DIFF
--- a/bucket/helm.json
+++ b/bucket/helm.json
@@ -9,7 +9,10 @@
         }
     },
     "extract_dir": "windows-amd64",
-    "bin": "helm.exe",
+    "bin": [
+        "helm.exe",
+        "tiller.exe"
+    ],
     "checkver": {
         "github": "https://github.com/kubernetes/helm"
     },


### PR DESCRIPTION
Along with helm executable there is also tiller executable, which should also be installed.

## Rationale

Originally Helm was designed to run tiller component inside the Kubernetes clusters, but for security reasons (as then it runs with e.g. cluster-admin permissions, which means that each user running helm client in the end have cluster-admin permissions) it is better to run tiller locally. This is supported and documented at https://helm.sh/docs/using_helm/#running-tiller-locally-1. To be able to use this approach, tiller component should be installed with helm.