### PR TITLE
broot: Add version 0.11.7

### DIFF
--- a/bucket/broot.json
+++ b/bucket/broot.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://dystroy.org/broot/",
+    "description": "A new way to see and navigate directory trees",
+    "version": "0.11.7",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Canop/broot/releases/download/v0.11.7/broot.exe",
+            "hash": "923a37656c3ed2c992ec86e4efb636e4ad33ac8833c66c9420ab69d1ecd93115"
+        }
+    },
+    "bin": "broot.exe",
+    "checkver": {
+        "github": "https://github.com/Canop/broot"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Canop/broot/releases/download/v$version/broot.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
> broot: A new way to see and navigate directory trees
> https://dystroy.org/broot/
> https://github.com/Canop/broot