### PR TITLE
rtools: Add version 3.5.0.4

### DIFF
--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -7,7 +7,7 @@
     "innosetup": true,
     "checkver": {
         "url": "https://cloud.r-project.org/bin/windows/Rtools/VERSION.txt",
-        "regex": "Rtools version (.*)"
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://cran.r-project.org/bin/windows/Rtools/Rtools$majorVersion$minorVersion.exe"

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://cran.r-project.org/bin/windows/Rtools",
+    "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
+    "version": "3.5.0.4",
+    "url": "https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe",
+    "hash": "18fd63bb9c903e1f9bfce5c9a2600bd24213295760592dbc130b73a61e9d9414",
+    "innosetup": true,
+    "checkver": {
+        "url": "https://cloud.r-project.org/bin/windows/Rtools/VERSION.txt",
+        "regex": "Rtools version (.*)"
+    },
+    "autoupdate": {
+        "url": "https://cran.r-project.org/bin/windows/Rtools/Rtools$majorVersion$minorVersion.exe"
+    }
+}

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -2,7 +2,7 @@
     "homepage": "https://cran.r-project.org/bin/windows/Rtools",
     "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
     "version": "3.5.0.4",
-    "url": "https://cran.r-project.org/bin/windows/Rtools/Rtools35.exe",
+    "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe",
     "hash": "18fd63bb9c903e1f9bfce5c9a2600bd24213295760592dbc130b73a61e9d9414",
     "innosetup": true,
     "checkver": {

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -5,6 +5,7 @@
     "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe",
     "hash": "18fd63bb9c903e1f9bfce5c9a2600bd24213295760592dbc130b73a61e9d9414",
     "innosetup": true,
+    "env_add_path": "bin",
     "checkver": {
         "url": "https://cloud.r-project.org/bin/windows/Rtools/VERSION.txt",
         "regex": "([\\d.]+)"

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -10,6 +10,6 @@
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://cran.r-project.org/bin/windows/Rtools/Rtools$majorVersion$minorVersion.exe"
+        "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools$majorVersion$minorVersion.exe"
     }
 }

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://cran.r-project.org/bin/windows/Rtools",
+    "homepage": "https://cloud.r-project.org/bin/windows/Rtools",
     "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
     "version": "3.5.0.4",
     "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe",

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -5,7 +5,31 @@
     "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe",
     "hash": "18fd63bb9c903e1f9bfce5c9a2600bd24213295760592dbc130b73a61e9d9414",
     "innosetup": true,
-    "env_add_path": "bin",
+    "installer": {
+        "script": [
+            "'r', 'mro' | ForEach-Object {",
+            "   if (Test-Path (appdir $_ $global)) {",
+            "       $renvloc = (versiondir $_ (current_version $_ $global) $global) + '\\etc\\Renviron.site'",
+            "       if (Test-Path $renvloc) {",
+            "           $renv = Get-Content $renvloc -Encoding ASCII",
+            "       } else {",
+            "           $renv = @()",
+            "       }",
+            "       if ($architecture -eq '32bit') {",
+            "           $rtoolspath = \"$dir\\bin;$dir\\mingw_32\\bin\"",
+            "       } else {",
+            "           $rtoolspath = \"$dir\\bin;$dir\\mingw_64\\bin\"",
+            "       }",
+            "       if ($renv -cmatch 'PATH=') {",
+            "           $renv = $renv -replace 'PATH=\"(.*)', 'PATH=\"$rtoolspath;$1'",
+            "       } else {",
+            "           $renv += '\r\nPATH=\"' + $rtoolspath + ';${PATH}\"'",
+            "       }",
+            "       $renv | Set-Content $renvloc -Encoding ASCII",
+            "   }",
+            "}"
+        ]
+    },
     "checkver": {
         "url": "https://cloud.r-project.org/bin/windows/Rtools/VERSION.txt",
         "regex": "([\\d.]+)"


### PR DESCRIPTION
R is in the main bucket but Rtools is not.
This file adds Rtools. Rtools is the collection of compiler tools for compiling R or some R projects that uses external C, C++ or Fortran libraries.