### PR TITLE
migrate: Add version 4.9.1

### DIFF
--- a/bucket/migrate.json
+++ b/bucket/migrate.json
@@ -1,0 +1,42 @@
+{
+    "version": "4.9.1",
+    "description": "Reads and applies migrations in correct order to a database.",
+    "homepage": "https://github.com/golang-migrate/migrate",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/golang-migrate/migrate/releases/download/v4.9.1/migrate.windows-amd64.exe.tar.gz",
+            "hash": "e54619afaff2dbc1a7d75799dffcbf10ee1d33b3b1c98fe0eb2acdf3e58ac861",
+            "bin": [
+                [
+                    "migrate.windows-amd64.exe",
+                    "migrate"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/golang-migrate/migrate/releases/download/v4.9.1/migrate.windows-386.exe.tar.gz",
+            "hash": "641dfc31989b95aed9cf569bdfda983bed8c9960a2182dd1d36a5e448e447df1",
+            "bin": [
+                [
+                    "migrate.windows-386.exe",
+                    "migrate"
+                ]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/golang-migrate/migrate/releases/download/v$version/migrate.windows-amd64.exe.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/golang-migrate/migrate/releases/download/v$version/migrate.windows-386.exe.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    }
+}


### PR DESCRIPTION
This is a very useful CLI when working with databases.
It is used to migrate/rollback database changes over time.

~~The current version (4.8.0) is only released as a 64-bit windows exe, so this bucket only supports 64-bit installs.~~
~~I asked if upstream could provide 32-bit windows binaries in the future in golang-migrate/migrate#339~~