### PR TITLE
iVeriLog: Add env_add_path

### DIFF
--- a/bucket/iverilog.json
+++ b/bucket/iverilog.json
@@ -12,6 +12,7 @@
         "bin\\vvp.exe",
         "gtkwave\\bin\\gtkwave.exe"
     ],
+    "env_add_path": "bin",
     "checkver": "iverilog-v([\\d.-]+)-x64_setup.exe",
     "autoupdate": {
         "url": "http://bleyer.org/icarus/iverilog-v$version-x64_setup.exe"


### PR DESCRIPTION
close lukesampson/scoop-extras#2980

I am not familiar with **iVeriLog**,  but it seems that we have to add `bin` to `Env:path` for **iVeriLog** to work properly, according to the user who suggested adding it to the bucket. 

Ref:
lukesampson/scoop-extras#2591
lukesampson/scoop-extras#2980