### PR TITLE
kubenswin: Add version 0.1.1

### DIFF
--- a/bucket/kubenswin.json
+++ b/bucket/kubenswin.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/thomasliddledba/kubenswin",
+    "description": "Kubernetes namespace switcher.",
+    "license": "MIT",
+    "version": "0.1.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/thomasliddledba/kubenswin/releases/download/0.1.1/kubenswin.exe",
+            "hash": "sha1:bcd69dec14d471767a4d26e17e2d3e7edd511172"
+        }
+    },
+    "bin": [
+        "kubenswin.exe",
+        [
+            "kubenswin.exe",
+            "kubenswin"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/thomasliddledba/kubenswin/releases/download/$version/kubenswin.exe"
+            }
+        }
+    }
+}

--- a/bucket/kubenswin.json
+++ b/bucket/kubenswin.json
@@ -1,27 +1,13 @@
 {
-    "homepage": "https://github.com/thomasliddledba/kubenswin",
-    "description": "Kubernetes namespace switcher.",
-    "license": "MIT",
     "version": "0.1.1",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/thomasliddledba/kubenswin/releases/download/0.1.1/kubenswin.exe",
-            "hash": "sha1:bcd69dec14d471767a4d26e17e2d3e7edd511172"
-        }
-    },
-    "bin": [
-        "kubenswin.exe",
-        [
-            "kubenswin.exe",
-            "kubenswin"
-        ]
-    ],
+    "description": "Kubernetes namespace switcher",
+    "homepage": "https://github.com/thomasliddledba/kubenswin",
+    "license": "MIT",
+    "url": "https://github.com/thomasliddledba/kubenswin/releases/download/0.1.1/kubenswin.exe",
+    "hash": "c3dd6a47e32cac5c0cfbeffd0d4451eb57e6b1228f518494e0110f6026890bb6",
+    "bin": "kubenswin.exe",
     "checkver": "github",
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/thomasliddledba/kubenswin/releases/download/$version/kubenswin.exe"
-            }
-        }
+        "url": "https://github.com/thomasliddledba/kubenswin/releases/download/$version/kubenswin.exe"
     }
 }


### PR DESCRIPTION
[kubenswin](https://github.com/thomasliddledba/kubenswin) is a Windows port of `kubens`, which works alongside [kubectxwin](https://github.com/thomasliddledba/kubectxwin), which [is already in the main bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/kubectxwin.json).

I am creating this PR now that [kubenswin/#1](https://github.com/thomasliddledba/kubenswin/issues/1) has been closed. :)