### PR TITLE
nmap-portable: Add version 7.80

### DIFF
--- a/bucket/nmap-portable.json
+++ b/bucket/nmap-portable.json
@@ -1,0 +1,44 @@
+{
+    "homepage": "https://nmap.org",
+    "description": "Network exploration and security auditing utility.",
+    "version": "7.80",
+    "license": {
+        "identifier": "GPL-2.0-only",
+        "url": "https://github.com/nmap/nmap/blob/master/COPYING"
+    },
+    "url": "https://nmap.org/dist/nmap-7.80-setup.exe#/dl.7z",
+    "hash": "3b4d726bd366e7439367fa78a186dfa9b641d3b2ad354fd915581b6567480f94",
+    "suggest": {
+        "Visual C++ Redist 2008": "extras/vcredist2008"
+    },
+    "bin": [
+        "nmap.exe",
+        "ncat.exe",
+        "ndiff.exe",
+        "zenmap.exe",
+        "nping.exe"
+    ],
+    "pre_install": [
+        "Get-ChildItem \"$dir\\`$PLUGINSDIR\\npcap-*-oem.exe\" | Select-Object -First 1 | Rename-Item -NewName 'npcap-oem.exe'",
+        "Move-Item \"$dir\\`$PLUGINSDIR\\npcap-oem.exe\" \"$dir\"",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Recurse"
+    ],
+    "shortcuts": [
+        [
+            "zenmap.exe",
+            "Nmap - Zenmap GUI"
+        ]
+    ],
+    "notes": [
+        "Please install 'Npcap' by manually running '$dir\\npcap-oem.exe'!",
+        "Please import the network performance improvements by running 'regedt32 \"$dir\\nmap_performance.reg\"'",
+        "See: https://nmap.org/book/inst-windows.html"
+    ],
+    "checkver": {
+        "url": "https://nmap.org/download.html",
+        "regex": "nmap-([\\d.]+)-setup.exe"
+    },
+    "autoupdate": {
+        "url": "https://nmap.org/dist/nmap-$version-setup.exe#/dl.7z"
+    }
+}

--- a/bucket/nmap.json
+++ b/bucket/nmap.json
@@ -1,14 +1,13 @@
 {
     "homepage": "https://nmap.org",
-    "description": "Network exploration and security auditing utility.",
+    "description": "Network exploration and security auditing utility. (includes Npcap)",
     "version": "7.80",
     "license": {
         "identifier": "GPL-2.0-only",
-        "url": "https://svn.nmap.org/nmap/COPYING"
+        "url": "https://github.com/nmap/nmap/blob/master/COPYING"
     },
     "url": "https://nmap.org/dist/nmap-7.80-setup.exe",
     "hash": "3b4d726bd366e7439367fa78a186dfa9b641d3b2ad354fd915581b6567480f94",
-    "extract_dir": "nmap",
     "installer": {
         "args": [
             "/S",
@@ -19,7 +18,6 @@
         "file": "Uninstall.exe",
         "args": "/S"
     },
-    "env_add_path": "bin",
     "bin": [
         "nmap.exe",
         "ncat.exe",
@@ -30,12 +28,13 @@
     "shortcuts": [
         [
             "zenmap.exe",
-            "Zenmap"
+            "Nmap - Zenmap GUI"
         ]
     ],
+    "notes": "'Npcap' has been installed automatically.",
     "checkver": {
         "url": "https://nmap.org/download.html",
-        "re": "nmap-([\\d.]+)-setup.exe"
+        "regex": "nmap-([\\d.]+)-setup.exe"
     },
     "autoupdate": {
         "url": "https://nmap.org/dist/nmap-$version-setup.exe"


### PR DESCRIPTION
This provides a nmap installation without priviliges.
- Some small fixes for the nmap manifest
- Closes https://github.com/lukesampson/scoop/issues/1799