### PR TITLE
dmg2img: Add version 1.6.7

### DIFF
--- a/bucket/dmg2img.json
+++ b/bucket/dmg2img.json
@@ -1,0 +1,13 @@
+{
+    "version": "1.6.7",
+    "description": "Converts DMG image file to IMG.",
+    "homepage": "http://vu1tur.eu.org/tools/",
+    "license": "GPL-2.0-or-later",
+    "url": "http://vu1tur.eu.org/tools/dmg2img-1.6.7-win32.zip",
+    "hash": "c33595575b08d04ab3cd1d7bc0339fc7ffa473d5969ce29a2a206d08dc4f42a4",
+    "bin": "dmg2img.exe",
+    "checkver": "dmg2img-([\\d.]+)",
+    "autoupdate": {
+        "url": "http://vu1tur.eu.org/tools/dmg2img-$version-win32.zip"
+    }
+}


### PR DESCRIPTION
**dmg2img** ([homepage](http://vu1tur.eu.org/tools/)) is a command-line tool that converts Apple's DMG disk image file to IMG image file.

Notes:
* The `GPL-2.0-or-later` license is contained in the archive. (dmg2img-1.6.7-win32.zip)