### PR TITLE
Yarn: Re-Add Prefix Global Directory Argument

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -13,7 +13,8 @@
     "post_install": [
         "yarn config set cache-folder \"$dir\\cache\"",
         "yarn config set yarn-offline-mirror \"$dir\\mirror\"",
-        "yarn config set global-folder \"$dir\\global\""
+        "yarn config set global-folder \"$dir\\global\"",
+        "yarn config set prefix \"$dir\\global\""
     ],
     "uninstaller": {
         "script": [


### PR DESCRIPTION
"Prefix" was changed to "Global-Folder" but "Prefix" is still required for global tools to set up their commands into the correct location rather than localappdata. Example is azure-functions-core-tools.

Both options can be specified concurrently and safely.