### PR TITLE
Add bison, byacc, btyacc (from GNUWin32) and winflexbison

### DIFF
--- a/bucket/bison.json
+++ b/bucket/bison.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "http://gnuwin32.sourceforge.net/packages/bison.htm",
+    "version": "2.4.1",
+    "license": "GPL-3.0-or-later",
+    "description": "Yacc-compatible parser generator (from GNUWin32)",
+    "url": [
+        "https://downloads.sourceforge.net/project/gnuwin32/bison/2.4.1/bison-2.4.1-bin.zip",
+        "https://downloads.sourceforge.net/project/gnuwin32/bison/2.4.1/bison-2.4.1-dep.zip"
+    ],
+    "hash": [
+        "cd239ab43baea53cfdb1f2663ad0883586b97f22cee825c3780ad9bba7e6ee19",
+        "a69c14f6c9766db0d2c0f69c6c46598dce4ce6a3060de8e20dbc5217d7ad714b"
+    ],
+    "bin": "bin\\bison.exe"
+}

--- a/bucket/btyacc.json
+++ b/bucket/btyacc.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "http://gnuwin32.sourceforge.net/packages/btyacc.htm",
+    "version": "3.0",
+    "license": "GPL-3.0-or-later",
+    "description": "A version of Byacc with backtracking (from GNUWin32)",
+    "url": "https://downloads.sourceforge.net/project/gnuwin32/btyacc/3.0/btyacc-3.0-bin.zip",
+    "hash": "7450fa179a304cc3185f5980f42f422e0c88fe545a1c9f96b715994a69c507b0",
+    "bin": "bin\\btyacc.exe"
+}

--- a/bucket/byacc.json
+++ b/bucket/byacc.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "http://gnuwin32.sourceforge.net/packages/byacc.htm",
+    "version": "1.9-1",
+    "license": "GPL-3.0-or-later",
+    "description": "Berkeley Yacc: LALR(1) parser generator (from GNUWin32)",
+    "url": "https://downloads.sourceforge.net/project/gnuwin32/byacc/1.9-1/byacc-1.9-1-bin.zip",
+    "hash": "8bb45e5fd4e7c3ab1b687fedf8c2a26aa65d9901fd1e09861f6b399297db2eb9",
+    "bin": "bin\\yacc.exe"
+}

--- a/bucket/winflexbison.json
+++ b/bucket/winflexbison.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/lexxmark/winflexbison",
+    "version": "2.5.18",
+    "license": "GPL-3.0-or-later",
+    "description": "A Windows port of Flex (the fast lexical analyser) and GNU Bison (parser generator).",
+    "url": "https://github.com/lexxmark/winflexbison/releases/download/v2.5.18/win_flex_bison-2.5.18.zip",
+    "hash": "095cf65cb3f12ee5888022f93109acbe6264e5f18f6ffce0bda77feb31b65bd8",
+    "bin": [
+        [
+            "win_bison.exe",
+            "bison"
+        ],
+        [
+            "win_flex.exe",
+            "flex"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/lexxmark/winflexbison/releases/download/v$version/win_flex_bison-$version.zip"
+    }
+}


### PR DESCRIPTION
Notes:
* `GNUWin32` has been frozen since 2010. Therefore **checkver** and **autoupdate** is not used in this package.