### PR TITLE
Removed godoc binary

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -9,8 +9,7 @@
     },
     "bin": [
         "bin/go.exe",
-        "bin/gofmt.exe",
-        "bin/godoc.exe"
+        "bin/gofmt.exe"
     ],
     "installer": {
         "script": "add_first_in_path \"$env:USERPROFILE\\go\\bin\" $global"


### PR DESCRIPTION
go 1.13 [no longer provides](https://golang.org/doc/go1.13#godoc) one out of the box