### PR TITLE
pandoc: add extract_dir

### DIFF
--- a/bucket/pandoc.json
+++ b/bucket/pandoc.json
@@ -6,15 +6,14 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-windows-x86_64.zip",
-            "hash": "260b6c5dfe5c36413d42d0ddc699438c0705e646cb196ad4f207d8f80564c3fb",
-            "extract_dir": "pandoc-2.9.2"
+            "hash": "260b6c5dfe5c36413d42d0ddc699438c0705e646cb196ad4f207d8f80564c3fb"
         },
         "32bit": {
             "url": "https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-windows-i386.zip",
-            "hash": "11fa220adb653ad7fdd6b3757cedb8c7ccd1d73e33f835008c1c09169c283c21",
-            "extract_dir": "pandoc-2.9.2"
+            "hash": "11fa220adb653ad7fdd6b3757cedb8c7ccd1d73e33f835008c1c09169c283c21"
         }
     },
+    "extract_dir": "pandoc-2.9.2",
     "bin": [
         "pandoc.exe",
         "pandoc-citeproc.exe"
@@ -23,6 +22,7 @@
         "github": "https://github.com/jgm/pandoc"
     },
     "autoupdate": {
+        "extract_dir": "pandoc-$version",
         "architecture": {
             "64bit": {
                 "url": "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-windows-x86_64.zip"

--- a/bucket/pandoc.json
+++ b/bucket/pandoc.json
@@ -6,11 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-windows-x86_64.zip",
-            "hash": "260b6c5dfe5c36413d42d0ddc699438c0705e646cb196ad4f207d8f80564c3fb"
+            "hash": "260b6c5dfe5c36413d42d0ddc699438c0705e646cb196ad4f207d8f80564c3fb",
+            "extract_dir": "pandoc-2.9.2"
         },
         "32bit": {
             "url": "https://github.com/jgm/pandoc/releases/download/2.9.2/pandoc-2.9.2-windows-i386.zip",
-            "hash": "11fa220adb653ad7fdd6b3757cedb8c7ccd1d73e33f835008c1c09169c283c21"
+            "hash": "11fa220adb653ad7fdd6b3757cedb8c7ccd1d73e33f835008c1c09169c283c21",
+            "extract_dir": "pandoc-2.9.2"
         }
     },
     "bin": [


### PR DESCRIPTION
Add `extract_dir` in `pandoc.json` to fix #812 