### PR TITLE
ChromeDriver Update 76.0.3809.68

### DIFF
--- a/bucket/chromedriver.json
+++ b/bucket/chromedriver.json
@@ -1,14 +1,14 @@
 {
-    "version": "75.0.3770.140",
-    "homepage": "https://sites.google.com/a/chromium.org/chromedriver/",
+    "version": "76.0.3809.68",
+    "homepage": "https://chromedriver.chromium.org/",
     "description": "An open source tool for automated testing of webapps across many browsers",
     "license": "BSD-3-Clause",
-    "url": "https://chromedriver.storage.googleapis.com/75.0.3770.140/chromedriver_win32.zip",
-    "hash": "30ba4f2a724b1a3f34ce4d4e53150d6155c21edd5d91b0f4bc40eea44a6d711b",
+    "url": "https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_win32.zip",
+    "hash": "a27d56f663326a6c742ae647f931224b70c84ba74b3f3a4b9e35628892cc7b1a",
     "bin": "chromedriver.exe",
     "checkver": {
-        "url": "https://sites.google.com/a/chromium.org/chromedriver/",
-        "regex": "Latest stable release:\\s*<a[^>]+>ChromeDriver\\s*([\\d.]+)<"
+        "url": "https://chromedriver.chromium.org/",
+        "regex": "Latest stable release:\\s*<a[^>]+>ChromeDriver[^\\d]*([\\d.]+)<"
     },
     "autoupdate": {
         "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip"


### PR DESCRIPTION
Update ChromeDriver from 75.0.3770.140 to 76.0.3809.68. Required to update Homepage-URL and especially the pattern to check for a new version. This is because between ChromeDriver and the corresponding version a non-breakable-space is rendered, which
did not match the previous `\s*` pattern.