### PR TITLE
hightlight@3.55: Fix extract dir

### DIFF
--- a/bucket/highlight.json
+++ b/bucket/highlight.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "http://www.andre-simon.de/zip/highlight-3.55-x64.zip",
             "hash": "b5048ca4e907b4b243e8a884d0baddfaf39ba9c67897c269d8f74910f522d9dd",
-            "extract_dir": "highlight-3.55-x64"
+            "extract_dir": "highlight-3.55-x86"
         },
         "32bit": {
             "url": "http://www.andre-simon.de/zip/highlight-3.55.zip",


### PR DESCRIPTION
Idea: would it be nice to validate `extract_dir` when, e.g., calculating the package hash?