### PR TITLE
kubectx: Add version 0.9.0

### DIFF
--- a/bucket/kubectx.json
+++ b/bucket/kubectx.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://kubectx.dev",
+    "description": "Utility to manage and switch between kubectl contexts.",
+    "license": "Apache-2.0",
+    "version": "0.9.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ahmetb/kubectx/releases/download/v0.9.0/kubectx_v0.9.0_windows_x86_64.zip",
+            "hash": "8c567d750ec77e71f6f9a7b818bf06dd45f9c90d9d44d763084a0054a024e560"
+        }
+    },
+    "bin": "kubectx.exe",
+    "checkver": {
+        "github": "https://github.com/ahmetb/kubectx"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ahmetb/kubectx/releases/download/v$version/kubectx_v$version_windows_x86_64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}

--- a/bucket/kubectx.json
+++ b/bucket/kubectx.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "https://kubectx.dev",
-    "description": "Utility to manage and switch between kubectl contexts.",
-    "license": "Apache-2.0",
     "version": "0.9.0",
+    "description": "Kubernetes contexts manager",
+    "homepage": "https://kubectx.dev",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ahmetb/kubectx/releases/download/v0.9.0/kubectx_v0.9.0_windows_x86_64.zip",

--- a/bucket/kubectxwin.json
+++ b/bucket/kubectxwin.json
@@ -1,8 +1,9 @@
 {
-    "homepage": "https://github.com/thomasliddledba/kubectxwin",
-    "description": "Kubernetes cluster switcher.",
-    "license": "MIT",
     "version": "0.1.1",
+    "description": "Kubernetes clusters switcher",
+    "homepage": "https://github.com/thomasliddledba/kubectxwin",
+    "license": "MIT",
+    "notes": "Deprecated. It is recommended to use 'kubectx' instead",
     "architecture": {
         "64bit": {
             "url": "https://github.com/thomasliddledba/kubectxwin/releases/download/0.1.1/kubectxwin.exe",
@@ -15,13 +16,5 @@
             "kubectxwin.exe",
             "kubectx"
         ]
-    ],
-    "checkver": "github",
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/thomasliddledba/kubectxwin/releases/download/$version/kubectxwin.exe"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
https://github.com/ahmetb/kubectx
kubectx is a utility to manage and switch between kubectl(1) contexts.

Ref: https://github.com/ScoopInstaller/Main/pull/995#issuecomment-635066207