### PR TITLE
yarn: Use bin property instead of PATH

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -5,6 +5,7 @@
     "license": "BSD-2-Clause",
     "url": "https://yarnpkg.com/downloads/1.21.1/yarn-1.21.1.msi",
     "hash": "95eb5eb485740788fe7bae57af403f71395139802a228a88d1afe290891a1344",
+    "bin": ""Yarn\\bin\\yarn.cmd",
     "persist": [
         "cache",
         "mirror",
@@ -23,8 +24,7 @@
         ]
     },
     "env_add_path": [
-        "global\\node_modules\\.bin",
-        "Yarn\\bin"
+        "global\\node_modules\\.bin"
     ],
     "env_set": {
         "NODE_PATH": "$dir\\global\\node_modules"

--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -5,7 +5,7 @@
     "license": "BSD-2-Clause",
     "url": "https://yarnpkg.com/downloads/1.21.1/yarn-1.21.1.msi",
     "hash": "95eb5eb485740788fe7bae57af403f71395139802a228a88d1afe290891a1344",
-    "bin": ""Yarn\\bin\\yarn.cmd",
+    "bin": "Yarn\\bin\\yarn.cmd",
     "persist": [
         "cache",
         "mirror",

--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -5,7 +5,10 @@
     "license": "BSD-2-Clause",
     "url": "https://yarnpkg.com/downloads/1.21.1/yarn-1.21.1.msi",
     "hash": "95eb5eb485740788fe7bae57af403f71395139802a228a88d1afe290891a1344",
-    "bin": "Yarn\\bin\\yarn.cmd",
+    "bin": [
+        "Yarn\\bin\\yarn.cmd",
+        "Yarn\\bin\\yarnpkg.cmd"
+    ],
     "persist": [
         "cache",
         "mirror",


### PR DESCRIPTION
Like #774, this PR adds new `bin`s instead of PATH. But since yarn has only two binaries, I removed `Yarn\\bin` in `env_add_path`.