### PR TITLE
cdrtools: Fix installation

### DIFF
--- a/bucket/cdrtools.json
+++ b/bucket/cdrtools.json
@@ -8,14 +8,7 @@
     },
     "url": "https://downloads.sourceforge.net/project/tumagcc/schily-cdrtools-3.02a09.7z",
     "hash": "sha1:f1b6a74e8963a97acd66e166064ab4f907e5237a",
-    "architecture": {
-        "32bit": {
-            "extract_dir": "win32"
-        },
-        "64bit": {
-            "extract_dir": "win64"
-        }
-    },
+    "extract_dir": "win32",
     "bin": [
         "btcflash.exe",
         "cdda2wav.exe",


### PR DESCRIPTION
cdrtools (at least schily-cdrtools-3.02a09.7z) only contains a win32 dir,
so don't specify architecture

closes https://github.com/lukesampson/scoop/issues/3856