### PR TITLE
grpcurl: Add version 1.6.0

### DIFF
--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -1,22 +1,22 @@
 {
+    "version": "1.6.0",
+    "description": "cURL like utility for gRPC",
     "homepage": "https://github.com/fullstorydev/grpcurl",
-    "description": "Command-line tool for interacting with gRPC servers",
     "license": "MIT",
-    "version": "1.5.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.5.0/grpcurl_1.5.0_windows_x86_64.zip",
-            "hash": "6561fe6eaf1f03806121093468a52c88faf59b496068d399c12a5a6ba124d782"
+            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.6.0/grpcurl_1.6.0_windows_x86_64.zip",
+            "hash": "6f418bb8bd7b57d4116925d894782142863617e35c46dca8a047983737f0301d"
         },
         "32bit": {
-            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.5.0/grpcurl_1.5.0_windows_x86_32.zip",
-            "hash": "1ddf66112882aea2c624ee48ddfcf5b94fcbc96b364fef6a19c54ce92a8bda02"
+            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.6.0/grpcurl_1.6.0_windows_x86_32.zip",
+            "hash": "d975772608dd98bc034526899320fb5bebb8e68efe377198643226ffb1f06288"
         }
     },
     "bin": "grpcurl.exe",
     "checkver": {
         "url": "https://github.com/fullstorydev/grpcurl/releases",
-        "re": "v(?<version>[\\d.]+)/grpcurl_\\k<version>.*\\.zip"
+        "regex": "grpcurl_([\\d.]+)_windows_x"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -1,0 +1,39 @@
+{
+    "homepage": "https://github.com/fullstorydev/grpcurl",
+    "description": "Command-line tool for interacting with gRPC servers",
+    "license": "MIT",
+    "version": "1.5.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.5.0/grpcurl_1.5.0_windows_x86_64.zip",
+            "hash": "6561fe6eaf1f03806121093468a52c88faf59b496068d399c12a5a6ba124d782"
+        },
+        "32bit": {
+            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.5.0/grpcurl_1.5.0_windows_x86_32.zip",
+            "hash": "1ddf66112882aea2c624ee48ddfcf5b94fcbc96b364fef6a19c54ce92a8bda02"
+        }
+    },
+    "bin": "grpcurl.exe",
+    "checkver": {
+        "url": "https://github.com/fullstorydev/grpcurl/releases",
+        "re": "v(?<version>[\\d.]+)/grpcurl_(?<short>[\\d.]+).*\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_64.zip",
+                "hash": {
+                    "url": "$baseurl/grpcurl_$version_checksums.txt",
+                    "mode": "extract"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_32.zip",
+                "hash": {
+                    "url": "$baseurl/grpcurl_$version_checksums.txt",
+                    "mode": "extract"
+                }
+            }
+        }
+    }
+}

--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -16,7 +16,7 @@
     "bin": "grpcurl.exe",
     "checkver": {
         "url": "https://github.com/fullstorydev/grpcurl/releases",
-        "re": "v(?<version>[\\d.]+)/grpcurl_(?<short>[\\d.]+).*\\.zip"
+        "re": "v(?<version>[\\d.]+)/grpcurl_\\k<version>.*\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -21,19 +21,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_64.zip",
-                "hash": {
-                    "url": "$baseurl/grpcurl_$version_checksums.txt",
-                    "mode": "extract"
-                }
+                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_32.zip",
-                "hash": {
-                    "url": "$baseurl/grpcurl_$version_checksums.txt",
-                    "mode": "extract"
-                }
+                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_32.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/grpcurl_$version_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
This PR adds grpcurl to the main bucket. This is a cURL-like command-line tool for interacting with gRPC servers.

Tool repository: https://github.com/fullstorydev/grpcurl

The grpcurl project doesn't always include the CLI tool assets for every release, which is why the more customized `checkver` logic is used instead of just `github`.

Thank you!