### PR TITLE
nircmd: removed "." extract_dir that broke install

### DIFF
--- a/bucket/nircmd.json
+++ b/bucket/nircmd.json
@@ -13,7 +13,6 @@
             "hash": "5071b54669bb1e88422c6c340204b0b3a0ffd07e2ac1d747ccbd1447abc92948"
         }
     },
-    "extract_dir": ".",
     "bin": "nircmdc.exe",
     "checkver": {
         "re": "<td>NirCmd v([\\d\\.]+)"


### PR DESCRIPTION
The field `"extract_dir": ".",` in the manifest was causing nothing to extract to the app directory, so the install would fail.

- Closes lukesampson/scoop#3726