### PR TITLE
shellcheck: Use github releases

### DIFF
--- a/bucket/shellcheck.json
+++ b/bucket/shellcheck.json
@@ -3,16 +3,14 @@
     "version": "0.7.0",
     "description": "Static analysis tool for shell scripts",
     "license": "GPL-3.0-only",
-    "url": "https://shellcheck.storage.googleapis.com/shellcheck-v0.7.0.zip",
+    "url": "https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.zip",
     "hash": "02cfa14220c8154bb7c97909e80e74d3a7fe2cbb7d80ac32adcac7988a95e387",
     "bin": "shellcheck.exe",
     "pre_install": "Get-ChildItem \"$dir\\shellcheck-*.exe\" | Rename-Item -NewName \"$dir\\shellcheck.exe\"",
     "checkver": {
-        "url": "https://shellcheck.storage.googleapis.com/",
-        "re": "<Key>shellcheck-v([\\d.]+)\\.zip</Key>",
-        "reverse": true
+        "github": "https://github.com/koalaman/shellcheck"
     },
     "autoupdate": {
-        "url": "https://shellcheck.storage.googleapis.com/shellcheck-v$version.zip"
+        "url": "https://github.com/koalaman/shellcheck/releases/download/v$version/shellcheck-v$version.zip"
     }
 }


### PR DESCRIPTION
koalaman/shellcheck#1871
> From now on, you can download precompiled binaries from GitHub Releases where they're uploaded as assets on each release.
