### PR TITLE
youtube-dl: Update GitHub owner to ytdl-org

### DIFF
--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -1,7 +1,7 @@
 {
     "version": "2019.11.22",
     "description": "Download videos from YouTube.com (and a few more sites) using command line.",
-    "homepage": "https://rg3.github.io/youtube-dl/",
+    "homepage": "https://ytdl-org.github.io/youtube-dl/",
     "license": "Unlicense",
     "suggest": {
         "FFmpeg": [
@@ -10,14 +10,14 @@
         ],
         "vcredist": "extras/vcredist2010"
     },
-    "url": "https://github.com/rg3/youtube-dl/releases/download/2019.11.22/youtube-dl.exe",
+    "url": "https://github.com/ytdl-org/youtube-dl/releases/download/2019.11.22/youtube-dl.exe",
     "hash": "580f74bc64f2d73fb53be2a1a1185d9426631479dcc4941b144dca0f351fb920",
     "bin": "youtube-dl.exe",
     "checkver": {
-        "github": "https://github.com/rg3/youtube-dl"
+        "github": "https://github.com/ytdl-org/youtube-dl"
     },
     "autoupdate": {
-        "url": "https://github.com/rg3/youtube-dl/releases/download/$version/youtube-dl.exe",
+        "url": "https://github.com/ytdl-org/youtube-dl/releases/download/$version/youtube-dl.exe",
         "hash": {
             "url": "$baseurl/SHA2-256SUMS"
         }


### PR DESCRIPTION
GitHub thankfully redirects rg3 just fine, but this is cleaner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scoopinstaller/main/616)
<!-- Reviewable:end -->
