### PR TITLE
gum: Add version 0.4.0

### DIFF
--- a/bucket/gum.json
+++ b/bucket/gum.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://github.com/kordamp/gm",
     "description": "Gum is a Gradle/Maven wrapper",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "license": "Apache-2.0",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/kordamp/gm/releases/download/v0.3.0/gm_Windows_i386.zip",
-            "hash": "sha512:1af52673cf1217d286ee3e392592829df1416c981198b5a4b58026684a24d488052da6425818243fef305126b04460aed60d800da9f1ac03c08baeaaa2a32372"
+            "url": "https://github.com/kordamp/gm/releases/download/v0.4.0/gm_Windows_i386.zip",
+            "hash": "sha512:ffa52b1c3dd54c1c2f9f6451164b99cc1d7d21db1d0475f390f3937bfa1590b23f0bbdce0bfd085f1f005ae550478582700933a6ab466f0d29315004be7d137d"
         },
         "64bit": {
-            "url": "https://github.com/kordamp/gm/releases/download/v0.3.0/gm_Windows_x86_64.zip",
-            "hash": "sha512:f33d6983695d966790aa8ac448c8612cd71d485151bd926bfcfde0f3a6e2ebf5bf1643e6d1242d93cb1f407f1debc4fea566acb0c92b7364891d8f02f232a3e4"
+            "url": "https://github.com/kordamp/gm/releases/download/v0.4.0/gm_Windows_x86_64.zip",
+            "hash": "sha512:9ffbdd4f3b54be8453f25b92061e67bb714f321fa6f26733c0488b9e568aac471b418d2b0785962809379d06e6ce53d660e59fb032abaaf911c6d80d42dc4662"
         }
     },
     "bin": [

--- a/bucket/gum.json
+++ b/bucket/gum.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://github.com/kordamp/gm",
+    "description": "Gum is a Gradle/Maven wrapper",
+    "version": "0.3.0",
+    "license": "Apache-2.0",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/kordamp/gm/releases/download/v0.3.0/gm_Windows_i386.zip",
+            "hash": "sha512:1af52673cf1217d286ee3e392592829df1416c981198b5a4b58026684a24d488052da6425818243fef305126b04460aed60d800da9f1ac03c08baeaaa2a32372"
+        },
+        "64bit": {
+            "url": "https://github.com/kordamp/gm/releases/download/v0.3.0/gm_Windows_x86_64.zip",
+            "hash": "sha512:f33d6983695d966790aa8ac448c8612cd71d485151bd926bfcfde0f3a6e2ebf5bf1643e6d1242d93cb1f407f1debc4fea566acb0c92b7364891d8f02f232a3e4"
+        }
+    },
+    "bin": [
+        [
+            "gm.exe",
+            "gum"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/kordamp/gm/releases/download/v$version/gm_Windows_i386.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/kordamp/gm/releases/download/v$version/gm_Windows_x86_64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Gum is a Gradle/Maven wrapper written in Go

Gum automatically detects if the project is Gradle or Maven-based and runs the appropriate command. However, in the case that Gum guesses wrong, you can force a specific build tool to be used.

Shim `gum` is defined because `gm` is not resolved as `gm.exe` but as Powershell commandlet `Get-Members` which is unfortunate.