### PR TITLE
Added kubenswin

### DIFF
--- a/bucket/kubenswin.json
+++ b/bucket/kubenswin.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/thomasliddledba/kubenswin",
+    "description": "Kubernetes namespace switcher.",
+    "license": "MIT",
+    "version": "0.1.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/thomasliddledba/kubenswin/releases/download/0.1.1/kubenswin.exe",
+            "hash": "sha1:bcd69dec14d471767a4d26e17e2d3e7edd511172"
+        }
+    },
+    "bin": ["kubenswin.exe", ["kubenswin.exe", "kubens"]],
+    "checkver": "github",
+    "depends": ["kubectxwin"],
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/thomasliddledba/kubenswin/releases/download/$version/kubenswin.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added kubenswin (kubens) app — same author as kubectxwin, but allows people to change namespaces instead of Kubernetes contexts. I copied manifest from kubectxwin, works on my machine (installed from the local bucket).