### PR TITLE
doctl: Fix hashes

### DIFF
--- a/bucket/doctl.json
+++ b/bucket/doctl.json
@@ -1,35 +1,28 @@
 {
-    "description": "A command line tool for Digital Ocean services",
     "homepage": "https://github.com/digitalocean/doctl",
     "version": "1.21.1",
     "license": "Apache-2.0",
+    "description": "A command line tool for Digital Ocean services",
     "architecture": {
         "64bit": {
             "url": "https://github.com/digitalocean/doctl/releases/download/v1.21.1/doctl-1.21.1-windows-amd64.zip",
-            "hash": "75677aaf23980dd740d74f9a9b7cbf1fb043a1d53787b0460955e8b92c37faef"
+            "hash": "a8ed685dda99d8c4c06e571e8d9b660475c912ac99488d069768ed7a8fb54790"
         },
         "32bit": {
             "url": "https://github.com/digitalocean/doctl/releases/download/v1.21.1/doctl-1.21.1-windows-386.zip",
-            "hash": "7265703d9fa249ae0e478437d00b3f2fd8deb498afb29425ba323e194a6dbab6"
+            "hash": "5f45dbb7c30d7a6a11857012927930ff0097a1edd68c948c578342fd63f9037f"
         }
     },
+    "pre_install": "Rename-Item \"$dir\\doctl\" 'doctl.exe'",
     "bin": "doctl.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/digitalocean/doctl/releases/download/v$version/doctl-$version-windows-amd64.zip",
-                "hash": {
-                    "url": "$baseurl/doctl-$version-windows-amd64.sha256",
-                    "regex": "$sha256"
-                }
+                "url": "https://github.com/digitalocean/doctl/releases/download/v$version/doctl-$version-windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/digitalocean/doctl/releases/download/v$version/doctl-$version-windows-386.zip",
-                "hash": {
-                    "url": "$baseurl/doctl-$version-windows-386.sha256",
-                    "regex": "$sha256"
-                }
+                "url": "https://github.com/digitalocean/doctl/releases/download/v$version/doctl-$version-windows-386.zip"
             }
         }
     }

--- a/bucket/doctl.json
+++ b/bucket/doctl.json
@@ -2,7 +2,7 @@
     "homepage": "https://github.com/digitalocean/doctl",
     "version": "1.21.1",
     "license": "Apache-2.0",
-    "description": "A command line tool for Digital Ocean services",
+    "description": "A command line tool for DigitalOcean services",
     "architecture": {
         "64bit": {
             "url": "https://github.com/digitalocean/doctl/releases/download/v1.21.1/doctl-1.21.1-windows-amd64.zip",


### PR DESCRIPTION
Fix #248

The `sha256` file is the hash of executive inside...