### PR TITLE
radare2: Fix 'extract_dir'

### DIFF
--- a/bucket/radare2.json
+++ b/bucket/radare2.json
@@ -34,7 +34,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://radare.mikelloc.com/get/$version/radare2-msvc_64-$version.zip",
-                "extract_dir": "radare2-vs2017_64_dyn-$version"
+                "extract_dir": "radare2-vs2017_64-$version"
             }
         },
         "hash": {

--- a/bucket/radare2.json
+++ b/bucket/radare2.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://radare.mikelloc.com/get/3.9.0/radare2-msvc_64-3.9.0.zip",
             "hash": "sha1:59f74e633e51393238281fa8f5d6e60c4ee50e33",
-            "extract_dir": "radare2-vs2017_64_dyn-3.9.0"
+            "extract_dir": "radare2-vs2017_64-3.9.0"
         }
     },
     "bin": [


### PR DESCRIPTION
Extract dir changed and should not contain the _dyn suffix