### PR TITLE
gcc: Update to 9.3.0-1 using MSYS2's build

### DIFF
--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -1,18 +1,108 @@
 {
     "homepage": "https://mingw-w64.org",
-    "description": "GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, Go, and D, as well as libraries for these languages (libstdc++,...). (MingW port)",
-    "version": "8.1.0.0",
+    "description": "GNU Compiler Collection (Mingw-w64 port from MSYS2 project)",
+    "version": "9.3.0-1",
     "license": "GPL-3.0-or-later,ZPL-2.1,...",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z",
-            "hash": "sha1:5aa456654a6ce77249c27888b5d0f856fc011b9c",
-            "extract_dir": "mingw64"
+            "url": [
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.34-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5685.ef310786-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-expat-2.2.9-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-fortran-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libgfortran-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gettext-0.19.8.1-8-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gmp-6.2.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-headers-git-8.0.0.5685.ef310786-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-isl-0.22.1-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libiconv-1.16-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libwinpthread-git-8.0.0.5680.0df6b89f-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-make-4.3-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-mpc-1.1.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-mpfr-4.0.2-2-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-pkg-config-0.29.2-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-windows-default-manifest-6.4-3-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-winpthreads-git-8.0.0.5680.0df6b89f-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-7-any.pkg.tar.xz"
+            ],
+            "hash": [
+                "c2c23fc704639f0e30a6aa094130f12028fd722d5961ef29df503f241d0bd93e",
+                "280cba536d752b8127d98f32598a537753ecf810e41710342b1ffac5a911316c",
+                "04ee9cc360b1aefb3729fec475001e1d35d94979a7dea1e604ac56015216df99",
+                "1f236bdc1894e10aebc1b65dd9847aab3a36712cc2243cacd1c5effc57608ee1",
+                "aebfb0daaac1bdb223c8b2c8dfbc8df3640fee62519e50070689758fe4c9a6c5",
+                "5ff88897cd262df5bc6ac631e8fb334f71748e8c63efe82dd32b66a13b9dc5af",
+                "84bed78b080225ef8c7e5ac000df2b929bd1aac42bf843919a792f7197364511",
+                "0349bd137cd15ec2e3e882b1b8152ffc4bc5369999b0aa1999c6b087c34148bc",
+                "5cb1a3b31c95cfb0c9dafa93b2898479ac660e5ac931be54f7dddc8e726f98d0",
+                "9b2cb6f16fc379354570ba6409003c12f745f1d10d8f9084162c5adadc847791",
+                "202d28c4d0eeb38837afa39c157c3c1c046ae313641e1a348e1ff60787d447da",
+                "b37b013727b16a90095deb90cecdc073c5bb8dde26886448e2cbf357b29c1271",
+                "a4cb775f275e13c2114d3c4c94e77fc5985e189d8ed40f3d7cf999a9a5b5d478",
+                "7863472b0763a1a6ca70bdcc6e98df3b2016b221c9da5fe264b28d1c6e1c236c",
+                "d7c59f4e347a86e1cf1c539277fd3e43096846642b1cdf764cae1a8a4e783374",
+                "322712f92173473913b3199988301c3b32639289a4410ba31e732e54bacf3143",
+                "f69c6a4f83164db254178821009e69877855a5dfbfc6b7c5a796cb79964ddaf0",
+                "6c0ea4adcef503dc8174e9d4d70a10aee8295d620db4494f78fa512df0589dcf",
+                "0a28e994a8fb25bc2d55de41d5db893363e0b1e98f9ac1c0db07716b386b3a5c",
+                "1decf05b8ae6ab10ddc9035929014837c18dd76da825329023da835aec53cec2"
+            ],
+            "pre_install": [
+                "Move-Item -Path \"$dir\\mingw64\\*\" -Destination \"$dir\"",
+                "Remove-Item -Path \"$dir\\mingw64\", \"$dir\\.*\""
+            ]
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/dwarf/i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z",
-            "hash": "sha1:dd4f34f473e84c79b6b446adb3a5fac7919ba9cb",
-            "extract_dir": "mingw32"
+            "url": [
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-binutils-2.34-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-crt-git-8.0.0.5685.ef310786-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-expat-2.2.9-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-fortran-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-libgfortran-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-libs-9.3.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gettext-0.19.8.1-8-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gmp-6.2.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-headers-git-8.0.0.5685.ef310786-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-isl-0.22.1-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libiconv-1.16-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-8.0.0.5680.0df6b89f-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-make-4.3-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-mpc-1.1.0-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-mpfr-4.0.2-2-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-windows-default-manifest-6.4-3-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-winpthreads-git-8.0.0.5680.0df6b89f-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-7-any.pkg.tar.xz"
+            ],
+            "hash": [
+                "234396201fb4078ef8463497c04151c7826f0313dcb4b40c9b82aea3a282e819",
+                "e06d7889a222182ac745a85435544dee951ba59ac29217a65236f3e9cbebd765",
+                "37dfa72246fd2478b991c93b5cce930b872420d6785fe7605458b472472134d8",
+                "181728706f67f9ed5683e96dab903d4f9414410464cd57df109fcc1741920431",
+                "8eea145827de9961fa5da0da3a215b5dbba6ed5dbf76aec77eda0b9473f69c82",
+                "a7125f82ea9df7def887d40ddd186e92d0dd08b6b8c51afe374b0df32781de9e",
+                "d5b2b3117b3127a719a2d2aa2b142b3f440d5b3cf207705f20c78c8d96615584",
+                "c1b3f4ea1a5c71b944bd0a71d2c2f6a36c38a5762a2b193bc4facf75c33d9c7a",
+                "3bf4783aed8e705fe9be132feced44d7097180d825367bc2b46fe45c39d2b701",
+                "1ab69f7d69898e09bedfadd40027eae7ec4723c19a2dffcf6b6a82be9d7f3288",
+                "7e6f75306aec44e3351aa1ae0adb9eed892d99dd552d564a903e9200474a0599",
+                "bbd79d5059f116e8f4b8dd26ca661f384eee1082b265389dbfa364d316eea334",
+                "a550b3412f88fe3e00e5b982a45aa850f728619dcd7095442106418544374066",
+                "49a9bd81fe265fd969618f9ffee9926a92193cc86d409cb1988f35a4dad3fe79",
+                "599a0276820e3d342d1c494c4506aaf79fbbbc2843bbec7aae5f22a1b71da284",
+                "7ba5ed9c5e535fdc619138278fff0567dad39b9251d5dc5c4d708ab6f345146e",
+                "39e07e61d739ba8f066605a109a19db397be6f7ddd81e5172f49ed253fdbe49f",
+                "56323bc39c7de0ff727915c09c4aaa25b8396efc0d7eda0006d5951bb6a6b983",
+                "e69339fda92b19469d5a4e0a1d5f50af8d8a420dc66f823d653ac8b536240493",
+                "addf6c52134027407640f1cbdf4efc5b64430f3a286cb4e4c4f5dbb44ce55a42"
+            ],
+            "pre_install": [
+                "Move-Item -Path \"$dir\\mingw32\\*\" -Destination \"$dir\"",
+                "Remove-Item -Path \"$dir\\mingw32\", \"$dir\\.*\""
+            ]
         }
     },
     "bin": [
@@ -21,24 +111,5 @@
             "make"
         ]
     ],
-    "env_add_path": "bin",
-    "checkver": {
-        "url": "https://sourceforge.net/projects/mingw-w64/files/",
-        "regex": "x86_64-([\\d.]+)-release-posix-sjlj-rt_v(?<rt>\\d+)-rev(\\d+)\\.7z",
-        "replace": "${1}.${2}"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/$matchHead/threads-posix/seh/x86_64-$matchHead-release-posix-seh-rt_v$matchRt-rev$buildVersion.7z"
-            },
-            "32bit": {
-                "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/$matchHead/threads-posix/dwarf/i686-$matchHead-release-posix-dwarf-rt_v$matchRt-rev$buildVersion.7z"
-            }
-        }
-    },
-    "notes": [
-        "The 64-bit version is built with Structured Exception Handling (SEH), whereas the 32-bit version is built with DWARF.",
-        "Both 64-bit and 32-bit versions use the POSIX threading model."
-    ]
+    "env_add_path": "bin"
 }


### PR DESCRIPTION
Close #928

This needs to update manually.

Or should I move this to `versions` bucket?