### PR TITLE
sass: Add dart-sass shim

### DIFF
--- a/bucket/sass.json
+++ b/bucket/sass.json
@@ -1,6 +1,6 @@
 {
-    "homepage": "https://github.com/sass/dart-sass",
-    "description": "The reference implementation of Sass, written in Dart.",
+    "homepage": "https://sass-lang.com/dart-sass",
+    "description": "The primary implementation of Sass, written in Dart.",
     "version": "1.26.3",
     "license": "MIT",
     "architecture": {
@@ -15,18 +15,14 @@
     },
     "extract_dir": "dart-sass",
     "bin": [
-        [
-            "sass.bat",
-            "sass"
-        ],
+        "sass.bat",
         [
             "sass.bat",
             "dart-sass"
         ]
     ],
     "checkver": {
-        "url": "https://github.com/sass/dart-sass/releases/latest",
-        "re": "/releases/tag/(?:v)?([\\d\\w.-]+)"
+        "github": "https://github.com/sass/dart-sass"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/sass.json
+++ b/bucket/sass.json
@@ -18,6 +18,10 @@
         [
             "sass.bat",
             "sass"
+        ],
+        [
+            "sass.bat",
+            "dart-sass"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
There is an official alias `dart-sass` alias for the sass package I added to the manifest for compatibility reasons. 

Check https://github.com/sass/dart-sass/blob/master/pubspec.yaml
```yaml
executables:
  dart-sass: sass
  sass: sass
```