### PR TITLE
ffsend: Remove OpenSSL dependency

### DIFF
--- a/bucket/ffsend.json
+++ b/bucket/ffsend.json
@@ -9,7 +9,6 @@
             "hash": "42b5ce4c29e5f1376fc46d4d45c29b13adfa48db2445effe0a2ea53939f72517"
         }
     },
-    "depends": "openssl",
     "bin": "ffsend.exe",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
The `openssl` dependency is not needed anymore.