### PR TITLE
go: Remove godoc shim

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -9,8 +9,7 @@
     },
     "bin": [
         "bin/go.exe",
-        "bin/gofmt.exe",
-        "bin/godoc.exe"
+        "bin/gofmt.exe"
     ],
     "installer": {
         "script": "add_first_in_path \"$env:USERPROFILE\\go\\bin\" $global"


### PR DESCRIPTION
Godoc is just the web server and no longer distributed with go 1.13 (go doc is the cmd command as of 1.12).
Context: https://go-review.googlesource.com/c/build/+/174322/