### PR TITLE
Terraform: Handle plugin directory

### DIFF
--- a/bucket/terraform.json
+++ b/bucket/terraform.json
@@ -5,11 +5,21 @@
     "architecture": {
         "64bit": {
             "url": "https://releases.hashicorp.com/terraform/0.12.2/terraform_0.12.2_windows_amd64.zip",
-            "hash": "ad4867345c404b21bdb39d8ee8041c2a7897b74590867bd98f12a29e4b3f0a52"
+            "hash": "ad4867345c404b21bdb39d8ee8041c2a7897b74590867bd98f12a29e4b3f0a52",
+            "installer": {
+                "script": [
+                    "New-Item -ItemType Directory -Force -Path \"$Env:APPDATA\\terraform.d\\plugins\\windows_amd64\" | Out-Null"
+                ]
+            }
         },
         "32bit": {
             "url": "https://releases.hashicorp.com/terraform/0.12.2/terraform_0.12.2_windows_386.zip",
-            "hash": "e0738cb2b7462569f1bea30c53d9cf4ca0a56c5b8060cccc5ce5cd04fb5f5776"
+            "hash": "e0738cb2b7462569f1bea30c53d9cf4ca0a56c5b8060cccc5ce5cd04fb5f5776",
+            "installer": {
+                "script": [
+                    "New-Item -ItemType Directory -Force -Path \"$Env:APPDATA\\terraform.d\\plugins\\windows_386\" | Out-Null"
+                ]
+            }
         }
     },
     "bin": "terraform.exe",


### PR DESCRIPTION
This allows scoop to handle terraform plugins (providers, etc). Plugin example manifest:

```JSON
    "architecture": {
        "64bit": {
            "installer": {
                "script": [
                    "Copy-Item \"$dir\\terraform-provider_v$version.exe\" \"$Env:APPDATA\\terraform.d\\plugins\\windows_amd64\""
                ]
            },
            "uninstaller": {
                "script": [
                    "Remove-Item \"$Env:APPDATA\\terraform.d\\plugins\\windows_amd64\\terraform-provider_v$version.exe\""
                ]
            }
        }
    },
```