### PR TITLE
yarn: Add env_set

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -26,6 +26,9 @@
         "global\\node_modules\\.bin",
         "Yarn\\bin"
     ],
+    "env_set": {
+        "NODE_PATH": "$dir\\global\\node_modules"
+    },
     "checkver": {
         "url": "https://yarnpkg.com/latest-version",
         "re": "([\\d.]+)"


### PR DESCRIPTION
By default, `require` function doesn't look in the folder where global modules are installed by yarn, so only global modules installed by npm can be require properly. Add the path of global modules folder to the NODE_PATH environment variable to solve this.