### PR TITLE
tesseract: set new env var SCROLLVIEW_PATH

### DIFF
--- a/bucket/tesseract.json
+++ b/bucket/tesseract.json
@@ -32,7 +32,8 @@
         "wordlist2dawg.exe"
     ],
     "env_set": {
-        "TESSDATA_PREFIX": "$persist_dir\\tessdata"
+        "TESSDATA_PREFIX": "$persist_dir\\tessdata",
+        "SCROLLVIEW_PATH": "$persist_dir\\tessdata"
     },
     "persist": "tessdata",
     "post_install": [


### PR DESCRIPTION
`tesseract` requires env var `SCROLLVIEW_PATH` to be set to call .jar files (see [here](https://tesseract-ocr.github.io/tessdoc/ViewerDebugging.html)).