### PR TITLE
llvm: Fix autoupdate

### DIFF
--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -58,10 +58,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://releases.llvm.org/$version/LLVM-$version-win64.exe#/llvm.7z"
+                "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/LLVM-$version-win64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://releases.llvm.org/$version/LLVM-$version-win32.exe#/llvm.7z"
+                "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/LLVM-$version-win32.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
#150. (Outstanding Excavator issues)

**LLVM** has changed their download url, which causes the 404 error.