### PR TITLE
git: remove gitk shortcut

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -37,10 +37,6 @@
         [
             "cmd\\git-gui.exe",
             "Git GUI"
-        ],
-        [
-            "cmd\\gitk.exe",
-            "gitk"
         ]
     ],
     "post_install": "git config --global credential.helper manager",

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -29,10 +29,6 @@
         [
             "cmd\\git-gui.exe",
             "Git GUI"
-        ],
-        [
-            "cmd\\gitk.exe",
-            "gitk"
         ]
     ],
     "post_install": "git config --global credential.helper manager",


### PR DESCRIPTION
gitk does not work from the shortcut, it runs as a cli tool. The shortcut was introduced in #546