### PR TITLE
pandoc@2.9.2: Fix installation

### DIFF
--- a/bucket/pandoc.json
+++ b/bucket/pandoc.json
@@ -13,6 +13,7 @@
             "hash": "11fa220adb653ad7fdd6b3757cedb8c7ccd1d73e33f835008c1c09169c283c21"
         }
     },
+    "extract_dir": "pandoc-2.9.2",
     "bin": [
         "pandoc.exe",
         "pandoc-citeproc.exe"
@@ -28,7 +29,8 @@
             "32bit": {
                 "url": "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-windows-i386.zip"
             }
-        }
+        },
+        "extract_dir": "pandoc-$version"
     },
     "suggest": {
         "MiKTeX": "latex"


### PR DESCRIPTION
As the pandoc executables now are located deeper inside another level of the path, an extract_dir is needed.