### PR TITLE
nomad@0.10.1: Fix hash

### DIFF
--- a/bucket/nomad.json
+++ b/bucket/nomad.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://releases.hashicorp.com/nomad/0.10.1/nomad_0.10.1_windows_amd64.zip",
-            "hash": "1123effd6c1bafc04f5c9976af3e506f33229b95ed03999a05e24d7a93a0f835"
+            "hash": "227b753a1f4407d16714e86506f503be576f6b2203ecc35e5c9f37bd7a62af91"
         },
         "32bit": {
             "url": "https://releases.hashicorp.com/nomad/0.10.1/nomad_0.10.1_windows_386.zip",
-            "hash": "997c03c74a54cfde54b744ee46d7c840c12915663f043cf728c44da9c22b2467"
+            "hash": "00531dc66f33051aeccca8a644fdb0fa4a9276ef889b7748cd31cd3f821a76d4"
         }
     },
     "bin": "nomad.exe",


### PR DESCRIPTION
According to https://releases.hashicorp.com/nomad/0.10.1/nomad_0.10.1_SHA256SUMS 
```
00531dc66f33051aeccca8a644fdb0fa4a9276ef889b7748cd31cd3f821a76d4  ./nomad_0.10.1_windows_386.zip
227b753a1f4407d16714e86506f503be576f6b2203ecc35e5c9f37bd7a62af91  ./nomad_0.10.1_windows_amd64.zip
```