### PR TITLE
radare2: Fix au.hash

### DIFF
--- a/bucket/radare2.json
+++ b/bucket/radare2.json
@@ -1,12 +1,13 @@
 {
-    "version": "3.5.1",
-    "license": "GPL-2.0",
     "homepage": "https://www.radare.org/r/",
+    "version": "3.6.0",
+    "license": "GPL-2.0",
+    "description": "Portable reversing framework.",
     "architecture": {
         "64bit": {
-            "url": "https://radare.mikelloc.com/get/3.5.1/radare2-msvc_64-3.5.1.zip",
-            "hash": "sha1:95ab04202a57ed6424a7fe471d2868fbe1e0208b",
-            "extract_dir": "radare2-vs2017_64-3.5.1"
+            "url": "https://radare.mikelloc.com/get/3.6.0/radare2-msvc_64-3.6.0.zip",
+            "hash": "sha1:fe34f0b58a81ebffc54e60e54e7dc8250df102f6",
+            "extract_dir": "radare2-vs2017_64-3.6.0"
         }
     },
     "bin": [
@@ -33,7 +34,8 @@
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.sha1sum"
+            "url": "https://radare.mikelloc.com/release/$version",
+            "regex": "$basename.*?$sha1"
         }
     }
 }


### PR DESCRIPTION
Windows edition is released later than other, and don't have hash in hash file. So use webpage to get hash is better.