### PR TITLE
shasum: Update to 0.2020.01.26 (version only)

### DIFF
--- a/bucket/shasum.json
+++ b/bucket/shasum.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "An approximation of the Unix shasum command.",
-    "version": "0.2018.08.04",
+    "version": "0.2020.01.26",
     "license": "MIT",
     "url": [
         "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/shasum.ps1",


### PR DESCRIPTION
To quiet spurious log entry. See #150