### PR TITLE
Refactor perl manifest to use bin

### DIFF
--- a/bucket/perl.json
+++ b/bucket/perl.json
@@ -19,10 +19,9 @@
         "## NOTE: conversion to byte[] avoids adding an extra trailing newline to the output file",
         "[System.IO.File]::WriteAllBytes(\"$dir\\portable.perl\", ([byte[]][char[]]((Get-Content -Raw \"$dir\\portable.perl\") -replace \"(?ms)^HomeDir:.*?^(?=\\S)\",\"\")))"
     ],
-    "env_add_path": [
-        "perl\\site\\bin",
-        "perl\\bin",
-        "c\\bin"
+    "bin": [
+        "perl\\bin\\perl.exe",
+        "perl\\bin\\wperl.exe"
     ],
     "checkver": "Strawberry Perl ([\\d.]+)",
     "autoupdate": {


### PR DESCRIPTION
Currently, every executable under the moon is available via the PATH when installing the perl manifest. This creates issues when compiling C/C++ code since build tools find the compilers/linkers included in perl manifest and decide to use those over other installed compilers.

I changed the manifest to only add perl.exe and wperl.exe to the PATH. It is extremely likely that there are other useful executables buried in the perl bin directory but it seems like a reasonable approach to add these on a as-needed basis when issues are reported by users who expect some binary to be available from the perl manifest (compared to polluting the PATH of everyone who installs the perl manifest only to have perl.exe available).

This is a breaking change but I feel the current situation is rather excessive and should be fixed.