### PR TITLE
nu: Update to version 0.5.0 (manually)

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://www.nushell.sh",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "license": "MIT",
     "description": "A modern shell written in Rust.",
-    "url": "https://github.com/nushell/nushell/releases/download/0.4.0/nu_0_4_0_windows.zip",
-    "hash": "45a9da6c70f03af629dca37402cddf6304fc0b1c8c98cd1f4b655ac68c091fb5",
-    "extract_dir": "nushell_0_4_0",
+    "url": "https://github.com/nushell/nushell/releases/download/0_5_0/nu_0_5_0_windows.zip",
+    "hash": "3feb39d6a903e8a753380003c8d49144a5320637e114de766c034a0e9bd09baf",
+    "extract_dir": "nushell_0_5_0",
     "installer": {
         "script": [
             "New-Item \"$dir\\Plugins\" -ItemType Directory | Out-Null",
@@ -15,10 +15,11 @@
     "bin": "nu.exe",
     "env_add_path": "Plugins",
     "checkver": {
-        "github": "https://github.com/nushell/nushell"
+        "github": "https://github.com/nushell/nushell",
+        "regex": "([\\d.]+) Release</a>"
     },
     "autoupdate": {
-        "url": "https://github.com/nushell/nushell/releases/download/$version/nu_$underscoreVersion_windows.zip",
+        "url": "https://github.com/nushell/nushell/releases/download/$underscoreVersion/nu_$underscoreVersion_windows.zip",
         "extract_dir": "nushell_$underscoreVersion"
     }
 }


### PR DESCRIPTION
#150 (Outstanding Excavator issues)

The download URL was changed because [nushell](https://github.com/nushell/nushell/releases) changed their version tag pattern from `0.5.0` to `0_5_0` 