### PR TITLE
openssl: Add to PATH to make libraries discoverable

### DIFF
--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -21,6 +21,9 @@
     "env_set": {
         "OPENSSL_CONF": "$dir\\bin\\cnf\\openssl.cnf"
     },
+    "env_add_path": [
+        "bin"
+    ],
     "checkver": "Win32 OpenSSL v([^\\s]+)",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This adds the `bin` directory to `PATH` to make provided libraries discoverable.

This is according to https://github.com/timvisee/ffsend/issues/106#issuecomment-584661412, and is needed because `ffsend` currently fails to find the installed OpenSSL libraries.

I'm not sure whether to increase a version number or anything in this manifest as well, to force-update and apply the `PATH` variable on current systems.