### PR TITLE
radare2: Fix download url and hash

### DIFF
--- a/bucket/radare2.json
+++ b/bucket/radare2.json
@@ -5,8 +5,8 @@
     "description": "Portable reversing framework.",
     "architecture": {
         "64bit": {
-            "url": "https://radare.mikelloc.com/get/4.0.0/radare2-msvc_64-4.0.0.zip",
-            "hash": "sha1:682995baca59cc7500c4c1f5a3574061cc5a2809",
+            "url": "https://radare.mikelloc.com/get/4.0.0/radare2-vs2017_64-4.0.0.zip",
+            "hash": "1def3cb10ad79a1704465355ac8fed677ca78779e8666a12c24f39282ee7aa5a",
             "extract_dir": "radare2-vs2017_64-4.0.0"
         }
     },
@@ -33,7 +33,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://radare.mikelloc.com/get/$version/radare2-msvc_64-$version.zip",
+                "url": "https://radare.mikelloc.com/get/$version/radare2-vs2017_64-$version.zip",
                 "extract_dir": "radare2-vs2017_64-$version"
             }
         },


### PR DESCRIPTION
Fix #551 

There's new binary zip with new name, but not sure it is permanent or not.