### PR TITLE
gh: Update to version 0.6.3

### DIFF
--- a/bucket/gh.json
+++ b/bucket/gh.json
@@ -1,16 +1,16 @@
 {
     "version": "0.6.3",
-    "homepage": "https://cli.github.com",
     "description": "Official GitHub CLI",
+    "homepage": "https://cli.github.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/cli/cli/releases/download/v0.6.3/gh_0.6.3_windows_amd64.zip",
-            "hash": "7B3AF8C8DF4A293EA5D00FBAD7997E2CDCB517C367F09ADF84BDA28FA916036B"
+            "hash": "7b3af8c8df4a293ea5d00fbad7997e2cdcb517c367f09adf84bda28fa916036b"
         },
         "32bit": {
             "url": "https://github.com/cli/cli/releases/download/v0.6.3/gh_0.6.3_windows_386.zip",
-            "hash": "39DFD70EB42521285133B6E7E4B9CA3B1177831D00E230680402A86EC622043C"
+            "hash": "39dfd70eb42521285133b6e7e4b9ca3b1177831d00e230680402a86ec622043c"
         }
     },
     "bin": "bin\\gh.exe",

--- a/bucket/gh.json
+++ b/bucket/gh.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.6.1",
+    "version": "0.6.3",
     "homepage": "https://cli.github.com",
     "description": "Official GitHub CLI",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cli/cli/releases/download/v0.6.1/gh_0.6.1_windows_amd64.zip",
-            "hash": "80ce857ba2837128bff71648dae8e28660c1fc7d84c7530e9fe8a61e8476f320"
+            "url": "https://github.com/cli/cli/releases/download/v0.6.3/gh_0.6.3_windows_amd64.zip",
+            "hash": "7B3AF8C8DF4A293EA5D00FBAD7997E2CDCB517C367F09ADF84BDA28FA916036B"
         },
         "32bit": {
-            "url": "https://github.com/cli/cli/releases/download/v0.6.1/gh_0.6.1_windows_386.zip",
-            "hash": "ae07d29ad6f51dd4d12aeeb4aaeace48958b336200e96ea4579f8f425c1c8a34"
+            "url": "https://github.com/cli/cli/releases/download/v0.6.3/gh_0.6.3_windows_386.zip",
+            "hash": "39DFD70EB42521285133B6E7E4B9CA3B1177831D00E230680402A86EC622043C"
         }
     },
     "bin": "bin\\gh.exe",


### PR DESCRIPTION
Maybe there is a better way but I manually edited this file and downloaded the files manually and checked their hash via powershell

```ps
> get-filehash -path .\gh_0.6.3_windows_amd64.zip  -Algorithm SHA256 | format-list
```