### PR TITLE
ie11webdriver: Update to version 3.150.1

### DIFF
--- a/bucket/ie11webdriver.json
+++ b/bucket/ie11webdriver.json
@@ -1,22 +1,22 @@
 {
-    "version": "3.14.0",
-    "homepage": "http://www.seleniumhq.org/",
-    "description": "Selenium WebDriver for Internet Explorer 11.",
-    "license": "Unknown",
-    "bin": "IEDriverServer.exe",
+    "version": "3.150.1",
+    "homepage": "https://selenium.dev",
+    "description": "Selenium WebDriver for Internet Explorer 11",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://selenium-release.storage.googleapis.com/3.14/IEDriverServer_x64_3.14.0.zip",
-            "hash": "5e94943c2d31a285217ac8793e970339c0f87e4bbbc757f55aa293643741aed3"
+            "url": "https://selenium-release.storage.googleapis.com/3.150/IEDriverServer_x64_3.150.1.zip",
+            "hash": "b4c2ae00c6536258db7aaec989f37c7900467ec5369c7352ae897017bfd51d16"
         },
         "32bit": {
-            "url": "https://selenium-release.storage.googleapis.com/3.14/IEDriverServer_Win32_3.14.0.zip",
-            "hash": "29de31f5a3028224e5ae2df5757e112755ef8ccd0a06de8f333b129139647d70"
+            "url": "https://selenium-release.storage.googleapis.com/3.150/IEDriverServer_Win32_3.150.1.zip",
+            "hash": "09263561924a5a222b39bd0a80ef3778b8bf45457e1cf91c79b6a9f65d6230aa"
         }
     },
+    "bin": "IEDriverServer.exe",
     "checkver": {
-        "url": "http://www.seleniumhq.org/download/",
-        "re": "Download version ([\\d.]+).*[^<]+32 bit Windows IE"
+        "url": "https://selenium.dev/downloads/",
+        "regex": "(?sm)Download version ([\\d.]+).*?32 bit Windows IE"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
https://github.com/ScoopInstaller/Main/issues/150
[Here](https://github.com/SeleniumHQ/selenium/tree/master/cpp/iedriverserver) is the source code.