### PR TITLE
just: Update to version 0.4.5 (manually)

### DIFF
--- a/bucket/just.json
+++ b/bucket/just.json
@@ -2,12 +2,12 @@
     "homepage": "https://github.com/casey/just",
     "description": "A command runner written in rust",
     "license": "CC0-1.0",
-    "version": "0.4.4",
-    "url": "https://github.com/casey/just/releases/download/v0.4.4/just-v0.4.4-x86_64-pc-windows-gnu.zip",
-    "hash": "5a1ce463e97e299520e0b95463b34ef7dbd53de1c02bed83c089ab7e47a99ec7",
+    "version": "0.4.5",
+    "url": "https://github.com/casey/just/releases/download/v0.4.5/just-v0.4.5-x86_64-pc-windows-msvc.zip",
+    "hash": "5e8fe49c859345b2043ef4127a33de18a20e76b54544b46458ad09a5e79c9024",
     "bin": "just.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/casey/just/releases/download/v$version/just-v$version-x86_64-pc-windows-gnu.zip"
+        "url": "https://github.com/casey/just/releases/download/v$version/just-v$version-x86_64-pc-windows-msvc.zip"
     }
 }


### PR DESCRIPTION
#150 (Outstanding Excavator issues)

The file name was changed because [Just](https://github.com/casey/just/releases) changed their toolchain from `gnu` to `msvc`.