### PR TITLE
hostctl: Add version 0.5.3

### DIFF
--- a/bucket/hostctl.json
+++ b/bucket/hostctl.json
@@ -1,0 +1,26 @@
+    {
+    "version": "0.5.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/guumaster/hostctl/releases/download/v0.5.3/hostctl_0.5.3_windows_64-bit.zip",
+            "bin": [
+                "hostctl.exe"
+            ],
+            "hash": "31d9b0b262f2079661164113e6c59a2ca2d3cb4998b4e9466c3b55a0a89be6ec"
+        }
+    },
+    "homepage": "https://github.com/guumaster/hostctl",
+    "license": "MIT",
+    "description": "manage your hosts file like a pro",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/guumaster/hostctl/releases/download/$version/hostctl_$version_windows_64-bit.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/hostctl_$version_checksums.txt"
+        }
+    }
+}

--- a/bucket/hostctl.json
+++ b/bucket/hostctl.json
@@ -1,17 +1,15 @@
-    {
+{
     "version": "0.5.3",
+    "description": "Hosts file manager",
+    "homepage": "https://github.com/guumaster/hostctl",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/guumaster/hostctl/releases/download/v0.5.3/hostctl_0.5.3_windows_64-bit.zip",
-            "bin": [
-                "hostctl.exe"
-            ],
             "hash": "31d9b0b262f2079661164113e6c59a2ca2d3cb4998b4e9466c3b55a0a89be6ec"
         }
     },
-    "homepage": "https://github.com/guumaster/hostctl",
-    "license": "MIT",
-    "description": "manage your hosts file like a pro",
+    "bin": "hostctl.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/hostctl.json
+++ b/bucket/hostctl.json
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/guumaster/hostctl/releases/download/$version/hostctl_$version_windows_64-bit.zip"
+                "url": "https://github.com/guumaster/hostctl/releases/download/v$version/hostctl_$version_windows_64-bit.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
This CLI tool allows you to manage your hosts file by profiles with ease. Check [hostctl home](https://github.com/guumaster/hostctl)