### PR TITLE
y-cruncher: Add version 0.7.7.9501

### DIFF
--- a/bucket/y-cruncher.json
+++ b/bucket/y-cruncher.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.numberworld.org/y-cruncher/",
-    "description": "Scalable multi-threaded benchmark program that calculate Pi and other constants to trillions of digits",
+    "description": "Scalable multi-threaded benchmark calculating multiple mathematical constants to trillions of digits.",
     "version": "0.7.7.9501",
     "license": {
         "identifier": "Freeware",

--- a/bucket/y-cruncher.json
+++ b/bucket/y-cruncher.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "http://www.numberworld.org/y-cruncher/",
+    "description": "Scalable multi-threaded benchmark program that calculate Pi and other constants to trillions of digits",
+    "version": "0.7.7.9501",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://www.numberworld.org/y-cruncher/license.html"
+    },
+    "url": "http://www.numberworld.org/y-cruncher/y-cruncher%20v0.7.7.9501.zip",
+    "hash": "1d7c9edcb696699ea1cf0ac2ee516f3a5436591fcbbb8c4c0a771330a4e4284a",
+    "extract_dir": "y-cruncher v0.7.7.9501",
+    "bin": "y-cruncher.exe",
+    "checkver": "y-cruncher v([\\d.]+).zip",
+    "autoupdate": {
+        "url": "http://www.numberworld.org/y-cruncher/y-cruncher%20v$version.zip",
+        "extract_dir": "y-cruncher v$version"
+    }
+}


### PR DESCRIPTION
**y-cruncher** ([homepage](http://www.numberworld.org/y-cruncher/)) is a multi-threaded benchmark program that calculate Pi and other constants to trillions of digits.

Notes:
* The website (www.numberworld.org) does not support HTTPS.