### PR TITLE
texlive-x64: Add version 2019-11-03

### DIFF
--- a/bucket/texlive-x64
+++ b/bucket/texlive-x64
@@ -1,0 +1,14 @@
+{
+    "homepage": "https://tug.org/texlive/",
+    "description": "The 64-bit binaries for the TeXLive distribution (Currently distributed and updated separately from the main TeXLive distribution.).",
+    "version": "2019-11-03",
+    "url": "http://mirror.ctan.org/systems/win32/w32tex/TLW64/tl-win64.zip",
+    "hash": "197c114fbfeefc50c76b53c6b7d01292c7b91b531e03ca8094b8f4b243535746",
+    "checkver": {
+        "url": "http://mirror.ctan.org/systems/win32/w32tex/TLW64/",
+        "regex": "tl-win64.zip.*([\\d]{4}-[\\d]{2}-[\\d]{2})"
+    },
+    "autoupdate": {
+        "url": "http://mirror.ctan.org/systems/win32/w32tex/TLW64/tl-win64.zip"
+    }
+}


### PR DESCRIPTION
The main texlive distro distributes only 32-bit binaries. As per the texlive documentation, 64-bit binaries are currently distributed and updated separately from the 32-bit binaries.