### PR TITLE
espanso@0.5.0: Fix hash

### DIFF
--- a/bucket/espanso.json
+++ b/bucket/espanso.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/federico-terzi/espanso/releases/download/v0.5.0/espanso-win-installer.exe",
-            "hash": "5a62342866d5b7d2be4feaa108ff4b6733866a4542261633fcf1a63f835651c7"
+            "hash": "4f15503e98a3380c33449489e8674d8318155f5110eb183091292fea85df0870"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
Fixes #781 

Ran autoupdate locally; hash calc by Extract Mode and subsequent installation worked as expected.