### PR TITLE
swi-prolog: Add version 8.0.3-1

### DIFF
--- a/bucket/swi-prolog.json
+++ b/bucket/swi-prolog.json
@@ -1,6 +1,6 @@
 {
     "version": "8.0.3-1",
-    "description": "",
+    "description": "A versatile implementation of the Prolog programming language.",
     "homepage": "https://www.swi-prolog.org",
     "license": "BSD-2-Clause",
     "architecture": {

--- a/bucket/swi-prolog.json
+++ b/bucket/swi-prolog.json
@@ -1,0 +1,41 @@
+{
+    "version": "8.0.3-1",
+    "description": "",
+    "homepage": "https://www.swi-prolog.org",
+    "license": "BSD-2-Clause",
+    "architecture": {
+        "32bit": {
+            "url": "https://www.swi-prolog.org/download/stable/bin/swipl-8.0.3-1.x86.exe#dl.7z",
+            "hash": "7b6b7295a8a19d350f16b38b00201725091e5d8272d4694c8df8696eabe45767"
+        },
+        "64bit": {
+            "url": "https://www.swi-prolog.org/download/stable/bin/swipl-8.0.3-1.x64.exe#dl.7z",
+            "hash": "f3b4783dd05a746219600185e8404238ee451708f3512c601a2c99cf549b0fa5"
+        }
+    },
+    "bin": [
+        "bin/swipl.exe",
+        "bin/swipl-win.exe",
+        "bin/swipl-ld.exe"
+    ],
+    "checkver": {
+        "url": "https://www.swi-prolog.org/download/stable",
+        "regex": "<b>([\\d-.]+)</b>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://www.swi-prolog.org/download/stable/bin/swipl-$version.x86.exe#dl.7z",
+                "hash": {
+                    "url": "https://www.swi-prolog.org/download/stable/bin/swipl-$version.x86.exe.sha256"
+                }
+            },
+            "64bit": {
+                "url": "https://www.swi-prolog.org/download/stable/bin/swipl-$version.x64.exe#dl.7z",
+                "hash": {
+                    "url": "https://www.swi-prolog.org/download/stable/bin/swipl-$version.x64.exe.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/swi-prolog.json
+++ b/bucket/swi-prolog.json
@@ -2,7 +2,7 @@
     "version": "8.0.3-1",
     "description": "A versatile implementation of the Prolog programming language.",
     "homepage": "https://www.swi-prolog.org",
-    "license": "BSD-2-Clause",
+    "license": "BSD-2-Clause, LGPL-3.0-only",
     "architecture": {
         "32bit": {
             "url": "https://www.swi-prolog.org/download/stable/bin/swipl-8.0.3-1.x86.exe#dl.7z",


### PR DESCRIPTION
SWI-Prolog is the most popular implementation and runtime for the Prolog programming language.

The package comes with a GUI tool (`swipl-win.exe`), but is not essential (comparable to Python's IDLE). 
In the same spirit of Python's manifest for this bucket, a shortcut was not added. 