### PR TITLE
chuck: Add version 1.4.0.0

### DIFF
--- a/bucket/chuck.json
+++ b/bucket/chuck.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-only",
     "url": "http://chuck.stanford.edu/release/files/exe/chuck-1.4.0.0.msi",
     "hash": "d3f24d49222dd18d0c7e3b3bb2d2965ad68dccd8e774723c62ad7eb33127a6d5",
-    "extract_dir": "PFiles/ChucK",
+    "extract_dir": "PFiles\\ChucK",
     "bin": [
         "bin/chuck.exe",
         "miniAudicle.exe"

--- a/bucket/chuck.json
+++ b/bucket/chuck.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.4.0.0",
+    "description": "Strongly-timed, Concurrent, and On-the-fly Music Programming Language.",
+    "homepage": "http://chuck.stanford.edu",
+    "license": "GPL-2.0-only",
+    "url": "http://chuck.stanford.edu/release/files/exe/chuck-1.4.0.0.msi",
+    "hash": "d3f24d49222dd18d0c7e3b3bb2d2965ad68dccd8e774723c62ad7eb33127a6d5",
+    "extract_dir": "PFiles/ChucK",
+    "bin": [
+        "bin/chuck.exe",
+        "miniAudicle.exe"
+    ],
+    "checkver": {
+        "url": "http://chuck.stanford.edu/release/",
+        "regex": "([\\d.]+) \\(\\w+\\)"
+    },
+    "autoupdate": {
+        "url": "http://chuck.stanford.edu/release/files/exe/chuck-$version.msi"
+    }
+}

--- a/bucket/chuck.json
+++ b/bucket/chuck.json
@@ -7,7 +7,7 @@
     "hash": "d3f24d49222dd18d0c7e3b3bb2d2965ad68dccd8e774723c62ad7eb33127a6d5",
     "extract_dir": "PFiles\\ChucK",
     "bin": [
-        "bin/chuck.exe",
+        "bin\\chuck.exe",
         "miniAudicle.exe"
     ],
     "checkver": {

--- a/bucket/chuck.json
+++ b/bucket/chuck.json
@@ -11,8 +11,8 @@
         "miniAudicle.exe"
     ],
     "checkver": {
-        "url": "http://chuck.stanford.edu/release/",
-        "regex": "([\\d.]+) \\(\\w+\\)"
+        "url": "http://chuck.stanford.edu/release/VERSIONS",
+        "regex": "^([\\d.]+)"
     },
     "autoupdate": {
         "url": "http://chuck.stanford.edu/release/files/exe/chuck-$version.msi"


### PR DESCRIPTION
ChucK is a strongly-timed, music oriented programming language.

**Considerations:**
- The installer comes with a GUI tool (`miniAudicle.exe`). A shortcut was not added, although it might be a good idea to do so given it's usefulness (but clearly not required to be able to work with it!);
- At the moment, ChucK is distributed by two universities: [Stanford](http://chuck.stanford.edu) and [Princeton](https://chuck.cs.princeton.edu). While the former is apparently the "official" one, the latter is (from my testing) faster + supports https.