### PR TITLE
jx: updated executable name in shim definition

### DIFF
--- a/bucket/jx.json
+++ b/bucket/jx.json
@@ -9,12 +9,7 @@
             "hash": "3fee78b13383b8f8602fb3364c0712205371b3d5873399f282f84ad564678051"
         }
     },
-    "bin": [
-        [
-            "jx.exe",
-            "jx"
-        ]
-    ],
+    "bin": "jx.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/jx.json
+++ b/bucket/jx.json
@@ -11,7 +11,7 @@
     },
     "bin": [
         [
-            "jx-windows-amd64.exe",
+            "jx.exe",
             "jx"
         ]
     ],


### PR DESCRIPTION
Starting from version 2.0.340, the executable is named just `jx.exe`, not `jx-windows-amd64.exe`. Due to this change, a shim for the executable is not correctly created, which results in an incomplete installation. This pull request should fix this behaviour.