### PR TITLE
Update octave, change check version url and regex

### DIFF
--- a/bucket/octave.json
+++ b/bucket/octave.json
@@ -28,8 +28,8 @@
         }
     },
     "checkver": {
-        "url": "https://wiki.octave.org/GNU_Octave_Wiki",
-        "re": "GNU Octave ([\\d.]+).*is the current stable release"
+        "url": "https://www.gnu.org/software/octave/",
+        "re": "octave-([\\d.]+_\\d?)-w64\\.zip\\.sig"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
The old `url` doesn't cover the latest patch numbers such as `5.2.0_1`. The software home page contains a gpg signature that can do the version check.