### PR TITLE
xxcopy: Add version 3.33.3

### DIFF
--- a/bucket/xxcopy.json
+++ b/bucket/xxcopy.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "http://www.xxcopy.com",
+    "version": "3.33.3",
+    "license": "Freeware",
+    "description": "A versatile file management tool for Microsoft Windows®.",
+    "url": "http://www.xxcopy.com/download/xxfw3333.zip",
+    "hash": "d5fd9d2446a0d54b564c864310b481c9e160ee487f305af67f584eff5b6bd767",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "64bit"
+        },
+        "32bit": {
+            "extract_dir": "32bit"
+        }
+    },
+    "bin": [
+        [
+            "xxcopysu.exe",
+            "xxcopy"
+        ],
+        "xxconsole.exe"
+    ]
+}


### PR DESCRIPTION
Binary files in package:

- xxcopy.exe     ; Win XP/Vista/2003/Win7/Win8/2008 (xxcopy.exe)
- xxcopysu.exe   ; Win XP/Vista/2003/Win7/Win8/2008(std user)
- xxpbar64.exe   ; The Progress Bar display module
- xxconsole.exe  ; a Super Console Generator

`xxcopy` needs installation (write Registry) while `xxcopysu` needn't, and `xxcopy` can't be used in standard user env. So port `xxcopysu` as `xxcopy` and all work fine.