### PR TITLE
packer@1.5.2: Fix hash

### DIFF
--- a/bucket/packer.json
+++ b/bucket/packer.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://releases.hashicorp.com/packer/1.5.2/packer_1.5.2_windows_amd64.zip",
-            "hash": "0f1d36897257f8ab50e5be519ab20bed67e59505cf04e71bd7a21d525443984f"
+            "hash": "6267a0023042848e144197cb3c28f72f9a4c2ef6432ae657057f08747f3fb5fe"
         },
         "32bit": {
             "url": "https://releases.hashicorp.com/packer/1.5.2/packer_1.5.2_windows_386.zip",
-            "hash": "c07b0b0a81bbc380512344151aa8e34e83d53a5b90511156510d22b0effd3b34"
+            "hash": "275d5e9dacda5f75bf5656b6cc753ff24a33c85389ba8c41021c5450a0db1d66"
         }
     },
     "bin": "packer.exe",


### PR DESCRIPTION
Updated hashes for both x86 and x64 installers.