### PR TITLE
latex: Fix manifest and update to 2.9.7086

### DIFF
--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -5,7 +5,7 @@
         "identifier": "Freeware",
         "url": "https://miktex.org/copying"
     },
-    "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7086.exe",
+    "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7086.exe",
     "hash": "1d4b3d343b86e2c0b573518969f9e3e73253ca1b08e4d65f854b09be68730c71",
     "installer": {
         "args": "--portable=\"$dir\" --unattended --private"
@@ -24,7 +24,7 @@
         "regex": "basic-miktex-([\\d.]+).exe"
     },
     "autoupdate": {
-        "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe",
+        "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe",
         "hash": {
             "url": "https://miktex.org/download",
             "regex": "$basename</td>[\\S\\s]*?$sha256"

--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -13,7 +13,7 @@
     "bin": [
         [
             "texmfs\\install\\miktex\\bin\\miktex-console.exe",
-            "miktex-portable",
+            "miktex",
             "--hide --mkmaps"
         ]
     ],

--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -1,22 +1,33 @@
 {
     "homepage": "https://miktex.org",
-    "version": "2.9.6942",
+    "version": "2.9.7086",
     "license": {
         "identifier": "Freeware",
         "url": "https://miktex.org/copying"
     },
-    "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable-2.9.6942.exe#/dl.7z",
-    "hash": "20e42d52e7601f7b0abaf042408a18b39ffd84b3bb5c2a51f9b70a6555ea5897",
+    "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7086.exe",
+    "hash": "1d4b3d343b86e2c0b573518969f9e3e73253ca1b08e4d65f854b09be68730c71",
+    "installer": {
+        "args": "--portable=\"$dir\" --unattended --private"
+    },
+    "bin": [
+        [
+            "texmfs\\install\\miktex\\bin\\miktex-console.exe",
+            "miktex-portable",
+            "--hide --mkmaps"
+        ]
+    ],
     "env_add_path": "texmfs\\install\\miktex\\bin",
+    "persist": "texmfs\\config",
     "checkver": {
-        "url": "https://miktex.org/download#portable",
-        "re": "miktex-portable-([\\d.]+).exe"
+        "url": "https://miktex.org/download",
+        "regex": "basic-miktex-([\\d.]+).exe"
     },
     "autoupdate": {
-        "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable-$version.exe#/dl.7z",
+        "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe",
         "hash": {
-            "url": "https://miktex.org/download#portable",
-            "find": "SHA-256:</td>\\s*<td>\\s*([a-fA-F0-9]{64})"
+            "url": "https://miktex.org/download",
+            "regex": "$basename</td>[\\S\\s]*?$sha256"
         }
     }
 }

--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://miktex.org",
-    "version": "2.9.7086",
+    "version": "2.9.7100",
     "license": {
         "identifier": "Freeware",
         "url": "https://miktex.org/copying"
     },
-    "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7086.exe",
-    "hash": "1d4b3d343b86e2c0b573518969f9e3e73253ca1b08e4d65f854b09be68730c71",
+    "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7100.exe",
+    "hash": "893505ea259a77a8a3744b64a1975a20abc57e4d270edc2d03affad36b3427dd",
     "installer": {
         "args": "--portable=\"$dir\" --unattended --private"
     },

--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -5,10 +5,15 @@
         "identifier": "Freeware",
         "url": "https://miktex.org/copying"
     },
+    "description": "An up-to-date implementation of TeX/LaTeX and related programs.",
     "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7100.exe",
     "hash": "893505ea259a77a8a3744b64a1975a20abc57e4d270edc2d03affad36b3427dd",
     "installer": {
-        "args": "--portable=\"$dir\" --unattended --private"
+        "args": [
+            "--portable=\"$dir\"",
+            "--unattended",
+            "--private"
+        ]
     },
     "bin": [
         [
@@ -27,7 +32,7 @@
         "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe",
         "hash": {
             "url": "https://miktex.org/download",
-            "regex": "$basename</td>[\\S\\s]*?$sha256"
+            "regex": "(?sm)$basename</td>.*?$sha256"
         }
     }
 }


### PR DESCRIPTION
Close #102, close https://github.com/lukesampson/scoop/issues/3497

MiKTeX has 64bit installer, but with different `env_add_path`, so after a small hotfix of scoop-core, 64bit will add to the manifest. Now 32bit works fine.