### PR TITLE
git-annex: fix checkver and au.hash

### DIFF
--- a/bucket/git-annex.json
+++ b/bucket/git-annex.json
@@ -1,21 +1,20 @@
 {
-    "description": "Manage files with git, without comitting them",
-    "homepage": "http://git-annex.branchable.com/",
-    "license": "GPL-3.0",
-    "version": "7.20190708",
-    "notes": "NOTE: Running `git-annex version` may report a slightly older version number",
+    "version": "7.20190627",
+    "description": "Manage files with git, without comitting them.",
+    "homepage": "https://git-annex.branchable.com/",
+    "license": "AGPL-3.0-or-later",
     "bin": "usr/bin/git-annex.exe",
     "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
-    "hash": "e25d8ff4ad7a6f6d773078c541aff223e41c5ab5ef6fc7a304fb2f913c721666",
+    "hash": "b9b479d4f137c79563ed27b61577c9a5794aa2fc83d9bf700a4d0f6816c98be2",
     "checkver": {
-        "url": "https://hackage.haskell.org/package/git-annex",
-        "re": "/git-annex-([\\d.]+)\\.tar\\.gz"
+        "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe.info",
+        "regex": "distributionVersion = \"([\\d.]+)\""
     },
     "autoupdate": {
         "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
         "hash": {
             "url": "$url.info",
-            "find": "$sha256.exe"
+            "regex": "$sha256\\.exe"
         }
     }
 }


### PR DESCRIPTION
In fact, it can't pass its test on my machine. Maybe because it needs 32bit git to work, see https://git-annex.branchable.com/install/Windows/. Anyway, it can be downloaded correctly now. If there is anyone who use git-annex with scoop, please try to fix it.