### PR TITLE
cuda@10.2.89_441.22: Fix env variables

### DIFF
--- a/bucket/cuda.json
+++ b/bucket/cuda.json
@@ -26,7 +26,7 @@
         "libnvvp"
     ],
     "env_set": {
-        "CUDA_PATH": "."
+        "CUDA_PATH": "$dir"
     },
     "checkver": {
         "url": "https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exelocal",


### PR DESCRIPTION
env variable **CUDA_PATH** should be set to the installation path, not `.`. This fixes the problem.

![image](https://user-images.githubusercontent.com/27724471/71642444-3c0ff380-2ce6-11ea-8ff5-36acda646a7a.png)