### PR TITLE
lwc: Add version 0.4.5

### DIFF
--- a/bucket/lwc.json
+++ b/bucket/lwc.json
@@ -18,17 +18,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-$version-windows-amd64.tar.gz",
-                "hash": {
-                    "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-checksums.txt"
-                }
+                "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-$version-windows-amd64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-$version-windows-386.tar.gz",
-                "hash": {
-                    "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-checksums.txt"
-                }
+                "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-$version-windows-386.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/lwc-checksums.txt"
         }
     }
 }

--- a/bucket/lwc.json
+++ b/bucket/lwc.json
@@ -1,0 +1,34 @@
+{
+    "description": "A live-updating version of the UNIX wc command.",
+    "homepage": "https://github.com/timdp/lwc",
+    "version": "0.4.5",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/timdp/lwc/releases/download/v0.4.5/lwc-0.4.5-windows-amd64.tar.gz",
+            "hash": "0adaa5395692d25b90f3e25c942dcdc4f20005c5a77fb047a5e27112a5220f8a"
+        },
+        "32bit": {
+            "url": "https://github.com/timdp/lwc/releases/download/v0.4.5/lwc-0.4.5-windows-386.tar.gz",
+            "hash": "29a5067a2a51b2d674f02dbd4049ad47c6c5600ca09fa552d28944506a82da3a"
+        }
+    },
+    "bin": "lwc.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-$version-windows-amd64.tar.gz",
+                "hash": {
+                    "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-checksums.txt"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-$version-windows-386.tar.gz",
+                "hash": {
+                    "url": "https://github.com/timdp/lwc/releases/download/v$version/lwc-checksums.txt"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `lwc`, a simple CLI tool writen in Go.

In case `lwc` is a bit too niche, i'll gladly open a PR for the extra bucket.