### PR TITLE
lame: Update to 3.100-20190620 (manually)

### DIFF
--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix-64$matchSuffix.zip"
+                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix-64-$matchSuffix.zip"
             },
             "32bit": {
                 "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix$matchSuffix.zip"

--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -2,29 +2,30 @@
     "homepage": "https://lame.sourceforge.net/",
     "description": "LAME is a high quality MPEG Audio Layer III (MP3) encoder",
     "license": "LGPL-2.0-only",
-    "version": "3.100",
+    "version": "3.100-20190620",
     "architecture": {
         "64bit": {
-            "url": "http://www.rarewares.org/files/mp3/lame3.100-64.zip",
-            "hash": "c9cddf1650fff0ebe0ba79de794b1fa9b334f43f08e2d365b7a158941ad78fa7"
+            "url": "http://www.rarewares.org/files/mp3/lame3.100-64-20190620.zip",
+            "hash": "d10888ec491a6b7406c357f6825e70ccd1820abcec973c049b7cdfe2a859cbfc"
         },
         "32bit": {
-            "url": "http://www.rarewares.org/files/mp3/lame3.100.zip",
-            "hash": "910e14565e7edc419e3b841d1cd7eb83db52727d0f34fceec2b04d905a148ac6"
+            "url": "http://www.rarewares.org/files/mp3/lame3.100-20190620.zip",
+            "hash": "8779b2de0cde05b7c3a35ff702a169ee086be48d00925e669cdf6fbf87d5619a"
         }
     },
     "bin": "lame.exe",
     "checkver": {
         "url": "http://www.rarewares.org/mp3-lame-bundle.php",
-        "re": "http://www.rarewares.org/files/mp3/lame([\\d.]+).zip"
+        "re": "http://www\\.rarewares\\.org/files/mp3/lame(?<prefix>[\\d.]+)(?<suffix>[^.]*)\\.zip",
+        "replace": "${1}${2}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.rarewares.org/files/mp3/lame$version-64.zip"
+                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix-64$matchSuffix.zip"
             },
             "32bit": {
-                "url": "http://www.rarewares.org/files/mp3/lame$version.zip"
+                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix$matchSuffix.zip"
             }
         }
     }

--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -16,13 +16,13 @@
     "bin": "lame.exe",
     "checkver": {
         "url": "http://www.rarewares.org/mp3-lame-bundle.php",
-        "regex": "/files/mp3/lame(?<prefix>[\\d.]+)-(?<suffix>[^.]*)\\.zip",
-        "replace": "${prefix}-${suffix}"
+        "regex": "/files/mp3/lame(?<prefix>[\\d.]+)(?<suffix>[^.]*)\\.zip",
+        "replace": "${prefix}${suffix}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix-64-$matchSuffix.zip"
+                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix-64$matchSuffix.zip"
             },
             "32bit": {
                 "url": "http://www.rarewares.org/files/mp3/lame$version.zip"

--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -25,7 +25,7 @@
                 "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix-64-$matchSuffix.zip"
             },
             "32bit": {
-                "url": "http://www.rarewares.org/files/mp3/lame$matchPrefix$matchSuffix.zip"
+                "url": "http://www.rarewares.org/files/mp3/lame$version.zip"
             }
         }
     }

--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -18,7 +18,6 @@
         "url": "http://www.rarewares.org/mp3-lame-bundle.php",
         "regex": "/files/mp3/lame(?<prefix>[\\d.]+)-(?<suffix>[^.]*)\\.zip",
         "replace": "${prefix}-{$suffix}"
-        "replace": "${1}${2}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -17,7 +17,7 @@
     "checkver": {
         "url": "http://www.rarewares.org/mp3-lame-bundle.php",
         "regex": "/files/mp3/lame(?<prefix>[\\d.]+)-(?<suffix>[^.]*)\\.zip",
-        "replace": "${prefix}-{$suffix}"
+        "replace": "${prefix}-${suffix}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/lame.json
+++ b/bucket/lame.json
@@ -16,7 +16,8 @@
     "bin": "lame.exe",
     "checkver": {
         "url": "http://www.rarewares.org/mp3-lame-bundle.php",
-        "re": "http://www\\.rarewares\\.org/files/mp3/lame(?<prefix>[\\d.]+)(?<suffix>[^.]*)\\.zip",
+        "regex": "/files/mp3/lame(?<prefix>[\\d.]+)-(?<suffix>[^.]*)\\.zip",
+        "replace": "${prefix}-{$suffix}"
         "replace": "${1}${2}"
     },
     "autoupdate": {


### PR DESCRIPTION
Fixes:
```
lame: couldn't match 'http://www.rarewares.org/files/mp3/lame([\d.]+).zip' in http://www.rarewares.org/mp3-lame-bundle.php
```
in https://scoop.r15.ch/main/mud-20190621-050001.log