### PR TITLE
mill: Support auto-update for in-between versions.

### DIFF
--- a/bucket/mill.json
+++ b/bucket/mill.json
@@ -10,7 +10,7 @@
         "github": "https://github.com/lihaoyi/mill"
     },
     "autoupdate": {
-        "url": "https://github.com/lihaoyi/mill/releases/download/$version/$version-assembly#/mill.bat"
+        "url": "https://github.com/lihaoyi/mill/releases/download/$matchHead/$version-assembly#/mill.bat"
     },
     "suggest": {
         "JDK": [


### PR DESCRIPTION
The current version does not support auto-updating to "in-between" versions like 0.6.2-7-f10b89. This change allows such versions to be installed as well.