### PR TITLE
git: Add bin/bash.exe to path

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -17,6 +17,7 @@
         "cmd\\git.exe",
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
+        "bin\\bash.exe",
         "git-bash.exe",
         "usr\\bin\\ssh.exe",
         "usr\\bin\\sshd.exe",

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -18,6 +18,7 @@
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
         "usr\\bin\\tig.exe",
+        "bin\\bash.exe",
         "git-bash.exe"
     ],
     "shortcuts": [


### PR DESCRIPTION
Unlike the already existing git-bash.exe, this allows you to properly launch bash in a console without opening a new terminal window.

I think this might be a somewhat opinionated change, even though I personally find it very useful. Maybe this could alternatively be a separate preset `git-with-bash` instead?