### PR TITLE
youtube-dl: Suggest ffmpeg instead of depending on it

### DIFF
--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -1,15 +1,18 @@
 {
-    "homepage": "https://rg3.github.io/youtube-dl/",
-    "description": "Download videos from YouTube.com (and a few more sites) using command line.",
-    "license": "Unlicense",
     "version": "2019.11.05",
+    "description": "Download videos from YouTube.com (and a few more sites) using command line.",
+    "homepage": "https://rg3.github.io/youtube-dl/",
+    "license": "Unlicense",
+    "suggest": {
+        "FFmpeg": [
+            "ffmpeg",
+            "ffmpeg-nightly"
+        ],
+        "vcredist": "extras/vcredist2010"
+    },
     "url": "https://github.com/rg3/youtube-dl/releases/download/2019.11.05/youtube-dl.exe",
     "hash": "0985ff04edfdce319356bf687061f99858c74d41df052f14308d1d64ef1baca6",
     "bin": "youtube-dl.exe",
-    "depends": "ffmpeg",
-    "suggest": {
-        "vcredist": "extras/vcredist2010"
-    },
     "checkver": {
         "github": "https://github.com/rg3/youtube-dl"
     },


### PR DESCRIPTION
This would be convenient, as I use ffmpeg-nightly instead of ffmpeg. I've also seen other manifests in the known repos do it this way.
I also reordered the manifest to the recommended order.
**EDIT:** As far as I can tell, youtube-dl doesn't strictly need FFmpeg to run.