### PR TITLE
gsudo: Add version 0.4.1

### DIFF
--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.4.1",
+    "description": "A Sudo for Windows",
+    "homepage": "https://github.com/gerardog/gsudo",
+    "license": "MIT",
+    "url": "https://github.com/gerardog/gsudo/releases/download/v0.4.1/gsudo.v0.4.1.zip",
+    "hash": "5a7c2bdaa5e2c399c99bd396fea6e35a3267c62d901e7326959b17b1abaf4a3b",
+    "bin": [
+        "gsudo.exe",
+        [
+            "gsudo.exe",
+            "sudo"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.v$version.zip"
+    }
+}


### PR DESCRIPTION
gsudo: A sudo for windows with similar user experience as *nix sudo and credentials cache (avoid repeated UAC popups)

Migrated from scoop-extras to main repo: lukesampson/scoop-extras#3369 as per https://github.com/lukesampson/scoop-extras/pull/3369#pullrequestreview-335592819