### PR TITLE
cmder: Persist "bin"

### DIFF
--- a/bucket/cmder-full.json
+++ b/bucket/cmder-full.json
@@ -18,6 +18,7 @@
         ]
     ],
     "persist": [
+        "bin",
         "config",
         "vendor\\conemu-maximus5\\ConEmu.xml"
     ],

--- a/bucket/cmder.json
+++ b/bucket/cmder.json
@@ -18,6 +18,7 @@
         ]
     ],
     "persist": [
+        "bin",
         "config",
         "vendor\\conemu-maximus5\\ConEmu.xml"
     ],


### PR DESCRIPTION
Move the folder "bin" into persist.
Fix https://github.com/ScoopInstaller/Main/issues/1027.