### PR TITLE
less: new upstream, version 561

### DIFF
--- a/bucket/less.json
+++ b/bucket/less.json
@@ -9,7 +9,7 @@
     ],
     "checkver": "github",
 
-    "hash": "a1d778f5f82a2399b0df279b3c182becae5f5474ff6f507f61e78af1dd41a7cd",
+    "hash": [ "a1d778f5f82a2399b0df279b3c182becae5f5474ff6f507f61e78af1dd41a7cd", "25224f351d5c7bebadad62fde950ec851e0df3adba7ba5e3c075ba3caa53634c"],
     "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/lesskey.exe" ],
     "autoupdate": {
         "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v$version/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v$version/lesskey.exe" ],

--- a/bucket/less.json
+++ b/bucket/less.json
@@ -1,22 +1,18 @@
 {
     "homepage": "http://www.greenwoodsoftware.com/less/",
     "description": "A terminal pager program used to view (but not change) the contents of a text file one screen at a time, similar to the 'more' command.",
-    "version": "551",
+    "version": "561.1",
     "license": "GPL-3.0-only|BSD-3-Clause",
     "bin": [
         "less.exe",
         "lesskey.exe"
     ],
-    "checkver": {
-        "url": "https://www.guysalias.tk/misc/less/",
-        "re": "less-([\\d]+)-"
-    },
-    "extract_dir": "less-551-win32-static-x86",
-    "hash": "8ec4eb52b6f8cedf48d18491fd161ea9039ba40fdbd8fb466aa978c55cf5a372",
-    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/less/less-551-win32-static-x86.7z",
+    "checkver": "github",
+
+    "hash": "a1d778f5f82a2399b0df279b3c182becae5f5474ff6f507f61e78af1dd41a7cd",
+    "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/lesskey.exe" ],
     "autoupdate": {
-        "extract_dir": "less-$version-win32-static-x86",
-        "url": "https://www.guysalias.tk/misc/less/less-$version-win32-static-x86.7z",
+        "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v$version/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v$version/lesskey.exe" ],
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/less.json
+++ b/bucket/less.json
@@ -12,7 +12,7 @@
     "hash": [ "a1d778f5f82a2399b0df279b3c182becae5f5474ff6f507f61e78af1dd41a7cd", "25224f351d5c7bebadad62fde950ec851e0df3adba7ba5e3c075ba3caa53634c"],
     "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/lesskey.exe" ],
     "autoupdate": {
-        "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v$version/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v$version/lesskey.exe" ],
+        "url": "https://github.com/jftuga/less-Windows/releases/download/less-v$version/less.exe",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
It appears as though the upstream source for this package is dead: `www.guysalias.tk` (parked domain?).  It also points to an older version of `less`.

I have created this repo to address this problem:

https://github.com/jftuga/less-Windows/

I am using `AppVeyor` for automatic nightly builds of `less`.  The `version_compare.py` script will run once per day.  It compares the version this repo is hosting against the [official less version](http://greenwoodsoftware.com/less/download.html).  If there is a new version, then `build.py` will download, compile, and create a new GitHub release containing `less.exe` and `lesskey.exe`.  If the versions are the same, then nothing will be updated.

I am currently tracking the `BETA` instead of the `RECOMMENDED` version as `v561` fixes a bug in which searches (with `/` key) were not being properly highlighted.  Once this version (or a newer one) becomes `RECOMMENDED`, I will switch over to `RECOMMENDED` instead of `BETA`.

The `.1` at the end of the version is used by `AppVeyor`.  It needs a way to internally increment each build attempt.  I don't think there is a way around this.

As this is my first time contributing to `scoop`, please review my `json` file.  I have tested locally and it seems to run OK.  I do not have enough experience to know if the `autoupdate` is correct.  Actually, I just noticed that `v562` has been released by my [upstream source](http://greenwoodsoftware.com/less/) within the last day.  Will be a good way for the `autoupdate` feature to be tested?

FWIW, this version of less is [now used](https://github.com/jftuga/less-Windows/issues/1#issuecomment-630420170) by `Chocolatey` and has also been [requested](https://github.com/sharkdp/bat/issues/860#issuecomment-626978119) for use in `scoop`.
