### PR TITLE
BIND: Add version 9.14.3

### DIFF
--- a/bucket/bind.json
+++ b/bucket/bind.json
@@ -1,0 +1,40 @@
+{
+    "homepage": "https://www.isc.org/bind/",
+    "description": "Versatile, classic, complete name server software.",
+    "license": "MPL-2.0",
+    "version": "9.14.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.isc.org/isc/bind9/9.14.3/BIND9.14.3.x64.zip",
+            "hash": "9182c6593d11581909d12706e663252c357696def102b260da02c98ec1ac7b86"
+        },
+        "32bit": {
+            "url": "https://downloads.isc.org/isc/bind9/9.14.3/BIND9.14.3.x86.zip",
+            "hash": "1ded768b090e633b1930f99e457c1f73b3955614aff621ec13ea12c186884472"
+        }
+    },
+    "env_add_path": "bin",
+    "persist": "etc",
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\BINDInstall.exe\", \"$dir\\vcredist_x*.exe\"",
+            "New-Item \"$dir\\bin\" -ItemType 'Directory' -Force | Out-Null",
+            "Move-Item \"$dir\\*.exe\", \"$dir\\*.dll\" \"$dir\\bin\" -Force",
+            "Remove-Item \"$dir\\*\" -Exclude 'bin'"
+        ]
+    },
+    "checkver": "(?sm)Current-Stable<.*?\\\/([\\d.]+)\\\/",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.isc.org/isc/bind$majorVersion/$version/BIND$version.x64.zip"
+            },
+            "32bit": {
+                "url": "https://downloads.isc.org/isc/bind$majorVersion/$version/BIND$version.x86.zip"
+            }
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2017"
+    }
+}

--- a/bucket/dig.json
+++ b/bucket/dig.json
@@ -1,34 +1,12 @@
 {
-    "homepage": "https://www.isc.org/",
+    "version": "nightly",
+    "homepage": "https://www.isc.org/bind/",
     "description": "dig (domain information groper) is a flexible tool for interrogating DNS name servers",
     "license": "MPL-2.0",
-    "version": "9.14.3",
-    "architecture": {
-        "64bit": {
-            "url": "https://ftp.isc.org/isc/bind9/9.14.3/BIND9.14.3.x64.zip",
-            "hash": "9182c6593d11581909d12706e663252c357696def102b260da02c98ec1ac7b86"
-        },
-        "32bit": {
-            "url": "https://ftp.isc.org/isc/bind9/9.14.3/BIND9.14.3.x86.zip",
-            "hash": "1ded768b090e633b1930f99e457c1f73b3955614aff621ec13ea12c186884472"
-        }
-    },
-    "bin": "dig.exe",
-    "checkver": {
-        "url": "https://www.isc.org/downloads/",
-        "re": "Current-Stable[\\S\\s]*?BIND(.+)\\.x64\\.zip\""
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://ftp.isc.org/isc/bind$majorVersion/$version/BIND$version.x64.zip"
-            },
-            "32bit": {
-                "url": "https://ftp.isc.org/isc/bind$majorVersion/$version/BIND$version.x86.zip"
-            }
-        }
-    },
-    "suggest": {
-        "vcredist": "extras/vcredist2012"
-    }
+    "depends": "bind",
+    "url":"https://www.isc.org/bind/",
+    "notes": [
+        "The dig package has been deprecated, and will be removed in the future.",
+        "Please use the bind package instead."
+    ]
 }

--- a/bucket/dig.json
+++ b/bucket/dig.json
@@ -1,10 +1,36 @@
 {
-    "version": "nightly",
+    "version": "9.14.3",
     "homepage": "https://www.isc.org/bind/",
     "description": "dig (domain information groper) is a flexible tool for interrogating DNS name servers",
     "license": "MPL-2.0",
-    "depends": "bind",
-    "url":"https://www.isc.org/bind/",
+    "architecture": {
+        "64bit": {
+            "url": "https://ftp.isc.org/isc/bind9/9.14.3/BIND9.14.3.x64.zip",
+            "hash": "9182c6593d11581909d12706e663252c357696def102b260da02c98ec1ac7b86"
+        },
+        "32bit": {
+            "url": "https://ftp.isc.org/isc/bind9/9.14.3/BIND9.14.3.x86.zip",
+            "hash": "1ded768b090e633b1930f99e457c1f73b3955614aff621ec13ea12c186884472"
+        }
+    },
+    "bin": "dig.exe",
+    "checkver": {
+        "url": "https://www.isc.org/downloads/",
+        "regex": "Current-Stable[\\S\\s]*?BIND(.+)\\.x64\\.zip\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://ftp.isc.org/isc/bind$majorVersion/$version/BIND$version.x64.zip"
+            },
+            "32bit": {
+                "url": "https://ftp.isc.org/isc/bind$majorVersion/$version/BIND$version.x86.zip"
+            }
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2012"
+    },
     "notes": [
         "The dig package has been deprecated, and will be removed in the future.",
         "Please use the bind package instead."


### PR DESCRIPTION
`dig` has been in scoop and it's a part of `bind` . Should I remove `dig.json` ? There is a `vcredist` in dir, could use it or must use `suggest` ?