### PR TITLE
git-filter-repo: Add version 2.24.0

### DIFF
--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -1,14 +1,18 @@
 {
-    "homepage": "https://github.com/newren/git-filter-repo",
-    "description": "git filter-branch replacement",
     "version": "2.24.0",
+    "description": "git filter-branch replacement",
+    "homepage": "https://github.com/newren/git-filter-repo",
     "license": "MIT",
+    "depends": "python",
+    "suggest": {
+        "Python 3": "python"
+    },
+    "notes": "Python 3 installation is needed.",
     "url": "https://github.com/newren/git-filter-repo/archive/v2.24.0.zip",
     "hash": "ac29c368b1c9ec751ccbdc800e5ce846e221acdeb564d64c2316c522b6a5d2a2",
     "extract_dir": "git-filter-repo-2.24.0",
+    "pre_install": "Set-Content -Path \"$dir\\git-filter-repo.ps1\" -Value \"python3 '$dir\\git-filter-repo' @args\"",
     "bin": "git-filter-repo.ps1",
-    "pre_install": "Set-Content -Path \"$dir\\git-filter-repo.ps1\" -Value \"python3 $dir\\git-filter-repo @args\"",
-    "depends": "python",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip",

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -3,7 +3,6 @@
     "description": "git filter-branch replacement",
     "homepage": "https://github.com/newren/git-filter-repo",
     "license": "MIT",
-    "depends": "python",
     "suggest": {
         "Python 3": "python"
     },

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/newren/git-filter-repo",
+    "description": "git filter-branch replacement",
+    "version": "2.24.0",
+    "license": "MIT",
+    "url": "https://github.com/newren/git-filter-repo/archive/v2.24.0.zip",
+    "hash": "ac29c368b1c9ec751ccbdc800e5ce846e221acdeb564d64c2316c522b6a5d2a2",
+    "extract_dir": "git-filter-repo-2.24.0",
+    "bin": "git-filter-repo.ps1",
+    "pre_install": "Set-Content -Path \"$dir\\git-filter-repo.ps1\" -Value \"python3 $dir\\git-filter-repo @args\"",
+    "depends": "python",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip",
+        "extract_dir": "git-filter-repo-$version"
+    }
+}


### PR DESCRIPTION
**git-filter-repo** is a tool for rewriting Git history, alternative to the `git filter-branch` command.

Endorsed by git itself:
```
$ git filter-branch
WARNING: git-filter-branch has a glut of gotchas generating mangled history
         rewrites.  Hit Ctrl-C before proceeding to abort, then use an
         alternative filtering tool such as 'git filter-repo'
         (https://github.com/newren/git-filter-repo/) instead.  See the
         filter-branch manual page for more details; to squelch this warning,
         set FILTER_BRANCH_SQUELCH_WARNING=1.
```

A few things to note:
1. Not sure whether `depend` on Python or `suggest` it.
2. Not sure whether call `python3` or just `python` in the ps1 shim.
The tool itself apparently expects Python 3.