### PR TITLE
unison: Add fsmonitor shim

### DIFF
--- a/bucket/unison.json
+++ b/bucket/unison.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/bcpierce00/unison/releases/download/v2.51.2/unison-windows-2.51.2-text.zip",
     "hash": "9c1e1fca202dd1e7f55b82c1abf632ee546424253284a062839e7a7212a180bf",
     "extract_dir": "unison-windows-2.51.2-text",
-    "bin": "unison.exe",
+    "bin": ["unison.exe", "unison-fsmonitor.exe"],
     "checkver": {
         "github": "https://github.com/bcpierce00/unison"
     },

--- a/bucket/unison.json
+++ b/bucket/unison.json
@@ -6,7 +6,10 @@
     "url": "https://github.com/bcpierce00/unison/releases/download/v2.51.2/unison-windows-2.51.2-text.zip",
     "hash": "9c1e1fca202dd1e7f55b82c1abf632ee546424253284a062839e7a7212a180bf",
     "extract_dir": "unison-windows-2.51.2-text",
-    "bin": ["unison.exe", "unison-fsmonitor.exe"],
+    "bin": [
+        "unison.exe",
+        "unison-fsmonitor.exe"
+    ],
     "checkver": {
         "github": "https://github.com/bcpierce00/unison"
     },


### PR DESCRIPTION
Fsmonitor is part of package and is used for auto-updating based on disk changes. I can also prepare separate json for fsmonitor only, if cache caches zip from github, it won't re-download same package.