### PR TITLE
connect: Add version 1.100

### DIFF
--- a/bucket/connect.json
+++ b/bucket/connect.json
@@ -3,7 +3,7 @@
     "description": "Simple relaying command to make network connection via SOCKS and https proxy.",
     "homepage": "https://web.archive.org/web/20080516100455/http://www.meadowy.org/~gotoh/projects/connect",
     "license": "GPL-2.0-or-later",
-    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe",
-    "hash": "md5:ec0fbe9ba703550956da976169ccb854",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe#/connect.exe",
+    "hash": "1220ee6a028c7c7506a2c0c7dfe107b9c97025e1a5080cebb57144eb018d03a0",
     "bin": "connect.exe"
 }

--- a/bucket/connect.json
+++ b/bucket/connect.json
@@ -1,7 +1,7 @@
 {
     "version": "1.100",
     "description": "Simple relaying command to make network connection via SOCKS and https proxy.",
-    "homepage": "http://www.meadowy.org/~gotoh/projects/connect",
+    "homepage": "https://web.archive.org/web/20080516100455/http://www.meadowy.org/~gotoh/projects/connect",
     "license": "GPL-2.0",
     "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe",
     "hash": "md5:ec0fbe9ba703550956da976169ccb854",

--- a/bucket/connect.json
+++ b/bucket/connect.json
@@ -2,7 +2,7 @@
     "version": "1.100",
     "description": "Simple relaying command to make network connection via SOCKS and https proxy.",
     "homepage": "https://web.archive.org/web/20080516100455/http://www.meadowy.org/~gotoh/projects/connect",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-or-later",
     "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe",
     "hash": "md5:ec0fbe9ba703550956da976169ccb854",
     "bin": "connect.exe"

--- a/bucket/connect.json
+++ b/bucket/connect.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.100",
+    "description": "Simple relaying command via proxy",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe",
+    "hash": "md5:ec0fbe9ba703550956da976169ccb854",
+    "bin": "connect.exe"
+}

--- a/bucket/connect.json
+++ b/bucket/connect.json
@@ -1,6 +1,8 @@
 {
     "version": "1.100",
-    "description": "Simple relaying command via proxy",
+    "description": "connect --- simple relaying command via proxy.",
+    "homepage": "http://www.meadowy.org/~gotoh/projects/connect",
+    "license": "GPL-2.0",
     "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe",
     "hash": "md5:ec0fbe9ba703550956da976169ccb854",
     "bin": "connect.exe"

--- a/bucket/connect.json
+++ b/bucket/connect.json
@@ -1,6 +1,6 @@
 {
     "version": "1.100",
-    "description": "connect --- simple relaying command via proxy.",
+    "description": "Simple relaying command to make network connection via SOCKS and https proxy.",
     "homepage": "http://www.meadowy.org/~gotoh/projects/connect",
     "license": "GPL-2.0",
     "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/connect/connect-1.100.exe",


### PR DESCRIPTION
> connect --- simple relaying command via proxy.

The program is no longer available so I created a [pull request](https://github.com/ScoopInstaller/Binary/pull/8) to Scoop's binary mirror.