### PR TITLE
byenow: Add version 0.2

### DIFF
--- a/bucket/byenow.json
+++ b/bucket/byenow.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2",
+    "description": "Utility for folder removal",
+    "homepage": "https://iobureau.com/byenow/",
+    "license": "Freeware",
+    "url": "https://iobureau.com/byenow/byenow-0.2.zip",
+    "hash": "4d074bb0906d810bee954b329814fdffbab29cc1178367a0055fca8e0bdbdb7c",
+    "architecture": {
+        "32bit": {
+            "extract_dir": "32-bit"
+        },
+        "64bit": {
+            "extract_dir": "64-bit"
+        }
+    },
+    "bin": "byenow.exe",
+    "checkver": "byenow-([\\d.]+)\\.zip",
+    "autoupdate": {
+        "url": "https://iobureau.com/byenow/byenow-$version.zip"
+    }
+}


### PR DESCRIPTION
[byenow](https://iobureau.com/byenow/) is a command-line Windows utility for faster folder removal.

fixes #831 