### PR TITLE
multi: Use installer.type for `python` and `mro`

### DIFF
--- a/bucket/mro.json
+++ b/bucket/mro.json
@@ -11,15 +11,14 @@
             "url": "https://mran.blob.core.windows.net/install/mro/3.5.3/windows/microsoft-r-open-3.5.3.exe",
             "hash": "a2ef254a63f60234996e6eafe9686fddf99b5835732ff52d6ae0f4bcd547d14b",
             "installer": {
+                "type": "wix",
                 "script": [
-                    "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\_tmp\"",
-                    "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\ROpen.msi\" \"$dir\\_tmp\"",
-                    "movedir \"$dir\\_tmp\\Microsoft\\MRO-$version.0\" \"$dir\" | Out-Null",
-                    "Expand-7zipArchive \"$dir\\Setup\\*.cab\" \"$dir\\Setup\"",
+                    "movedir \"$dir\\Microsoft\\MRO-$version.0\" \"$dir\" | Out-Null",
+                    "Expand-7zipArchive \"$dir\\Setup\\*.cab\"",
                     "Remove-Item \"$dir\\bin\\x64\\Rblas.dll\", \"$dir\\bin\\x64\\Rlapack.dll\" -Force",
                     "movedir \"$dir\\Setup\\bin\\x64\" \"$dir\\bin\\x64\" | Out-Null",
                     "movedir \"$dir\\Setup\\library\" \"$dir\\library\" | Out-Null",
-                    "Remove-Item \"$dir\\_tmp\", \"$dir\\Setup\", \"$dir\\$fname\" -Force -Recurse"
+                    "Remove-Item \"$dir\\Setup\", \"$dir\\Microsoft\" -Force -Recurse"
                 ]
             },
             "bin": [

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -1,8 +1,8 @@
 {
     "homepage": "https://www.python.org/",
-    "description": "A programming language that lets you work quickly and integrate systems more effectively.",
     "license": "Python-2.0",
     "version": "3.7.4",
+    "description": "A programming language that lets you work quickly and integrate systems more effectively.",
     "architecture": {
         "64bit": {
             "url": "https://www.python.org/ftp/python/3.7.4/python-3.7.4-amd64.exe",
@@ -14,13 +14,13 @@
         }
     },
     "installer": {
+        "type": "wix",
+        "exclude": [
+            "launcher.msi",
+            "path.msi",
+            "pip.msi"
+        ],
         "script": [
-            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\_tmp\"",
-            "@('launcher.msi', 'path.msi', 'pip.msi') | ForEach-Object {",
-            "    Remove-Item \"$dir\\_tmp\\AttachedContainer\\$_\"",
-            "}",
-            "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
-            "Remove-Item \"$dir\\_tmp\", \"$dir\\$fname\" -Force -Recurse",
             "& \"$dir\\python.exe\" -E -s -m ensurepip -U --default-pip | Out-Null",
             "if ($global) {",
             "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",


### PR DESCRIPTION
Test manifests for https://github.com/lukesampson/scoop/pull/3502

Could be merged after above PR merged.