### PR TITLE
stack: Update to version 2.3.1

### DIFF
--- a/bucket/stack.json
+++ b/bucket/stack.json
@@ -1,16 +1,12 @@
 {
+    "version": "2.3.1",
+    "description": "The Haskell Tool Stack",
     "homepage": "https://www.haskellstack.org",
     "license": "BSD-3-Clause",
-    "version": "2.1.3",
-    "description": "The Haskell Tool Stack",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-windows-x86_64.zip",
-            "hash": "415fb140c7497c4771b84e45a38b65ad47f50b9adc06499b03c4f5a8899aa32a"
-        },
-        "32bit": {
-            "url": "https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-windows-i386.zip",
-            "hash": "d764104ea162f12d10a5392f49587efa8f360ce179324d7e0253c74edd6f937a"
+            "url": "https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-windows-x86_64.zip",
+            "hash": "4790975b189d2a511e2e9fa6416d9d2d869763f7ae93e522afac7c2edae279c2"
         }
     },
     "bin": "stack.exe",
@@ -27,9 +23,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/commercialhaskell/stack/releases/download/v$version/stack-$version-windows-x86_64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/commercialhaskell/stack/releases/download/v$version/stack-$version-windows-i386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
#150

https://github.com/commercialhaskell/stack/releases/tag/v2.3.1

> We have reduced the number of platforms that we support with binary releases.
The reason behind this is that we've been slowed down in our release process
until now with issues trying to build binaries for less common platforms. In
order to make sure we can address issues more quickly (like supporting new
GHC versions), we're limiting support from the Stack team to:

>Linux 64-bit (static)
>macOS
>Windows 64-bit