### PR TITLE
graphql-playground: Add version 1.8.10

### DIFF
--- a/bucket/graphql-playground.json
+++ b/bucket/graphql-playground.json
@@ -1,0 +1,36 @@
+{
+    "version": "1.8.10",
+    "description": "GraphQL IDE for better development workflows (GraphQL subscriptions, interactive docs and collaboration)",
+    "homepage": "https://github.com/prisma-labs/graphql-playground",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/prisma-labs/graphql-playground/releases/download/v1.8.10/graphql-playground-electron-setup-1.8.10.exe#/dl.7z",
+            "hash": "sha512:30b6704409ef695b23458e33376cc222631d3d69e2123059250b8ad3cf29cab0252554ac0e0814bb3c9a8650c042603ad73fd84604ef9642859a6932573cf8d2",
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        }
+    },
+    "shortcuts": [
+        [
+            "GraphQL Playground.exe",
+            "GraphQL Playground"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/prisma-labs/graphql-playground/releases/download/v$version/graphql-playground-electron-setup-$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512: $base64"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
[GraphQL playground](https://github.com/prisma-labs/graphql-playground) is a GUI that permit to query graphql endpoint