### PR TITLE
lessmsi: Correct shortcut name

### DIFF
--- a/bucket/lessmsi.json
+++ b/bucket/lessmsi.json
@@ -9,7 +9,7 @@
     "shortcuts": [
         [
             "lessmsi-gui.exe",
-            "Less MSIérables"
+            "Less MSI"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
"Less MSIérables" -> "Less MSI"