### PR TITLE
openssl: Fix autoupdate hash URL

### DIFF
--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -30,8 +30,8 @@
         },
         "hash": {
             "mode": "json",
-            "jp": "$.files.['$basename'].sha512",
-            "url": "$baseurl/win32_openssl_hashes.json"
+            "jp": "$.files.['$basename'].sha256",
+            "url": "https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json"
         }
     }
 }


### PR DESCRIPTION
New location of win32_openssl_hashes.json found on https://slproweb.com/products/Win32OpenSSL.html