### PR TITLE
vim(-nightly): Add vimrc persist

### DIFF
--- a/bucket/vim-nightly.json
+++ b/bucket/vim-nightly.json
@@ -42,7 +42,8 @@
         "    $content = (Get-Content \"$dir\\$_\").Replace('$vim', $vimpath)",
         "    if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "    Set-Content \"$dir\\$_\" $content",
-        "}"
+        "}",
+        "if (!(Test-Path \"$persist_dir\\vimrc\")) { New-Item -Name \"$dir\\vimrc\" -ItemType File | Out-Null }"
     ],
     "bin": [
         "vim.exe",
@@ -117,7 +118,8 @@
     "persist": [
         "_vimrc",
         "_gvimrc",
-        "vimfiles"
+        "vimfiles",
+        "vimrc"
     ],
     "checkver": {
         "github": "https://github.com/vim/vim-win32-installer"

--- a/bucket/vim-nightly.json
+++ b/bucket/vim-nightly.json
@@ -43,7 +43,7 @@
         "    if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "    Set-Content \"$dir\\$_\" $content",
         "}",
-        "if (!(Test-Path \"$persist_dir\\vimrc\")) { New-Item -Name \"$dir\\vimrc\" -ItemType File | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\vimrc\")) { New-Item \"$dir\\vimrc\" -ItemType File | Out-Null }"
     ],
     "bin": [
         "vim.exe",

--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -26,7 +26,8 @@
         "    $content = (Get-Content \"$dir\\$_\").Replace('$vim', $vimpath)",
         "    if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "    Set-Content \"$dir\\$_\" $content",
-        "}"
+        "}",
+        "if (!(Test-Path \"$persist_dir\\vimrc\")) { New-Item -Name \"$dir\\vimrc\" -ItemType File | Out-Null }"
     ],
     "bin": [
         "vim.exe",
@@ -101,7 +102,8 @@
     "persist": [
         "_vimrc",
         "_gvimrc",
-        "vimfiles"
+        "vimfiles",
+        "vimrc"
     ],
     "checkver": {
         "url": "https://ftp.nluug.nl/pub/vim/pc",

--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -27,7 +27,7 @@
         "    if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
         "    Set-Content \"$dir\\$_\" $content",
         "}",
-        "if (!(Test-Path \"$persist_dir\\vimrc\")) { New-Item -Name \"$dir\\vimrc\" -ItemType File | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\vimrc\")) { New-Item \"$dir\\vimrc\" -ItemType File | Out-Null }"
     ],
     "bin": [
         "vim.exe",


### PR DESCRIPTION
- Closes #749 

Next to _vimrc, there is also a vimrc file that is loaded before any other configs, which is sometimes needed to modify for example the HOME variable or the rtp. See issue #749 for more information.