### PR TITLE
python: Add user base scripts to path

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -43,6 +43,7 @@
         "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
         "}"
     ],
+    "post_install": "add_first_in_path (Join-Path -Path (Split-Path -Path (& $dir\\python.exe -m site --user-site) -Parent) -ChildPath Scripts) $global",
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\_tmp\"",
@@ -60,6 +61,7 @@
     },
     "uninstaller": {
         "script": [
+            "remove_from_path (Join-Path -Path (Split-Path -Path (& $dir\\python.exe -m site --user-site) -Parent) -ChildPath Scripts) $global",
             "if ($global) {",
             "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
             "    env 'PATHEXT' $true \"$pathext\"",


### PR DESCRIPTION
This PR modifies the Python app manifest to add the Python user base scripts directory to PATH. Now, when installing Python packages with `pip install --user`, any CLI scripts are immediately accessible. For example:

```powershell
PS C:\Users\burke> pip install --user virtualenv
Collecting virtualenv
...
Successfully installed ... virtualenv-20.0.13
PS C:\Users\burke> pip list -v
Package    Version Location                                                     Installer
---------- ------- ------------------------------------------------------------ ---------
...
virtualenv 20.0.13 c:\users\burke\appdata\roaming\python\python38\site-packages pip
PS C:\Users\burke> scoop which virtualenv
C:\Users\burke\AppData\Roaming\Python\Python38\Scripts\virtualenv.exe
```

Additionally, an added benefit of this change is that any Python packages installed this way persist between updates of the same major Python version.