### PR TITLE
Update rga.json

### DIFF
--- a/bucket/rga.json
+++ b/bucket/rga.json
@@ -1,6 +1,6 @@
 {
     "version": "0.9.3",
-    "description": "rga: ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc.",
+    "description": "ripgrep-all: ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc.",
     "homepage": "https://github.com/phiresky/ripgrep-all",
     "license": "AGPL-3.0-or-later",
     "architecture": {


### PR DESCRIPTION
Couldn't find this using `scoop search ripgrep-all` so I propose at least changing the description to include 'ripgrep-all' as a keyword. For reference the package name for Arch Linux is `ripgrep-all`, as is the GitHub repo name itself.

Also from the scoop docs:
> Don’t include the name of the program, if it’s the same as the app’s filename.