### PR TITLE
nodejs: Use bin instead of adding new PATH

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -3,6 +3,11 @@
     "description": "As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.",
     "version": "13.7.0",
     "license": "MIT",
+    "bin": [
+        "node.exe",
+        "npm.cmd",
+        "npx.cmd"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://nodejs.org/dist/v13.7.0/node-v13.7.0-win-x64.7z",


### PR DESCRIPTION
While this PR doesn't give any new features, I think using `bin` over adding PATH is generally better in this kind of cases. (i.e. Scoop would be able to generate shims for Node.js)