### PR TITLE
dnscrypt-proxy: fix hash, change url, persist localhost.pem and polish

### DIFF
--- a/bucket/dnscrypt-proxy.json
+++ b/bucket/dnscrypt-proxy.json
@@ -5,44 +5,40 @@
     "license": "ISC",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.34/dnscrypt-proxy-win64-2.0.34.zip",
-            "hash": "2a13235378395d2f49483774b3af018bdc3ccebe5cd3f4861370e53ecfa02b0c",
+            "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.0.34/dnscrypt-proxy-win64-2.0.34.zip",
+            "hash": "d48da79ba4499eb8d92bd5bf3550587b043d0a76bb80070e23f7c207343f4b3a",
             "extract_dir": "win64"
         },
         "32bit": {
-            "url": "https://github.com/jedisct1/dnscrypt-proxy/releases/download/2.0.34/dnscrypt-proxy-win32-2.0.34.zip",
-            "hash": "75d7fd9735abb6c5280697564372230e8bd4390bcf3f9a314ddb0ad45378328b",
+            "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.0.34/dnscrypt-proxy-win32-2.0.34.zip",
+            "hash": "4848d713ec32d2ec52888c3212901b8521fe117e2df72139ce153a7e74560fd3",
             "extract_dir": "win32"
         }
     },
+    "pre_install": [
+        "'blacklist.txt', 'cloaking-rules.txt', 'dnscrypt-proxy.toml', 'forwarding-rules.txt', 'whitelist.txt' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { Copy-Item \"$dir\\example-$_\" \"$dir\\$_\" }",
+        "}"
+    ],
+    "bin": "dnscrypt-proxy.exe",
     "persist": [
         "blacklist.txt",
         "cloaking-rules.txt",
         "dnscrypt-proxy.toml",
         "forwarding-rules.txt",
+        "localhost.pem",
         "whitelist.txt"
     ],
-    "bin": "dnscrypt-proxy.exe",
-    "pre_install": [
-        "function CopyFile ($name) {",
-        "    if (!(Test-Path \"$persist_dir\\$name\")) {",
-        "        Copy-Item \"$dir\\example-$name\" \"$dir\\$name\" | Out-Null",
-        "    }",
-        "}",
-        "'blacklist.txt', 'cloaking-rules.txt', 'dnscrypt-proxy.toml', 'forwarding-rules.txt', 'whitelist.txt' | ForEach-Object {",
-        "    CopyFile $_",
-        "}"
-    ],
     "checkver": {
-        "github": "https://github.com/jedisct1/dnscrypt-proxy"
+        "github": "https://github.com/DNSCrypt/dnscrypt-proxy"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jedisct1/dnscrypt-proxy/releases/download/$version/dnscrypt-proxy-win64-$version.zip"
+                "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/$version/dnscrypt-proxy-win64-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/jedisct1/dnscrypt-proxy/releases/download/$version/dnscrypt-proxy-win32-$version.zip"
+                "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/$version/dnscrypt-proxy-win32-$version.zip"
             }
         }
     }


### PR DESCRIPTION
- Closes #636

About localhost.pem, see https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Local-DoH