### PR TITLE
Set DOTNET_ROOT upon install of the dotnet SDK

### DIFF
--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -14,6 +14,9 @@
         }
     },
     "bin": "dotnet.exe",
+    "env_set": {
+        "DOTNET_ROOT": "$dir"
+    },
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
         "jsonpath": "$..releases-index[?(@.support-phase == 'current')].latest-sdk"


### PR DESCRIPTION
This helps with e.g. making global tools work correctly; see [this blog post][1] for more details.

[1]: https://natemcmaster.com/blog/2018/05/12/dotnet-global-tools/#installing-the-net-core-cli-into-a-non-default-location