### PR TITLE
nmap: Extract and install npcap

### DIFF
--- a/bucket/nmap.json
+++ b/bucket/nmap.json
@@ -1,18 +1,26 @@
 {
-    "homepage": "https://nmap.org",
     "version": "7.70",
-    "license": "https://svn.nmap.org/nmap/COPYING",
-    "url": "https://nmap.org/dist/nmap-7.70-setup.exe",
+    "description": "A free and open source utility for network discovery and security auditing.",
+    "homepage": "https://nmap.org",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://svn.nmap.org/nmap/COPYING"
+    },
+    "url": "https://nmap.org/dist/nmap-7.70-setup.exe#/dl.7z",
     "hash": "7828197e66f5f6efb0c89d21cdf3c34769da525437147eea72cf713a6d4e7a11",
-    "extract_dir": "nmap",
+    "pre_install": [
+        "Move-Item \"$dir\\npcap*.exe\" \"$dir\\npcap.exe\"",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\", \"$dir\\vcredist*\" -Recurse -Force"
+    ],
     "installer": {
+        "file": "npcap.exe",
         "args": [
             "/S",
-            "/D=$dir"
+            "/D=$dir\\npcap"
         ]
     },
     "uninstaller": {
-        "file": "Uninstall.exe",
+        "file": "npcap\\Uninstall.exe",
         "args": "/S"
     },
     "env_add_path": "bin",
@@ -31,9 +39,12 @@
     ],
     "checkver": {
         "url": "https://nmap.org/download.html",
-        "re": "nmap-([\\d.]+)-setup.exe"
+        "regex": "nmap-([\\d.]+)-setup"
     },
     "autoupdate": {
-        "url": "https://nmap.org/dist/nmap-$version-setup.exe"
+        "url": "https://nmap.org/dist/nmap-$version-setup.exe#/dl.7z"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2013"
     }
 }


### PR DESCRIPTION
Now npcap will be installed in nmap directory. Due to unknown reasons, uninstall will fail and need to uninstall manaully.