### PR TITLE
Add saml2aws package

### DIFF
--- a/bucket/saml2aws.json
+++ b/bucket/saml2aws.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/Versent/saml2aws",
+    "description": "CLI tool which enables you to login and retrieve Amazon Web Services / AWS temporary credentials using a SAML IDP.",
+    "license": "MIT",
+    "version": "2.16.0",
+    "url": "https://github.com/Versent/saml2aws/releases/download/v2.16.0/saml2aws_2.16.0_windows_amd64.tar.gz",
+    "hash": "sha512:f5be1b59cc810c36949aaca3d5eed9a83e4b73d89abef8d5d71580fbb7ee45f4eb662af4c87845c79ec11088c2fb988e810c9cb38c8062618eb81aa972d5f4cc",
+    "bin": "saml2aws.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Versent/saml2aws/releases/download/v$version/saml2aws_$version_windows_amd64.tar.gz",
+        "hash": {
+            "url": "https://github.com/Versent/saml2aws/releases/download/v$version/saml2aws_$version_windows_amd64.sha512"
+        }
+    }
+}

--- a/bucket/saml2aws.json
+++ b/bucket/saml2aws.json
@@ -3,14 +3,22 @@
     "description": "Login and retrieve Amazon Web Services / AWS temporary credentials using a SAML IDP.",
     "license": "MIT",
     "version": "2.16.0",
-    "url": "https://github.com/Versent/saml2aws/releases/download/v2.16.0/saml2aws_2.16.0_windows_amd64.tar.gz",
-    "hash": "sha512:f5be1b59cc810c36949aaca3d5eed9a83e4b73d89abef8d5d71580fbb7ee45f4eb662af4c87845c79ec11088c2fb988e810c9cb38c8062618eb81aa972d5f4cc",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Versent/saml2aws/releases/download/v2.16.0/saml2aws_2.16.0_windows_amd64.tar.gz",
+            "hash": "sha512:f5be1b59cc810c36949aaca3d5eed9a83e4b73d89abef8d5d71580fbb7ee45f4eb662af4c87845c79ec11088c2fb988e810c9cb38c8062618eb81aa972d5f4cc"
+        }
+    },
     "bin": "saml2aws.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Versent/saml2aws/releases/download/v$version/saml2aws_$version_windows_amd64.tar.gz",
-        "hash": {
-            "url": "$baseurl/saml2aws_$version_windows_amd64.sha512"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Versent/saml2aws/releases/download/v$version/saml2aws_$version_windows_amd64.tar.gz",
+                "hash": {
+                    "url": "$baseurl/saml2aws_$version_windows_amd64.sha512"
+                }
+            }
         }
     },
     "suggest": {

--- a/bucket/saml2aws.json
+++ b/bucket/saml2aws.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/Versent/saml2aws",
-    "description": "CLI tool which enables you to login and retrieve Amazon Web Services / AWS temporary credentials using a SAML IDP.",
+    "description": "Login and retrieve Amazon Web Services / AWS temporary credentials using a SAML IDP.",
     "license": "MIT",
     "version": "2.16.0",
     "url": "https://github.com/Versent/saml2aws/releases/download/v2.16.0/saml2aws_2.16.0_windows_amd64.tar.gz",
@@ -12,5 +12,8 @@
         "hash": {
             "url": "https://github.com/Versent/saml2aws/releases/download/v$version/saml2aws_$version_windows_amd64.sha512"
         }
+    },
+    "suggest": {
+        "AWS": "aws"
     }
 }


### PR DESCRIPTION
I've created a package for [saml2aws](https://github.com/Versent/saml2aws). This would be used with *aws* and possibly *aws-iam-authnticator* which are both already in the main bucket. It is currently only available from Chocolatey.