### PR TITLE
k2tf: Add version 0.3.0

### DIFF
--- a/bucket/k2tf.json
+++ b/bucket/k2tf.json
@@ -9,7 +9,6 @@
             "hash": "8d424bf2776573e734aa90d9057cda4eb7a01a03a9896b54ab4bdb156ef51b56"
         }
     },
-```
     "bin": "k2tf.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/k2tf.json
+++ b/bucket/k2tf.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/sl1pm4t/k2tf",
+    "description": "Converts Kubernetes API Objects (in YAML format) into HashiCorp's Terraform configuration language.",
+    "license": "MPL-2.0",
+    "version": "0.3.0",
+    "url": "https://github.com/sl1pm4t/k2tf/releases/download/v0.3.0/k2tf_0.3.0_Windows_x86_64.tar.gz",
+    "hash": "8d424bf2776573e734aa90d9057cda4eb7a01a03a9896b54ab4bdb156ef51b56",
+    "bin": "k2tf.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/sl1pm4t/k2tf/releases/download/v$version/k2tf_$version_Windows_x86_64.tar.gz",
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}

--- a/bucket/k2tf.json
+++ b/bucket/k2tf.json
@@ -3,12 +3,21 @@
     "description": "Converts Kubernetes API Objects (in YAML format) into HashiCorp's Terraform configuration language.",
     "license": "MPL-2.0",
     "version": "0.3.0",
-    "url": "https://github.com/sl1pm4t/k2tf/releases/download/v0.3.0/k2tf_0.3.0_Windows_x86_64.tar.gz",
-    "hash": "8d424bf2776573e734aa90d9057cda4eb7a01a03a9896b54ab4bdb156ef51b56",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sl1pm4t/k2tf/releases/download/v0.3.0/k2tf_0.3.0_Windows_x86_64.tar.gz",
+            "hash": "8d424bf2776573e734aa90d9057cda4eb7a01a03a9896b54ab4bdb156ef51b56"
+        }
+    },
+```
     "bin": "k2tf.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/sl1pm4t/k2tf/releases/download/v$version/k2tf_$version_Windows_x86_64.tar.gz",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sl1pm4t/k2tf/releases/download/v$version/k2tf_$version_Windows_x86_64.tar.gz"
+             }
+        },
         "hash": {
             "url": "$baseurl/checksums.txt"
         }


### PR DESCRIPTION
> `k2tf` is a tool for converting Kubernetes API Objects (in YAML format) into HashiCorp's Terraform configuration language.
> 
> The converted `.tf` files are suitable for use with the Terraform Kubernetes Provider

See: https://github.com/sl1pm4t/k2tf
> `k2tf` is a tool for converting Kubernetes API Objects (in YAML format) into HashiCorp's Terraform configuration language.
> 
> The converted `.tf` files are suitable for use with the Terraform Kubernetes Provider

See: https://github.com/sl1pm4t/k2tf

Initially opened this PR for the `extras` bucket, but was redirected here.