### PR TITLE
minio: Use archive URL

### DIFF
--- a/bucket/minio-client.json
+++ b/bucket/minio-client.json
@@ -2,12 +2,12 @@
     "homepage": "https://min.io/",
     "description": "A high performance, distributed object storage server, designed for large-scale data infrastructure. (client)",
     "license": "Apache-2.0",
-    "version": "2020-04-25T00-43-23Z",
+    "version": "2020-05-05T06-03-47Z",
     "bin": "mc.exe",
     "architecture": {
         "64bit": {
-            "url": "https://dl.min.io/client/mc/release/windows-amd64/mc.RELEASE.2020-04-25T00-43-23Z#/mc.exe",
-            "hash": "ea2a58f9fe69305b12ccc231916cf68c5295b24dc7ee7fc082fb30e28f6af84b"
+            "url": "https://dl.min.io/client/mc/release/windows-amd64/archive/mc.RELEASE.2020-05-05T06-03-47Z#/mc.exe",
+            "hash": "d681890686a9319f84db3faf57a957c119d762bf1890a1137bc53627844e33c6"
         }
     },
     "suggest": {
@@ -20,9 +20,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.min.io/client/mc/release/windows-amd64/mc.RELEASE.$version#/mc.exe",
+                "url": "https://dl.min.io/client/mc/release/windows-amd64/archive/mc.RELEASE.$version#/mc.exe",
                 "hash": {
-                    "url": "$baseurl/mc.exe.sha256sum"
+                    "url": "$url.sha256sum"
                 }
             }
         }

--- a/bucket/minio.json
+++ b/bucket/minio.json
@@ -6,7 +6,7 @@
     "bin": "minio.exe",
     "architecture": {
         "64bit": {
-            "url": "https://dl.min.io/server/minio/release/windows-amd64/minio.RELEASE.2020-05-01T22-19-14Z#/minio.exe",
+            "url": "https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2020-05-01T22-19-14Z#/minio.exe",
             "hash": "d2de21816bc2620c5e7766b2eda7ca620141307359c0a9161137034fae4d42b9"
         }
     },
@@ -20,9 +20,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.min.io/server/minio/release/windows-amd64/minio.RELEASE.$version#/minio.exe",
+                "url": "https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.$version#/minio.exe",
                 "hash": {
-                    "url": "$baseurl/minio.RELEASE.$version.sha256sum"
+                    "url": "$url.sha256sum"
                 }
             }
         }


### PR DESCRIPTION
I updated the url accordingly to the min.io servers.

I also updated minio-client to the latest version while I was on it.

Cheers