### PR TITLE
cormanlisp: Add version 3.1.2b

### DIFF
--- a/bucket/cormanlisp.json
+++ b/bucket/cormanlisp.json
@@ -1,0 +1,43 @@
+{
+    "version": "3.1.2b",
+    "description": "A Common Lisp development environment integrated with Windows.",
+    "homepage": "https://github.com/sharplispers/cormanlisp",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2015"
+    },
+    "url": "https://github.com/sharplispers/cormanlisp/releases/download/v3.1.2b/CormanLisp-3.1.2b.zip",
+    "hash": "8bf722bd919a69ff743e2ae6448fcb3ccbc8be8b3ef746e6acc5cdcb1853ea95",
+    "extract_dir": "Corman Lisp",
+    "bin": [
+        "clconsole.exe",
+        "clconsoleapp.exe"
+    ],
+    "env_set": {
+        "CORMANLISP_HOME": "$dir"
+    },
+    "shortcuts": [
+        [
+            "CormanLisp.exe",
+            "Corman Lisp IDE"
+        ],
+        [
+            "documentation\\CormanLisp.pdf",
+            "Corman Lisp Manual"
+        ],
+        [
+            "clconsole.exe",
+            "Corman Lisp REPL",
+            "",
+            "CormanLisp.exe"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/sharplispers/cormanlisp",
+        "regex": "tree/v([\\w.]+)/"
+    },
+    "autoupdate": {
+        "url": "https://github.com/sharplispers/cormanlisp/releases/download/v$version/CormanLisp-$version.zip"
+    },
+    "notes": "Please restart your command line for CORMANLISP_HOME to take effect. Consider installing <https://www.quicklisp.org/>."
+}


### PR DESCRIPTION
Adds in Corman Lisp with all the proper initialization from the MSI installer.

The icon has to be downloaded separately because it's a byte array in the Icon table in the MSI, but the MSI extractor deletes that before we can do anything with it in `pre_` or `post_install`, and it also would be extracted normally via `dark -x`, but #3502 isn't merged yet, and it's present in the `CormanLisp.exe` Portable Executable, but there are no interfaces to `kernel32.dll` FindResource/LoadResource in .NET and extracting and recreating the `.ico` from here would require C#, `DllImport`, and more, or an ungodly section of PowerShell code, and overall we can't have nice things. So we download the `.ico` once again for the REPL shortcut to have the nice icon its supposed to have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scoopinstaller/main/613)
<!-- Reviewable:end -->
