### PR TITLE
minio(-client): Use official URL

### DIFF
--- a/bucket/minio-client.json
+++ b/bucket/minio-client.json
@@ -1,12 +1,12 @@
 {
-    "homepage": "https://minio.io/",
+    "homepage": "https://min.io/",
     "description": "A high performance, distributed object storage server, designed for large-scale data infrastructure. (client)",
     "license": "Apache-2.0",
     "version": "2020-01-25T03-02-19Z",
     "bin": "mc.exe",
     "architecture": {
         "64bit": {
-            "url": "https://dl.minio.io/client/mc/release/windows-amd64/mc.RELEASE.2020-01-25T03-02-19Z#/mc.exe",
+            "url": "https://dl.min.io/client/mc/release/windows-amd64/mc.RELEASE.2020-01-25T03-02-19Z#/mc.exe",
             "hash": "db78807fd27cfa12cf67f2c3e0ae459bece58f552ab17367a660c095b35cc963"
         }
     },
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.minio.io/client/mc/release/windows-amd64/mc.RELEASE.$version#/mc.exe",
+                "url": "https://dl.min.io/client/mc/release/windows-amd64/mc.RELEASE.$version#/mc.exe",
                 "hash": {
                     "url": "$baseurl/mc.exe.sha256sum"
                 }

--- a/bucket/minio.json
+++ b/bucket/minio.json
@@ -1,12 +1,12 @@
 {
-    "homepage": "https://minio.io/",
+    "homepage": "https://min.io/",
     "description": "A high performance, distributed object storage server, designed for large-scale data infrastructure. (server)",
     "license": "Apache-2.0",
     "version": "2020-01-25T02-50-51Z",
     "bin": "minio.exe",
     "architecture": {
         "64bit": {
-            "url": "https://dl.minio.io/server/minio/release/windows-amd64/minio.RELEASE.2020-01-25T02-50-51Z#/minio.exe",
+            "url": "https://dl.min.io/server/minio/release/windows-amd64/minio.RELEASE.2020-01-25T02-50-51Z#/minio.exe",
             "hash": "8c34c00255cd0b23e35299de33e607c38fe4179635d5609b31607e0d848b2d1c"
         }
     },
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.minio.io/server/minio/release/windows-amd64/minio.RELEASE.$version#/minio.exe",
+                "url": "https://dl.min.io/server/minio/release/windows-amd64/minio.RELEASE.$version#/minio.exe",
                 "hash": {
                     "url": "$baseurl/minio.RELEASE.$version.sha256sum"
                 }


### PR DESCRIPTION
MinIO officially using **min.io** as the main URL , now