### PR TITLE
zstd: Add extract_dir, remove shortcut

### DIFF
--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -6,30 +6,28 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.4.1/zstd-v1.4.1-win64.zip",
-            "hash": "be5d10b94702e8fc48bf3c9ed6fec19cab556a1c00bc905f8473bc8a128d3abf"
+            "hash": "be5d10b94702e8fc48bf3c9ed6fec19cab556a1c00bc905f8473bc8a128d3abf",
+            "extract_dir": "zstd-v1.4.1-win64"
         },
         "32bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.4.1/zstd-v1.4.1-win32.zip",
-            "hash": "1fa75edad0e3a97c0f0d32dc20be73d08c908eb245bc9c318dcfc8301028959a"
+            "hash": "1fa75edad0e3a97c0f0d32dc20be73d08c908eb245bc9c318dcfc8301028959a",
+            "extract_dir": "zstd-v1.4.1-win32"
         }
     },
     "bin": "zstd.exe",
-    "shortcuts": [
-        [
-            "zstd.exe",
-            "zstd"
-        ]
-    ],
     "checkver": {
         "github": "https://github.com/facebook/zstd"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip",
+                "extract_dir": "zstd-v$version-win64"
             },
             "32bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win32.zip"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win32.zip",
+                "extract_dir": "zstd-v$version-win32"
             }
         }
     }


### PR DESCRIPTION
Fixes #256 
It's a console app, so a shortcut is meaningless.