### PR TITLE
python: Add registry configuration

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -3,16 +3,46 @@
     "description": "A programming language that lets you work quickly and integrate systems more effectively.",
     "license": "Python-2.0",
     "version": "3.8.2",
+    "notes": "Allow applications and third-party installers to find python by running: \"$dir\\install-pep-514.reg\"",
     "architecture": {
         "64bit": {
-            "url": "https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe",
-            "hash": "8e400e3f32cdcb746e62e0db4d3ae4cba1f927141ebc4d0d5a4006b0daee8921"
+            "url": [
+                "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/install-pep-514.reg",
+                "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/uninstall-pep-514.reg",
+                "https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe"
+            ],
+            "hash": [
+                "5d9d7a604c057e67973e1d4b3b488ae20a0e5ee5496d03b5cf091410e33e39ed",
+                "d9309423b693ed63aea6b1fbfc0c34f16842cdca22a1b3edef283b87567a53b9",
+                "8e400e3f32cdcb746e62e0db4d3ae4cba1f927141ebc4d0d5a4006b0daee8921"
+            ]
         },
         "32bit": {
-            "url": "https://www.python.org/ftp/python/3.8.2/python-3.8.2.exe",
-            "hash": "03ac5754a69c9c11c08d1f4d694c14625a4d27348ad4dd2d1253e2547819db2c"
+            "url": [
+                "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/install-pep-514.reg",
+                "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/uninstall-pep-514.reg",
+                "https://www.python.org/ftp/python/3.8.2/python-3.8.2.exe"
+            ],
+            "hash": [
+                "5d9d7a604c057e67973e1d4b3b488ae20a0e5ee5496d03b5cf091410e33e39ed",
+                "d9309423b693ed63aea6b1fbfc0c34f16842cdca22a1b3edef283b87567a53b9",
+                "03ac5754a69c9c11c08d1f4d694c14625a4d27348ad4dd2d1253e2547819db2c"
+            ]
         }
     },
+    "pre_install": [
+        "'install-pep-514.reg', 'uninstall-pep-514.reg' | ForEach-Object {",
+        "    $py_root = \"$dir\".Replace('\\', '\\\\')",
+        "    $py_version = ($version -split '\\.')[0..1] -join '.'",
+        "    $content = Get-Content \"$dir\\$_\"",
+        "    $content = $content.Replace('$py_root', $py_root)",
+        "    $content = $content.Replace('$py_version', $py_version)",
+        "    if ($global) {",
+        "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    Set-Content \"$dir\\$_\" $content -Encoding UTF8",
+        "}"
+    ],
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\_tmp\"",

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -40,7 +40,7 @@
         "    if ($global) {",
         "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
         "    }",
-        "    Set-Content \"$dir\\$_\" $content -Encoding UTF8",
+        "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
         "}"
     ],
     "installer": {

--- a/scripts/python/install-pep-514.reg
+++ b/scripts/python/install-pep-514.reg
@@ -1,0 +1,17 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Python\PythonCore]
+"DisplayName"="Official Python installed with Scoop"
+"SupportUrl"="https://www.python.org/"
+
+[HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version]
+"DisplayName"="Python $py_version"
+
+[HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version\InstallPath]
+@="$py_root"
+"ExecutablePath"="$py_root\\python.exe"
+"WindowedExecutablePath"="$py_root\\pythonw.exe"
+
+[HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version\PythonPath]
+@="$py_root\\Lib\\;$py_root\\DLLs\\"
+

--- a/scripts/python/uninstall-pep-514.reg
+++ b/scripts/python/uninstall-pep-514.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Python\PythonCore]


### PR DESCRIPTION
- Closes #128

PEP 514 specifies how python should be added to the registry so
third-party installers, binary packages depending on python (vim), and
pre-compiled binary extension packages (kivy, Pillow, PyGame) can find
python.

I think it also helps resolve python finding 32-bit vs 64-bit
executables.

Seems that python requires the "PythonCore" key. Testing with gvim:
    gvim +"py3 print(3)"
crashes with "Scoop" but works with "PythonCore". We're installing
python built by the Python Software Foundation, so it might be matching
that name somewhere inside of python.exe.

Since the manifest uses github urls, it won't work until merged into master. If you want to check it out, I made [a testing branch that points to itself](https://github.com/idbrii/scoop-bucket-main/tree/py-registry-testing-against-mine).