### PR TITLE
use SourceForge download instead of MSYS2 repo

### DIFF
--- a/bucket/diffutils.json
+++ b/bucket/diffutils.json
@@ -5,10 +5,10 @@
     "architecture": {
         "64bit": {
             "url": [
-                "http://repo.msys2.org/msys/x86_64/diffutils-3.5-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/msys2-runtime-2.7.0-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libiconv-1.14-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libintl-0.19.7-3-x86_64.pkg.tar.xz"
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/diffutils-3.5-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/msys2-runtime-2.7.0-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libiconv-1.14-2-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libintl-0.19.7-3-x86_64.pkg.tar.xz"
             ],
             "hash": [
                 "6feba4594fe39180752213673510041d322be87977b573fc933141ddc8cb7f01",
@@ -19,10 +19,10 @@
         },
         "32bit": {
             "url": [
-                "http://repo.msys2.org/msys/i686/diffutils-3.5-1-i686.pkg.tar.xz",
-                "http://repo.msys2.org/msys/i686/msys2-runtime-2.7.0-1-i686.pkg.tar.xz",
-                "http://repo.msys2.org/msys/i686/libiconv-1.14-2-i686.pkg.tar.xz",
-                "http://repo.msys2.org/msys/i686/libintl-0.19.7-3-i686.pkg.tar.xz"
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/i686/diffutils-3.5-1-i686.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/i686/msys2-runtime-2.7.0-1-i686.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/i686/libiconv-1.14-2-i686.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/i686/libintl-0.19.7-3-i686.pkg.tar.xz"
             ],
             "hash": [
                 "3b60c994dfcf8fb8e3a61d1c4aab4b23102e16c5d9c5e080761d969bec414ebe",

--- a/bucket/openssh.json
+++ b/bucket/openssh.json
@@ -5,21 +5,21 @@
     "architecture": {
         "64bit": {
             "url": [
-                "http://repo.msys2.org/msys/x86_64/gcc-libs-6.4.0-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/heimdal-1.5.3-9-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/heimdal-libs-1.5.3-9-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/icu-59.1-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libcrypt-2.1-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libdb-5.3.28-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libedit-3.1-20170329-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libopenssl-1.0.2.m-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libreadline-7.0.003-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libsqlite-3.19.3.0-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/msys2-runtime-2.9.0-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/ncurses-6.0.20170708-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/openssh-7.6p1-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/bash-4.4.012-1-x86_64.pkg.tar.xz"
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/gcc-libs-6.4.0-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/heimdal-1.5.3-9-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/heimdal-libs-1.5.3-9-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/icu-59.1-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libcrypt-2.1-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libdb-5.3.28-2-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libedit-3.1-20170329-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libopenssl-1.0.2.m-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libreadline-7.0.003-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/libsqlite-3.19.3.0-2-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/msys2-runtime-2.9.0-2-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/ncurses-6.0.20170708-2-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/openssh-7.6p1-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz",
+                "https://downloads.sourceforge.net/project/msys2/REPOS/MSYS2/x86_64/bash-4.4.012-1-x86_64.pkg.tar.xz"
             ],
             "hash": [
                 "892a8125b41e2c11f26769755bec092b55c8d0c6c78bf8bd2c61d977df7e1fbd",


### PR DESCRIPTION
`repo.msys2.org` has been down every time I've tried to use it for some
time. Use SourceForge's MSYS2 mirror instead.