### PR TITLE
dosbox-x: Add version 0.82.19

### DIFF
--- a/bucket/dosbox-x.json
+++ b/bucket/dosbox-x.json
@@ -1,0 +1,35 @@
+{
+    "homepage": "http://dosbox-x.com",
+    "version": "0.82.19",
+    "license": "GPL-2.0-or-later",
+    "description": "DOSBox-X fork of the DOSBox project",
+    "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.82.19/dosbox-x-windows-20190531-214115-windows.zip",
+    "hash": "be97d086ebf12991f4f842c7218aecbfc500f82939a7bf8cf8d801ce402e7135",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "bin\\x64\\Release SDL2"
+        },
+        "32bit": {
+            "extract_dir": "bin\\Win32\\Release SDL2"
+        }
+    },
+    "shortcuts": [
+        [
+            "dosbox-x.exe",
+            "DOSBox-X"
+        ]
+    ],
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\dosbox.conf\")) {",
+        "   Copy-Item \"$dir\\dosbox.reference.conf\" \"$dir\\dosbox.conf\"",
+        "}"
+    ],
+    "persist": "dosbox.conf",
+    "checkver": {
+        "github": "https://github.com/joncampbell123/dosbox-x/",
+        "regex": "download/dosbox-x-v([\\d.]+)/dosbox-x-windows-(?<release>[\\d-]+)-windows"
+    },
+    "autoupdate": {
+        "url": "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v$version/dosbox-x-windows-$matchRelease-windows.zip"
+    }
+}


### PR DESCRIPTION
KNOWN ISSUE: Some removing error while extracting related with file permission in unused extracted files.

SOLUTION: Manually remove `_tmp` folder after installation.