### PR TITLE
Update nim.json: official ZIP files were updated for version 0.20

### DIFF
--- a/bucket/nim.json
+++ b/bucket/nim.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "https://nim-lang.org/download/nim-0.20.0_x64.zip",
-            "hash": "c4bbd29e2a48bdd8438465c9f85f15e4bf247498d4655f31aaecb2811421e062"
+            "hash": "47ce2a7e77c6ba65266eb35a3319cafe24e6845947bfbdcae929e57892ca1491"
         },
         "32bit": {
             "url": "https://nim-lang.org/download/nim-0.20.0_x32.zip",
-            "hash": "42abdf593a09db427a93ed0bb8b5a911c32eea59b2d0089a7392c1c4d9bcf45a"
+            "hash": "01801b88a8ba4974656b202c7ad6349c08d69d2e35456df3f065d20a11c18abc"
         }
     },
     "depends": "gcc",


### PR DESCRIPTION
Nim devs updated the zip files, and new hashes are needed:

PS > Get-FileHash .\nim-0.20.0_x32.zip

Algorithm       Hash                                                              
---------       ----                                                                   
SHA256          01801B88A8BA4974656B202C7AD6349C08D69D2E35456DF3F065D20A11C18ABC       

PS > Get-FileHash .\nim-0.20.0_x64.zip

Algorithm       Hash                                                           
---------       ----                                                                
SHA256          47CE2A7E77C6BA65266EB35A3319CAFE24E6845947BFBDCAE929E57892CA1491