### PR TITLE
zenhan: Add version 0.0.1

### DIFF
--- a/bucket/zenhan.json
+++ b/bucket/zenhan.json
@@ -1,0 +1,39 @@
+{
+    "version": "0.0.1",
+    "homepage": "https://github.com/iuchim/zenhan",
+    "description": "Switch the mode of input method editor from terminal. This is a tool similar to im-select.",
+    "license": "Unlicense",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/iuchim/zenhan/releases/download/v0.0.1/zenhan.zip",
+            "hash": "057e4ad47163c31d530a695353958e989200381b048c1e4f1bd8b40a97c20e28",
+            "extract_dir": "zenhan\\bin64"
+        },
+        "32bit": {
+            "url": "https://github.com/iuchim/zenhan/releases/download/v0.0.1/zenhan.zip",
+            "hash": "057e4ad47163c31d530a695353958e989200381b048c1e4f1bd8b40a97c20e28",
+            "extract_dir": "zenhan\\bin32"
+        }
+    },
+    "bin": "zenhan.exe",
+    "notes": [
+        "You can use zenhan from autoSwitchIM function of VSCodeVim.",
+        "see https://github.com/VSCodeVim/Vim#input-method",
+        "Settings example",
+        "\"vim.autoSwitchInputMethod.enable\": true,",
+        "\"vim.autoSwitchInputMethod.defaultIM\": \"0\",",
+        "\"vim.autoSwitchInputMethod.obtainIMCmd\": \"D:\\\\bin\\\\zenhan.exe\",",
+        "\"vim.autoSwitchInputMethod.switchIMCmd\": \"D:\\\\bin\\\\zenhan.exe {im}\""
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/iuchim/zenhan/releases/download/v$version/zenhan.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/iuchim/zenhan/releases/download/v$version/zenhan.zip"
+            }
+        }
+    }
+}

--- a/bucket/zenhan.json
+++ b/bucket/zenhan.json
@@ -1,39 +1,22 @@
 {
     "version": "0.0.1",
     "homepage": "https://github.com/iuchim/zenhan",
-    "description": "Switch the mode of input method editor from terminal. This is a tool similar to im-select.",
+    "description": "Editor input method switcher",
     "license": "Unlicense",
+    "notes": "You can use zenhan from autoSwitchIM function of VSCodeVim (see https://github.com/VSCodeVim/Vim#input-method)",
+    "url": "https://github.com/iuchim/zenhan/releases/download/v0.0.1/zenhan.zip",
+    "hash": "057e4ad47163c31d530a695353958e989200381b048c1e4f1bd8b40a97c20e28",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/iuchim/zenhan/releases/download/v0.0.1/zenhan.zip",
-            "hash": "057e4ad47163c31d530a695353958e989200381b048c1e4f1bd8b40a97c20e28",
             "extract_dir": "zenhan\\bin64"
         },
         "32bit": {
-            "url": "https://github.com/iuchim/zenhan/releases/download/v0.0.1/zenhan.zip",
-            "hash": "057e4ad47163c31d530a695353958e989200381b048c1e4f1bd8b40a97c20e28",
             "extract_dir": "zenhan\\bin32"
         }
     },
     "bin": "zenhan.exe",
-    "notes": [
-        "You can use zenhan from autoSwitchIM function of VSCodeVim.",
-        "see https://github.com/VSCodeVim/Vim#input-method",
-        "Settings example",
-        "\"vim.autoSwitchInputMethod.enable\": true,",
-        "\"vim.autoSwitchInputMethod.defaultIM\": \"0\",",
-        "\"vim.autoSwitchInputMethod.obtainIMCmd\": \"D:\\\\bin\\\\zenhan.exe\",",
-        "\"vim.autoSwitchInputMethod.switchIMCmd\": \"D:\\\\bin\\\\zenhan.exe {im}\""
-    ],
     "checkver": "github",
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/iuchim/zenhan/releases/download/v$version/zenhan.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/iuchim/zenhan/releases/download/v$version/zenhan.zip"
-            }
-        }
+        "url": "https://github.com/iuchim/zenhan/releases/download/v$version/zenhan.zip"
     }
 }

--- a/bucket/zenhan.json
+++ b/bucket/zenhan.json
@@ -2,7 +2,7 @@
     "version": "0.0.1",
     "homepage": "https://github.com/iuchim/zenhan",
     "description": "Editor input method switcher",
-    "license": "Unlicense",
+    "license": "Unknown",
     "notes": "You can use zenhan from autoSwitchIM function of VSCodeVim (see https://github.com/VSCodeVim/Vim#input-method)",
     "url": "https://github.com/iuchim/zenhan/releases/download/v0.0.1/zenhan.zip",
     "hash": "057e4ad47163c31d530a695353958e989200381b048c1e4f1bd8b40a97c20e28",


### PR DESCRIPTION
[zenhan](https://github.com/iuchim/zenhan): Switch the mode of input method editor from terminal. 

This is a tool similar to [im-select](https://github.com/daipeihust/im-select). zenhan switches IME mode instead of switching IME like im-select.

You can use zenhan from autoSwitchIM function of VSCodeVim.
https://github.com/VSCodeVim/Vim#input-method