### PR TITLE
vswhere: Add version 2.8.4

### DIFF
--- a/bucket/vswhere.json
+++ b/bucket/vswhere.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.8.4",
+    "description": "Locate Visual Studio 2017 and newer installations",
+    "homepage": "https://github.com/microsoft/vswhere",
+    "license": "MIT",
+    "url": "https://www.nuget.org/api/v2/package/vswhere/2.8.4#/vswhere.zip",
+    "hash": "sha512:2eb59e2047776dfdb8c415fda97cd05d9a92facc8506d162f0c049c5513bf783f96e31826911b044a969a346da260480b39862eebf2ba087c6e4253881e91693",
+    "extract_dir": "tools",
+    "bin": "vswhere.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://www.nuget.org/api/v2/package/vswhere/$version#/vswhere.zip",
+        "hash": {
+            "url": "https://www.nuget.org/api/v2/Packages(Id='vswhere',Version='$version')",
+            "regex": "<d:PackageHash>$base64</d:PackageHash>"
+        }
+    }
+}


### PR DESCRIPTION
vswhere is a tool commonly with over 6M tracked downloads used in both on-prem and cloud pipelines like Azure DevOps, Visual Studio-related GitHub Actions, boost build pipelines, and more. It is used to locate a suitable Visual Studio 2017 or newer install with required features, and find toolsets within it or set up PATH. It's already in chocolatey but some users have asked for scoop support.

Fixes microsoft/vswhere#122