### PR TITLE
watchexec: Update to version 1.11.1

### DIFF
--- a/bucket/watchexec.json
+++ b/bucket/watchexec.json
@@ -2,12 +2,12 @@
     "homepage": "https://github.com/mattgreen/watchexec",
     "description": "Execute commands in response to file modifications",
     "license": "Apache-2.0",
-    "version": "1.10.3",
-    "url": "https://github.com/mattgreen/watchexec/releases/download/1.10.3/watchexec-1.10.3-x86_64-pc-windows-gnu.zip",
-    "hash": "acdc33d6c12d11957549556f2d302ee67e93bc9acf4b1c25512f14d2a9c601f0",
+    "version": "1.11.1",
+    "url": "https://github.com/mattgreen/watchexec/releases/download/1.11.1/watchexec-1.11.1-x86_64-pc-windows-msvc.zip",
+    "hash": "afdc863928255b7d647cc90c567b0d11cd3d54600a6ff217ce71ecd21ace8964",
     "bin": "watchexec.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mattgreen/watchexec/releases/download/$version/watchexec-$version-x86_64-pc-windows-gnu.zip"
+        "url": "https://github.com/mattgreen/watchexec/releases/download/$version/watchexec-$version-x86_64-pc-windows-msvc.zip"
     }
 }


### PR DESCRIPTION
Moved from `gnu` to `msvc` builds.

#150 