### PR TITLE
moonscript: Add version 0.5.0

### DIFF
--- a/bucket/moonscript.json
+++ b/bucket/moonscript.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.5.0",
+    "description": "Compiler of MoonScript, a dynamic scripting language that compiles into Lua",
+    "homepage": "https://moonscript.org/",
+    "license": "MIT",
+    "url": "https://github.com/leafo/moonscript/releases/download/win32-v0.5.0/moonscript-187bac54ee5a7450013e9c38e005a0e671b76f45.zip",
+    "hash": "6c8a255a46a6805f5582fb03771a7289cb5ba79a83781f56ee5ee93d3ef489fc",
+    "bin": [
+        "moon.exe",
+        "moonc.exe"
+    ]
+}


### PR DESCRIPTION
close https://github.com/lukesampson/scoop/issues/3041

**MoonScript** ([homepage](https://moonscript.org/)) is a dynamic scripting language that compiles into *Lua*.


Notes:

* The *MIT license* can be found in the `LICENSE` file in the archive.

* *checkver/autoupdate* is not needed because *MoonScript* has not been updated since 2016.

* Usage of `moon.exe` and `moonc.exe` can be found [here](https://leafo.net/posts/getting_started_with_moonscript.html#creating-programs/compiling-and-running).