### PR TITLE
pwsh: Make shortcut start in home folder

### DIFF
--- a/bucket/pwsh.json
+++ b/bucket/pwsh.json
@@ -17,7 +17,8 @@
     "shortcuts": [
         [
             "pwsh.exe",
-            "PowerShell Core"
+            "PowerShell Core",
+            "-WorkingDirectory ~"
         ]
     ],
     "checkver": "github",


### PR DESCRIPTION
Currently the start menu shortcut for PowerShell Core uses the install folder as its working directory, i.e. `~/scoop/apps/pwsh/current`. This change makes it start in the user home folder instead, as you would normally expect.