### PR TITLE
pandoc-crossref: Update to version 0.3.6.3

### DIFF
--- a/bucket/pandoc-crossref.json
+++ b/bucket/pandoc-crossref.json
@@ -1,23 +1,23 @@
 {
     "homepage": "https://hackage.haskell.org/package/pandoc-crossref",
-    "version": "0.3.6.2",
+    "version": "0.3.6.3",
     "license": "GPL-2.0-or-later",
     "description": "Pandoc filter for cross-references.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.6.2/windows-x86_64-pandoc_2.9.2.zip",
-            "hash": "75ac5da714fae4b41aef5c4767f7a6dcec5373ad7928483738044150f41226de"
+            "url": "https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.6.3/pandoc-crossref-Windows-2.9.2.1.7z",
+            "hash": "AEE00B0EB376032C8B09ECF5384E194F61B078EB4840281EAD34BAA8D1206FEB"
         }
     },
     "bin": "pandoc-crossref.exe",
     "checkver": {
         "url": "https://github.com/lierdakil/pandoc-crossref/releases/",
-        "re": "download/v(?<version>[\\w.]+)/windows-x86_64-pandoc_(?<pandoc>[\\d.]+).zip"
+        "re": "download/v(?<version>[\\w.]+)/pandoc-crossref-Windows-(?<pandoc>[\\d.]+).7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lierdakil/pandoc-crossref/releases/download/v$version/windows-x86_64-pandoc_$matchPandoc.zip"
+                "url": "https://github.com/lierdakil/pandoc-crossref/releases/download/v$version/pandoc-crossref-Windows-$matchPandoc.zip"
             }
         }
     },


### PR DESCRIPTION
This version fixed compatability with pandoc 2.9.2.1