### PR TITLE
go: Remove godoc bin

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -9,8 +9,7 @@
     },
     "bin": [
         "bin/go.exe",
-        "bin/gofmt.exe",
-        "bin/godoc.exe"
+        "bin/gofmt.exe"
     ],
     "installer": {
         "script": "add_first_in_path \"$env:USERPROFILE\\go\\bin\" $global"


### PR DESCRIPTION
As release note, "The `godoc` webserver is no longer included in the main binary distribution" since Go 1.13.
https://golang.org/doc/go1.13#godoc