### PR TITLE
latex: Add 64bit installer

### DIFF
--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -6,8 +6,32 @@
         "url": "https://miktex.org/copying"
     },
     "description": "An up-to-date implementation of TeX/LaTeX and related programs.",
-    "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7100.exe",
-    "hash": "893505ea259a77a8a3744b64a1975a20abc57e4d270edc2d03affad36b3427dd",
+    "architecture": {
+        "64bit": {
+            "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x64/basic-miktex-2.9.7100-x64.exe",
+            "hash": "9aa26669c0cdf1b964829058d74aec2561270b22e4cc7ac43b1baa77cee8f26d",
+            "bin": [
+                [
+                    "texmfs\\install\\miktex\\bin\\x64\\miktex-console.exe",
+                    "miktex",
+                    "--hide --mkmaps"
+                ]
+            ],
+            "env_add_path": "texmfs\\install\\miktex\\bin\\x64"
+        },
+        "32bit": {
+            "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-2.9.7100.exe",
+            "hash": "893505ea259a77a8a3744b64a1975a20abc57e4d270edc2d03affad36b3427dd",
+            "bin": [
+                [
+                    "texmfs\\install\\miktex\\bin\\miktex-console.exe",
+                    "miktex",
+                    "--hide --mkmaps"
+                ]
+            ],
+            "env_add_path": "texmfs\\install\\miktex\\bin"
+        }
+    },
     "installer": {
         "args": [
             "--portable=\"$dir\"",
@@ -15,21 +39,20 @@
             "--private"
         ]
     },
-    "bin": [
-        [
-            "texmfs\\install\\miktex\\bin\\miktex-console.exe",
-            "miktex",
-            "--hide --mkmaps"
-        ]
-    ],
-    "env_add_path": "texmfs\\install\\miktex\\bin",
     "persist": "texmfs\\config",
     "checkver": {
         "url": "https://miktex.org/download",
         "regex": "basic-miktex-([\\d.]+).exe"
     },
     "autoupdate": {
-        "url": "https://ftp.fau.de/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe",
+        "architecture": {
+            "64bit": {
+                "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x64/basic-miktex-$version-x64.exe"
+            },
+            "32bit": {
+                "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe"
+            }
+        },
         "hash": {
             "url": "https://miktex.org/download",
             "regex": "(?sm)$basename</td>.*?$sha256"


### PR DESCRIPTION
Fix json validator error by https://github.com/lukesampson/scoop/pull/3503

Manifest installed well even if above PR not merged.

Sidenote: @r15ch13 Excavator will get the right hashes for installer, so autoupdate works correctly. During installation, redirection to nearest mirror is much more preferred. For those users that redirected to `http` mirror and failed downloading, manually downloading the file and moving and renaming it to cache folder should works. This case should be rare since most servers provide `https` protocol. (ref: https://miktex.org/pkg/repositories)