### PR TITLE
bind: Update to version 9.14.9

### DIFF
--- a/bucket/bind.json
+++ b/bucket/bind.json
@@ -2,15 +2,11 @@
     "homepage": "https://www.isc.org/bind/",
     "description": "Versatile, classic, complete name server software.",
     "license": "MPL-2.0",
-    "version": "9.14.8",
+    "version": "9.14.9",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.isc.org/isc/bind9/9.14.8/BIND9.14.8.x64.zip",
-            "hash": "2b28768b32cd4abe81cc83f1df041aba8d3d6531fc5fb1d85e31d1346029bf27"
-        },
-        "32bit": {
-            "url": "https://downloads.isc.org/isc/bind9/9.14.8/BIND9.14.8.x86.zip",
-            "hash": "f23608dfe2d3fc91be0ebe4e380b9425f619e349863c0c18d9bec5a32a4475f5"
+            "url": "https://downloads.isc.org/isc/bind9/9.14.9/BIND9.14.9.x64.zip",
+            "hash": "3f070f75f73e0672f2d9f70122eab95b7b859717d3561b7ffae82511150fd8bd"
         }
     },
     "env_add_path": "bin",
@@ -23,14 +19,11 @@
             "Remove-Item \"$dir\\*\" -Exclude 'bin'"
         ]
     },
-    "checkver": "(?sm)Current-Stable<.*?\\/([\\d.]+)\\/",
+    "checkver": "(?sm)Current-Stable<.*?/([\\d.]+)/",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://downloads.isc.org/isc/bind$majorVersion/$version/BIND$version.x64.zip"
-            },
-            "32bit": {
-                "url": "https://downloads.isc.org/isc/bind$majorVersion/$version/BIND$version.x86.zip"
             }
         }
     },


### PR DESCRIPTION
Remove 32bit. https://github.com/ScoopInstaller/Main/issues/150

fix https://github.com/ScoopInstaller/Main/issues/710
dig in bind 9.14.9 works without msvcr110.dll . I don't know why 9.14.8 need that.

Should I remove or fix dig manifest?