### PR TITLE
win-acme: Update to version 2.1.5.742

### DIFF
--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -29,7 +29,7 @@
                 "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x64.trimmed.zip"
             },
             "32bit": {
-                "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x86.trimmed.zip"
+                "url": "https://github.com/win-acme/win-acme/releases/download/v$matchHead/win-acme.v$version.x86.trimmed.zip"
             }
         }
     }

--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -21,7 +21,8 @@
     "bin": "wacs.exe",
     "persist": "settings.json",
     "checkver": {
-        "github": "https://github.com/win-acme/win-acme"
+        "github": "https://github.com/win-acme/win-acme",
+        "regex": "win-acme\\.v([\\d.]+)\\.x64"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -1,16 +1,16 @@
 {
-    "homepage": "https://pkisharp.github.io/win-acme/",
-    "version": "2.1.3.671",
+    "homepage": "https://www.win-acme.com",
+    "version": "2.1.5.742",
     "description": "A Simple ACME Client",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PKISharp/win-acme/releases/download/v2.1.3.671/win-acme.v2.1.3.671.x64.trimmed.zip",
-            "hash": "72d9632a160ec0e98e8fa02b620bc0e88e61c7c82d4691c054490e903107ee43"
+            "url": "https://github.com/win-acme/win-acme/releases/download/v2.1.5/win-acme.v2.1.5.742.x64.trimmed.zip",
+            "hash": "a6c043c4707e80e2c2754134b542a80558b8f161e33054d9ebab4d94e76ad424"
         },
         "32bit": {
-            "url": "https://github.com/PKISharp/win-acme/releases/download/v2.1.3.671/win-acme.v2.1.3.671.x86.trimmed.zip",
-            "hash": "be0a43e2a5a295effa24b298fc4fd2d82e8d2e605dd36a8998008eaba8bd4ab6"
+            "url": "https://github.com/win-acme/win-acme/releases/download/v2.1.5/win-acme.v2.1.5.742.x86.trimmed.zip",
+            "hash": "f9fb2026c729093666cf767ef467173d289a9ead0272e795c050ec017ae9e8ed"
         }
     },
     "pre_install": [
@@ -21,15 +21,15 @@
     "bin": "wacs.exe",
     "persist": "settings.json",
     "checkver": {
-        "github": "https://github.com/PKISharp/win-acme"
+        "github": "https://github.com/win-acme/win-acme"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/PKISharp/win-acme/releases/download/v$version/win-acme.v$version.x64.trimmed.zip"
+                "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x64.trimmed.zip"
             },
             "32bit": {
-                "url": "https://github.com/PKISharp/win-acme/releases/download/v$version/win-acme.v$version.x86.trimmed.zip"
+                "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x86.trimmed.zip"
             }
         }
     }

--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -27,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x64.trimmed.zip"
+                "url": "https://github.com/win-acme/win-acme/releases/download/v$matchHead/win-acme.v$version.x64.trimmed.zip"
             },
             "32bit": {
                 "url": "https://github.com/win-acme/win-acme/releases/download/v$matchHead/win-acme.v$version.x86.trimmed.zip"


### PR DESCRIPTION
#150 

Updated version, github page moved, and new website.

https://github.com/win-acme/win-acme/releases/tag/v2.1.5
> * For those who hadn't noticed yet, we have moved to our own Github organisation and our own domain name https://win-acme.com/

There may be a problem with the autoupdate URLs though. As you can see this release is v2.1.5 but still includes the build number `...download/v2.1.5/win-acme.v2.1.5.742.x...` which doesn't match the pattern, and most likely won't in the future either.