### PR TITLE
dotnet-sdk: Set MSBuildSDKsPath environment

### DIFF
--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -15,7 +15,8 @@
     },
     "bin": "dotnet.exe",
     "env_set": {
-        "DOTNET_ROOT": "$dir"
+        "DOTNET_ROOT": "$dir",
+        "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",


### PR DESCRIPTION
OmniSharp isn't able to find SDKs otherwise (see https://github.com/OmniSharp/omnisharp-vscode/issues/2970#issuecomment-524292461)