### PR TITLE
mockery: Add version 2.0.4

### DIFF
--- a/bucket/mockery.json
+++ b/bucket/mockery.json
@@ -1,6 +1,23 @@
 {
-  "version": "1.1.0",
-  "url": "https://github.com/vektra/mockery/releases/download/v1.1.0/mockery_1.1.0_Windows_x86_64.tar.gz",
-  "hash": "5df46b1b88b9f43d783cafe16d1cb49c753c4da17d43f482023b97e3abeb56ef",
-  "bin": "mockery.exe"
+    "version": "2.0.4",
+    "description": "A mock code autogenerator for Golang",
+    "homepage": "https://github.com/vektra/mockery",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/vektra/mockery/releases/download/v2.0.4/mockery_2.0.4_Windows_x86_64.tar.gz",
+            "hash": "719a931fb443381734aa445df77b86fdca7c6837e0802ef0ffa4b31470f7a2a0"
+        }
+    },
+    "bin": "mockery.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/vektra/mockery/releases/download/v$version/mockery_$version_Windows_x86_64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksum.txt"
+        }
+    }
 }

--- a/bucket/mockery.json
+++ b/bucket/mockery.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.1.0",
+  "url": "https://github.com/vektra/mockery/releases/download/v1.1.0/mockery_1.1.0_Windows_x86_64.tar.gz",
+  "hash": "5df46b1b88b9f43d783cafe16d1cb49c753c4da17d43f482023b97e3abeb56ef",
+  "bin": "mockery.exe"
+}

--- a/bucket/mockery.json
+++ b/bucket/mockery.json
@@ -2,6 +2,7 @@
     "version": "2.0.4",
     "description": "A mock code autogenerator for Golang",
     "homepage": "https://github.com/vektra/mockery",
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
             "url": "https://github.com/vektra/mockery/releases/download/v2.0.4/mockery_2.0.4_Windows_x86_64.tar.gz",


### PR DESCRIPTION
[vektra/mockery](https://github.com/vektra/mockery) is a tool for generating mocks of Go interfaces.

Rationale for including in the main bucket:
* a reasonably well-known and widely used developer tool: I believe so. It is one of the two most well known mock generators for Go. Here is a [relatively recent comparison](https://blog.codecentric.de/2019/07/gomock-vs-testify/) which should prove the prominence of this tool.
* the latest stable version of the program: Yes. You can check the [releases](https://github.com/vektra/mockery/releases) page.
* the full version i.e. not a trial version: The program is open source.
* a fairly standard install (e.g. uses a version-specific download URL, no elaborate pre/post install scripts): It is distributed as a single tarball containing a single executable file, `mockery.exe`
* a non-GUI tool: It is command line only.