### PR TITLE
Maven: persist lib/ext

### DIFF
--- a/bucket/maven.json
+++ b/bucket/maven.json
@@ -23,5 +23,8 @@
             "url": "$url.sha1"
         }
     },
-    "persist": "conf"
+    "persist": [
+        "conf",
+        "lib/ext"
+    ]
 }


### PR DESCRIPTION
From the README located in `lib/ext`:

> Use this directory to contribute 3rd-party extensions to the Maven core. These extensions can either extend or override Maven's default implementation.

It would be nice if this folder could be persisted between updates.