### PR TITLE
ziglang: Suggest vcredist

### DIFF
--- a/bucket/ziglang.json
+++ b/bucket/ziglang.json
@@ -14,6 +14,9 @@
     "checkver": {
         "github": "https://github.com/zig-lang/zig/"
     },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/ziglang.json
+++ b/bucket/ziglang.json
@@ -3,6 +3,9 @@
     "description": "General-purpose programming language designed for robustness, optimality, and maintainability.",
     "homepage": "https://ziglang.org/",
     "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/ziglang/zig/releases/download/0.5.0/zig-windows-x86_64-0.5.0.zip",
@@ -13,9 +16,6 @@
     "bin": "zig.exe",
     "checkver": {
         "github": "https://github.com/zig-lang/zig/"
-    },
-    "suggest": {
-        "vcredist": "extras/vcredist2019"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Zig compiler does not start when `vcruntime400_1.dll` is not present on the system. Since shim gives no output, it is very confusing behavior and user gets impression that there is something fishy with zig. It's preventable by suggesting vcredist2019.

![ziglang](https://user-images.githubusercontent.com/544082/75192337-55687580-5754-11ea-9ad2-2f0e3ee2bbb7.png)
