### PR TITLE
fix: WixToolPath not added to env Variables

### DIFF
--- a/bucket/wixtoolset.json
+++ b/bucket/wixtoolset.json
@@ -5,6 +5,9 @@
     "version": "3.11.2",
     "url": "https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip",
     "hash": "2c1888d5d1dba377fc7fa14444cf556963747ff9a0a289a3599cf09da03b9e2e",
+    "env_set": {
+        "WixToolPath": "$dir"
+    },
     "bin": [
         "candle.exe",
         "dark.exe",


### PR DESCRIPTION
environment variable for WixToolPath added