### PR TITLE
rtools: Update to rtools40 and mod 'r', 'mro'

### DIFF
--- a/bucket/mro.json
+++ b/bucket/mro.json
@@ -19,7 +19,27 @@
                     "Remove-Item \"$dir\\bin\\x64\\Rblas.dll\", \"$dir\\bin\\x64\\Rlapack.dll\" -Force",
                     "movedir \"$dir\\Setup\\bin\\x64\" \"$dir\\bin\\x64\" | Out-Null",
                     "movedir \"$dir\\Setup\\library\" \"$dir\\library\" | Out-Null",
-                    "Remove-Item \"$dir\\_tmp\", \"$dir\\Setup\", \"$dir\\$fname\" -Force -Recurse"
+                    "Remove-Item \"$dir\\_tmp\", \"$dir\\Setup\", \"$dir\\$fname\" -Force -Recurse",
+                    "if (Test-Path (appdir 'rtools35' $global)) {",
+                    "   $renvloc = \"$dir\\etc\\Renviron.site\"",
+                    "   $rtoolsloc = versiondir 'rtools35' (current_version 'rtools35' $global) $global",
+                    "   if (Test-Path $renvloc) {",
+                    "       $renv = Get-Content $renvloc -Encoding ASCII",
+                    "   } else {",
+                    "       $renv = @()",
+                    "   }",
+                    "   if ($architecture -eq '32bit') {",
+                    "       $rtoolspath = \"$rtoolsloc\\bin;$rtoolsloc\\mingw_32\\bin\"",
+                    "   } else {",
+                    "       $rtoolspath = \"$rtoolsloc\\bin;$rtoolsloc\\mingw_64\\bin\"",
+                    "   }",
+                    "   if ($renv -cmatch 'PATH=') {",
+                    "       $renv = $renv -replace 'PATH=\"(.*)', ('PATH=\"' + $rtoolspath + ';$1')",
+                    "   } else {",
+                    "       $renv += '\r\nPATH=\"' + $rtoolspath + ';${PATH}\"'",
+                    "   }",
+                    "   $renv | Set-Content $renvloc -Encoding ASCII",
+                    "}"
                 ]
             },
             "bin": [
@@ -30,6 +50,8 @@
         }
     },
     "notes": [
+        "For source packages installation, please install 'versions/rtools35'.",
+        "",
         "You'll need to type 'r.ps1' or 'r.cmd' to run MRO, because in Powershell 'r' runs the last command. Alternatively 'rterm' can be used to start the interactive R terminal session.",
         "",
         "You can remove Powershell's 'r' command with:",

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -43,10 +43,28 @@
     "installer": {
         "script": [
             "Remove-Item \"$dir\\bin\\R,*.exe\" -Force",
-            "Copy-Item \"$dir\\bin\\R.exe\" \"$dir\\bin\\Rscript.exe\""
+            "Copy-Item \"$dir\\bin\\R.exe\" \"$dir\\bin\\Rscript.exe\"",
+            "if (Test-Path (appdir 'rtools' $global)) {",
+            "   $renvloc = \"$dir\\etc\\Renviron.site\"",
+            "   $rtoolsloc = versiondir 'rtools' (current_version 'rtools' $global) $global",
+            "   if (Test-Path $renvloc) {",
+            "       $renv = Get-Content $renvloc -Encoding ASCII",
+            "   } else {",
+            "       $renv = @()",
+            "   }",
+            "   $rtoolspath = \"$rtoolsloc\\usr\\bin\"",
+            "   if ($renv -cmatch 'PATH=') {",
+            "       $renv = $renv -replace 'PATH=\"(.*)', ('PATH=\"' + $rtoolspath + ';$1')",
+            "   } else {",
+            "       $renv += '\r\nPATH=\"' + $rtoolspath + ';${PATH}\"'",
+            "   }",
+            "   $renv | Set-Content $renvloc -Encoding ASCII",
+            "}"
         ]
     },
     "notes": [
+        "For source packages installation, please install 'rtools'.",
+        "",
         "You'll need to type 'r.ps1' or 'r.cmd' to run R, because in Powershell 'r' runs the last command. Alternatively 'rterm' can be used to start the interactive R terminal session.",
         "",
         "You can remove Powershell's 'r' command with:",

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -1,6 +1,7 @@
 {
     "homepage": "https://cloud.r-project.org/bin/windows/Rtools",
     "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
+    "license": "BSD-3-Clause",
     "version": "nightly",
     "architecture": {
         "64bit": {

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -1,40 +1,66 @@
 {
     "homepage": "https://cloud.r-project.org/bin/windows/Rtools",
     "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
-    "version": "3.5.0.4",
-    "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe",
-    "hash": "18fd63bb9c903e1f9bfce5c9a2600bd24213295760592dbc130b73a61e9d9414",
+    "version": "nightly",
+    "architecture": {
+        "64bit": {
+            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe"
+        },
+        "32bit": {
+            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools40-i686.exe"
+        }
+    },
     "innosetup": true,
     "installer": {
         "script": [
             "'r', 'mro' | ForEach-Object {",
-            "   if (Test-Path (appdir $_ $global)) {",
+            "   if ((current_version $_ $global) -match '^4') {",
             "       $renvloc = (versiondir $_ (current_version $_ $global) $global) + '\\etc\\Renviron.site'",
             "       if (Test-Path $renvloc) {",
             "           $renv = Get-Content $renvloc -Encoding ASCII",
             "       } else {",
             "           $renv = @()",
             "       }",
-            "       if ($architecture -eq '32bit') {",
-            "           $rtoolspath = \"$dir\\bin;$dir\\mingw_32\\bin\"",
-            "       } else {",
-            "           $rtoolspath = \"$dir\\bin;$dir\\mingw_64\\bin\"",
-            "       }",
+            "       $rtoolspath = \"$dir\\usr\\bin\"",
             "       if ($renv -cmatch 'PATH=') {",
-            "           $renv = $renv -replace 'PATH=\"(.*)', 'PATH=\"$rtoolspath;$1'",
+            "           $renv = $renv -replace 'PATH=\"(.*)', ('PATH=\"' + $rtoolspath + ';$1')",
             "       } else {",
             "           $renv += '\r\nPATH=\"' + $rtoolspath + ';${PATH}\"'",
             "       }",
             "       $renv | Set-Content $renvloc -Encoding ASCII",
             "   }",
+            "}",
+            "if (Test-Path 'C:\\rtools40') {",
+            "   if ($null -eq (Get-Item 'C:\\rtools40').LinkType) {",
+            "       Rename-Item -Path 'C:\\rtools40' -NewName 'rtools40.old' -Force",
+            "   } else {",
+            "       Remove-Item -Path 'C:\\rtools40' -Force",
+            "   }",
+            "}",
+            "New-Item -Path 'C:\\rtools40' -Target \"$dir\" -ItemType Junction | Out-Null"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "'r', 'mro' | ForEach-Object {",
+            "   if ((current_version $_ $global) -match '^4') {",
+            "       $renvloc = (versiondir $_ (current_version $_ $global) $global) + '\\etc\\Renviron.site'",
+            "       if (Test-Path $renvloc) {",
+            "           $renv = Get-Content $renvloc -Encoding ASCII",
+            "       } else {",
+            "           $renv = @()",
+            "       }",
+            "       $renv = $renv -replace '[^;\"]*rtools.*?;', ''",
+            "       $renv | Set-Content $renvloc -Encoding ASCII",
+            "   }",
+            "}",
+            "if ((Test-Path 'C:\\rtools40') -and ($null -ne (Get-Item 'C:\\rtools40').LinkType)) {",
+            "   Remove-Item -Path 'C:\\rtools40' -Force",
+            "}",
+            "if (Test-Path 'C:\\rtools40.old') {",
+            "   Rename-Item -Path 'C:\\rtools40.old' -NewName 'rtools40' -Force",
             "}"
         ]
     },
-    "checkver": {
-        "url": "https://cloud.r-project.org/bin/windows/Rtools/VERSION.txt",
-        "regex": "([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "https://cloud.r-project.org/bin/windows/Rtools/Rtools$majorVersion$minorVersion.exe"
-    }
+    "notes": "For R 3.3.x to 3.6.x, please use 'versions/rtools35'."
 }

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -2,13 +2,15 @@
     "homepage": "https://cloud.r-project.org/bin/windows/Rtools",
     "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
     "license": "BSD-3-Clause",
-    "version": "nightly",
+    "version": "4.0.0",
     "architecture": {
         "64bit": {
-            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe"
+            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools40-x86_64.exe",
+            "hash": "5c10d60e73dd0186e8f886ef0b9388bb7dbdfdc17366c14c16183edb08fdb58a"
         },
         "32bit": {
-            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools40-i686.exe"
+            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools40-i686.exe",
+            "hash": "d51ea2561fbb07025ba1d2a25aba4ab1ad0143259f0ca2d7c8935cad080f866a"
         }
     },
     "innosetup": true,
@@ -62,6 +64,20 @@
             "   Rename-Item -Path 'C:\\rtools40.old' -NewName 'rtools40' -Force",
             "}"
         ]
+    },
+    "checkver": {
+        "url": "https://cloud.r-project.org/bin/windows/Rtools/VERSION.txt",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools$majorVersion$minorVersion-x86_64.exe"
+            },
+            "32bit": {
+                "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools$majorVersion$minorVersion-i686.exe"
+            }
+        }
     },
     "notes": "For R 3.3.x to 3.6.x, please use 'versions/rtools35'."
 }


### PR DESCRIPTION
- Closes #1003 
- Closes #1013
- Closes #1024

The version number could not be found now so be set to 'nightly' temporarily.

Rtools 3.x has been moved to 'versions/rtools35' (https://github.com/ScoopInstaller/Versions/pull/203), just for 'mro'.