### PR TITLE
pandoc-crossref@0.3.6.3: Fix installation

### DIFF
--- a/bucket/pandoc-crossref.json
+++ b/bucket/pandoc-crossref.json
@@ -9,6 +9,7 @@
             "hash": "AEE00B0EB376032C8B09ECF5384E194F61B078EB4840281EAD34BAA8D1206FEB"
         }
     },
+    "extract_dir": "windows-build",
     "bin": "pandoc-crossref.exe",
     "checkver": {
         "url": "https://github.com/lierdakil/pandoc-crossref/releases/",


### PR DESCRIPTION
Updating to pandoc-crossref 0.3.6.3 (see scoop's installation log below): This commit should fix the path to the binary from `pandoc-crossref.exe` to `windows-build/pandoc-crossref.exe`. 

NOTE: The change is untested.

~~~
pandoc-crossref: 0.3.6.2 -> 0.3.6.3
Updating one outdated app:
Updating 'pandoc-crossref' (0.3.6.2 -> 0.3.6.3)
Downloading new version
pandoc-crossref-Windows-2.9.2.1.7z (9,4 MB) [==========================================================================================================================] 100%
Checking hash of pandoc-crossref-Windows-2.9.2.1.7z ... ok.
Uninstalling 'pandoc-crossref' (0.3.6.2)
Removing shim for 'pandoc-crossref'.
Unlinking ~\scoop\apps\pandoc-crossref\current
Installing 'pandoc-crossref' (0.3.6.3) [64bit]
Loading pandoc-crossref-Windows-2.9.2.1.7z from cache
Extracting pandoc-crossref-Windows-2.9.2.1.7z ... done.
Linking ~\scoop\apps\pandoc-crossref\current => ~\scoop\apps\pandoc-crossref\0.3.6.3
Creating shim for 'pandoc-crossref'.
Can't shim 'pandoc-crossref.exe': File doesn't exist.
~~~