### PR TITLE
kubefwd: Fix autoupdate

### DIFF
--- a/bucket/kubefwd.json
+++ b/bucket/kubefwd.json
@@ -1,11 +1,12 @@
 {
     "homepage": "https://github.com/txn2/kubefwd",
     "license": "Apache-2.0",
-    "version": "1.8.2",
+    "version": "1.8.3",
+    "description": "Bulk port forwarding Kubernetes services for local development.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/txn2/kubefwd/releases/download/1.8.2/kubefwd_windows_amd64.zip",
-            "hash": "16b967ebc664a7ec712bf5349f2209827cffc260750efd8559a667d2a1ba6347"
+            "url": "https://github.com/txn2/kubefwd/releases/download/v1.8.3/kubefwd_windows_amd64.zip",
+            "hash": "993db00959b37f7d4c676d0c6ea809a7ed0f6a1d908bad2334203baf975c7e3a"
         }
     },
     "bin": "kubefwd.exe",
@@ -13,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/txn2/kubefwd/releases/download/$version/kubefwd_windows_amd64.zip"
+                "url": "https://github.com/txn2/kubefwd/releases/download/v$version/kubefwd_windows_amd64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
It just adds `v` before tag version