### PR TITLE
iVeriLog: Add version 11-20190327

### DIFF
--- a/bucket/iverilog.json
+++ b/bucket/iverilog.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://bleyer.org/icarus/",
-    "description": "Free compiler for IEEE-1364 Verilog hardware description language",
+    "description": "Compiler for IEEE-1364 Verilog hardware description language.",
     "version": "11-20190327",
     "license": "GPL-2.0-or-later",
     "url": "http://bleyer.org/icarus/iverilog-v11-20190327-x64_setup.exe",

--- a/bucket/iverilog.json
+++ b/bucket/iverilog.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "http://bleyer.org/icarus/",
+    "description": "Free compiler for IEEE-1364 Verilog hardware description language",
+    "version": "11-20190327",
+    "license": "GPL-2.0-or-later",
+    "url": "http://bleyer.org/icarus/iverilog-v11-20190327-x64_setup.exe",
+    "hash": "18325eb91c57c2ef6d06ab5be8eede460a23af4c2b5a0fb01e3edebf56f77612",
+    "innosetup": true,
+    "bin": [
+        "bin\\iverilog.exe",
+        "bin\\iverilog-vpi.exe",
+        "bin\\vvp.exe",
+        "gtkwave\\bin\\gtkwave.exe"
+    ],
+    "checkver": "iverilog-v([\\d.-]+)-x64_setup.exe",
+    "autoupdate": {
+        "url": "http://bleyer.org/icarus/iverilog-v$version-x64_setup.exe"
+    }
+}


### PR DESCRIPTION
close https://github.com/lukesampson/scoop-extras/issues/2591

**Icarus VeriLog** (iVeriLog) ([homepage](http://bleyer.org/icarus/)) is a free compiler for IEEE-1364 Verilog hardware description language.