### PR TITLE
k6: Add version 0.25.1

### DIFF
--- a/bucket/k6.json
+++ b/bucket/k6.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://k6.io",
+    "description": "Load and performance regression testing tool for cloud native backend infrastructure",
+    "version": "0.25.1",
+    "license": "AGPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/loadimpact/k6/releases/download/v0.25.1/k6-v0.25.1-win64.zip",
+            "hash": "4c1f9c4a669eceeda0c6d8864673fe7dc7fa481b514905f700c6946687b44a8f",
+            "extract_dir": "k6-v0.25.1-win64"
+        },
+        "32bit": {
+            "url": "https://github.com/loadimpact/k6/releases/download/v0.25.1/k6-v0.25.1-win32.zip",
+            "hash": "6776890125143bf9d9bea97597230601a581cccd2be7be0f97cfae2422519d65",
+            "extract_dir": "k6-v0.25.1-win32"
+        }
+    },
+    "bin": "k6.exe",
+    "checkver": {
+        "github": "https://github.com/loadimpact/k6"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-win64.zip",
+                "extract_dir": "k6-v$version-win64"
+            },
+            "32bit": {
+                "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-win32.zip",
+                "extract_dir": "k6-v$version-win32"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/k6-v$version-checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
https://k6.io/

moved here from this [PR in extras](https://github.com/lukesampson/scoop-extras/pull/3231) as requested

- Closes lukesampson/scoop-extras#3220