### PR TITLE
kubefwd: Update to version 1.9.5 (manually)

### DIFF
--- a/bucket/kubefwd.json
+++ b/bucket/kubefwd.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://github.com/txn2/kubefwd",
     "license": "Apache-2.0",
-    "version": "1.9.4",
+    "version": "1.9.5",
     "description": "Bulk port forwarding Kubernetes services for local development.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/txn2/kubefwd/releases/download/v1.9.4/kubefwd_windows_amd64.zip",
-            "hash": "c1fb9993ceddb9526b50af8f8b99dcf9eda37cf66a876ca5e33c92ae39348c04"
+            "url": "https://github.com/txn2/kubefwd/releases/download/1.9.5/kubefwd_windows_amd64.zip",
+            "hash": "2691467c1ffa083d116f4ae33d8045ac1e5fffcef698a10c514b6d5e9e424b79"
         }
     },
     "bin": "kubefwd.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/txn2/kubefwd/releases/download/v$version/kubefwd_windows_amd64.zip"
+                "url": "https://github.com/txn2/kubefwd/releases/download/$version/kubefwd_windows_amd64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
#150 (Outstanding Excavator issues)

The download URL is changed from `releases/download/v$version/xxx` to `releases/download/$version/xxx`.
(See: https://github.com/txn2/kubefwd/releases/)