### PR TITLE
xmake: fix hash

### DIFF
--- a/bucket/xmake.json
+++ b/bucket/xmake.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/xmake-io/xmake/releases/download/v2.2.7/xmake-v2.2.7.win64.zip",
-            "hash": "5d04c7ef1bf3e1f178884f624a0c96dc21cf8a53ec54b1f2a95b9fd590b476ee"
+            "hash": "ddd0ac761327378c70f253ff59da55e95959f4331709135b000b040dc2c46ec9"
         },
         "32bit": {
             "url": "https://github.com/xmake-io/xmake/releases/download/v2.2.7/xmake-v2.2.7.win32.zip",
-            "hash": "2c48fb07441593a474e157b43a3bf63a7130bbdd6b78219b396b511ba9ca43ca"
+            "hash": "204819bdfc44598c3f5f17dd2e059efd70b5aafa6907fcbcc56ffc76bf92d545"
         }
     },
     "extract_dir": "xmake",


### PR DESCRIPTION
https://github.com/xmake-io/xmake/releases/download/v2.2.7/xmake-v2.2.7.win64.sha256

https://github.com/xmake-io/xmake/releases/download/v2.2.7/xmake-v2.2.7.win32.sha256