### PR TITLE
freepascal: Add version 3.0.4

### DIFF
--- a/bucket/freepascal.json
+++ b/bucket/freepascal.json
@@ -16,7 +16,9 @@
     "shortcuts": [
         [
             "bin\\i386-win32\\fp.exe",
-            "Free Pascal IDE"
+            "Free Pascal IDE",
+            "",
+            "bin\\i386-win32\\fp32.ico"
         ]
     ],
     "checkver": "fpc-(?<fpc>[\\d.]+).i386-win32.exe",

--- a/bucket/freepascal.json
+++ b/bucket/freepascal.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://www.freepascal.org",
+    "version": "3.0.4",
+    "description": "Professional Pascal compiler.",
+    "license": {
+        "identifier": "GPL-2.0-or-later | FPC-modified-LGPL-2.0-or-later",
+        "url": "http://wiki.lazarus.freepascal.org/licensing"
+    },
+    "url": "https://sourceforge.net/projects/freepascal/files/Win32/3.0.4/fpc-3.0.4.i386-win32.exe/download",
+    "hash": "1f6323d3362eca1f0b2f63160c2329205df0415f6aa9d8e42910629aaaa823bb",
+    "innosetup": true,
+    "bin": [
+        "bin\\i386-win32\\fp.exe",
+        "bin\\i386-win32\\fpc.exe"
+    ],
+    "shortcuts": [
+        [
+            "bin\\i386-win32\\fp.exe",
+            "Free Pascal IDE"
+        ]
+    ],
+    "checkver": "fpc-(?<fpc>[\\d.]+).i386-win32.exe",
+     "autoupdate": {
+        "url": "https://sourceforge.net/projects/freepascal/files/Win32/$version/fpc-$version.i386-win32.exe/download"
+    }
+}

--- a/bucket/freepascal.json
+++ b/bucket/freepascal.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": "fpc-(?<fpc>[\\d.]+).i386-win32.exe",
-     "autoupdate": {
-        "url": "https://sourceforge.net/projects/freepascal/files/Win32/$version/fpc-$version.i386-win32.exe/download"
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/freepascal/Win32/$version/fpc-$version.i386-win32.exe"
     }
 }

--- a/bucket/freepascal.json
+++ b/bucket/freepascal.json
@@ -6,8 +6,8 @@
         "identifier": "GPL-2.0-or-later | FPC-modified-LGPL-2.0-or-later",
         "url": "http://wiki.lazarus.freepascal.org/licensing"
     },
-    "url": "https://sourceforge.net/projects/freepascal/files/Win32/3.0.4/fpc-3.0.4.i386-win32.exe/download",
-    "hash": "1f6323d3362eca1f0b2f63160c2329205df0415f6aa9d8e42910629aaaa823bb",
+    "url": "https://downloads.sourceforge.net/project/freepascal/Win32/3.0.4/fpc-3.0.4.i386-win32.exe",
+    "hash": "sha1:69b0d42739ccb22108a35d8f108741a7883ff3ff",
     "innosetup": true,
     "bin": [
         "bin\\i386-win32\\fp.exe",


### PR DESCRIPTION
- Closes #844 

Providing definition file that will allow scoop install `freepascal` compiler (FPC) 