### PR TITLE
llvm: Remove lldb-test.exe shim

### DIFF
--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -42,7 +42,6 @@
         "bin\\lld.exe",
         "bin\\lldb-argdumper.exe",
         "bin\\lldb-mi.exe",
-        "bin\\lldb-test.exe",
         "bin\\lldb-vscode.exe",
         "bin\\lldb.exe",
         "bin\\llvm-ar.exe",


### PR DESCRIPTION
It was removed in the 9.0.0 release.