### PR TITLE
tor@0.4.2.5: Fix url

### DIFF
--- a/bucket/tor.json
+++ b/bucket/tor.json
@@ -5,11 +5,11 @@
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://dist.torproject.org/torbrowser/9.0.3/tor-win64-0.4.2.5.zip",
+            "url": "https://dist.torproject.org/torbrowser/9.0.4/tor-win64-0.4.2.5.zip",
             "hash": "a221503d63f8938d99731560981adb68a5ff651f258e5aea919d6618ab24d28c"
         },
         "32bit": {
-            "url": "https://dist.torproject.org/torbrowser/9.0.3/tor-win32-0.4.2.5.zip",
+            "url": "https://dist.torproject.org/torbrowser/9.0.4/tor-win32-0.4.2.5.zip",
             "hash": "ce6bc27dd36e53f01e4ba6cf93bdb0600f5c6eafcf602f1aaae9262dcb1e3549"
         }
     },


### PR DESCRIPTION
This PR fixes - for the time being - the download URL for tor (see #760, #730 ).

The issue will occur again when the browser is updated, but not tor. In this case, one has to force an Autoupdate to fix the URL.