### PR TITLE
jdupes: Fix autoupdate URLs

### DIFF
--- a/bucket/jdupes.json
+++ b/bucket/jdupes.json
@@ -20,12 +20,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jbruchon/jdupes/releases/download/v$version/jdupes-$version_win64.zip",
-                "extract_dir": "jdupes-$version_win64"
+                "url": "https://github.com/jbruchon/jdupes/releases/download/v$version/jdupes-$version-win64.zip",
+                "extract_dir": "jdupes-$version-win64"
             },
             "32bit": {
-                "url": "https://github.com/jbruchon/jdupes/releases/download/v$version/jdupes-$version_win32.zip",
-                "extract_dir": "jdupes-$version_win32"
+                "url": "https://github.com/jbruchon/jdupes/releases/download/v$version/jdupes-$version-win32.zip",
+                "extract_dir": "jdupes-$version-win32"
             }
         }
     }


### PR DESCRIPTION
I tested this locally, and it works:
````
jdupes: 1.13.1 (scoop version is 1.12) autoupdate available
Autoupdating jdupes
Downloading jdupes-1.13.1-win32.zip to compute hashes!
jdupes-1.13.1-win32.zip (201.6 KB) [=============================================================================================================================================================================================================================================================================] 100%
Computed hash: c18aaf14c1e8c5e51bba17cdafc473b23916f50dc498e640e1c8aae22cf39de6
Downloading jdupes-1.13.1-win64.zip to compute hashes!
jdupes-1.13.1-win64.zip (138.5 KB) [=============================================================================================================================================================================================================================================================================] 100%
Computed hash: b359ca2732c3817451eb616379fb91ea27cfc661f00d6855b0a615ec5502d836
Writing updated jdupes manifest