### PR TITLE
aws-iam-authenticator: Use GitHub repository

### DIFF
--- a/bucket/aws-iam-authenticator.json
+++ b/bucket/aws-iam-authenticator.json
@@ -1,16 +1,25 @@
 {
-    "homepage": "https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html",
+    "homepage": "https://github.com/kubernetes-sigs/aws-iam-authenticator",
     "description": "A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster",
     "license": "Apache-2.0",
-    "version": "2019-08-22",
-    "url": "https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/windows/amd64/aws-iam-authenticator.exe",
-    "hash": "9014193536bc97b79bf8d5540954548704453648bba63d74ac63e0b0f32aab49",
+    "version": "0.4.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_windows_amd64.exe",
+            "hash": "d26ccd0e83667f79dea88a72072371fd87c2023895417b54c2bd0e4c55d7d5fa"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\\aws-iam-authenticator_*.exe\" | Rename-Item -NewName \"$dir\\aws-iam-authenticator.exe\"",
     "bin": "aws-iam-authenticator.exe",
-    "checkver": "/(?<kubernetes>[\\d.]+)/(?<version>[\\d-]+)/bin/windows/amd64/aws-iam-authenticator.exe",
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://amazon-eks.s3-us-west-2.amazonaws.com/$matchKubernetes/$version/bin/windows/amd64/aws-iam-authenticator.exe",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v$version/aws-iam-authenticator_$version_windows_amd64.exe"
+            }
+        },
         "hash": {
-            "url": "$url.sha256"
+            "url": "$baseurl/authenticator_$version_checksums.txt"
         }
     }
 }

--- a/bucket/aws-iam-authenticator.json
+++ b/bucket/aws-iam-authenticator.json
@@ -5,17 +5,16 @@
     "version": "0.4.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_windows_amd64.exe",
+            "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_windows_amd64.exe#/aws-iam-authenticator.exe",
             "hash": "d26ccd0e83667f79dea88a72072371fd87c2023895417b54c2bd0e4c55d7d5fa"
         }
     },
-    "pre_install": "Get-ChildItem \"$dir\\aws-iam-authenticator_*.exe\" | Rename-Item -NewName \"$dir\\aws-iam-authenticator.exe\"",
     "bin": "aws-iam-authenticator.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v$version/aws-iam-authenticator_$version_windows_amd64.exe"
+                "url": "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v$version/aws-iam-authenticator_$version_windows_amd64.exe#/aws-iam-authenticator.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
This PR conflicts with #658 to solve #150 for `aws-iam-authenticator` with a (hopefully) more robust approach.

Instead of fetching the executable from Amazon's well-hidden download link in their documentation, this gets it from their GitHub project.