### PR TITLE
doctl: Remove unnecessary pre_install

### DIFF
--- a/bucket/doctl.json
+++ b/bucket/doctl.json
@@ -13,7 +13,6 @@
             "hash": "d16aea8e28c2575a382799dfd23c0a80e55ec5d21844db253b40696a4d5931b6"
         }
     },
-    "pre_install": "Rename-Item \"$dir\\doctl\" 'doctl.exe'",
     "bin": "doctl.exe",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
The pre_install script used to rename "doctl" to "doctl.exe", but this isn't necessary since https://github.com/digitalocean/doctl/releases/tag/v1.30.0, and will produce an error:
```
Rename-Item : Cannot rename because item at 'C:\Users\Pedro\scoop\apps\doctl\1.33.0\doctl' does not exist.
At line:1 char:1
+ Rename-Item "$dir\doctl" 'doctl.exe'
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Rename-Item], PSInvalidOperationException
    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.RenameItemCommand
```