### PR TITLE
imagemagick: www subdomain does no longer exist.

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -5,11 +5,11 @@
     "version": "7.0.10-18",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.10-18-portable-Q16-x64.zip",
+            "url": "https://imagemagick.org/download/binaries/ImageMagick-7.0.10-18-portable-Q16-x64.zip",
             "hash": "e1ba9afca9ae34f9ecc8b1f1a32c5631ad43ceccedd87e2046c72904638ae583"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.10-18-portable-Q16-x86.zip",
+            "url": "https://imagemagick.org/download/binaries/ImageMagick-7.0.10-18-portable-Q16-x86.zip",
             "hash": "b058e645b8bea63e2c08d3632a7f2cef21c7ab749d80c5279429e1bb2cddddb9"
         }
     },
@@ -36,15 +36,15 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x64.zip"
+                "url": "https://imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x64.zip"
             },
             "32bit": {
-                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x86.zip"
+                "url": "https://imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x86.zip"
             }
         },
         "hash": {
             "mode": "rdf",
-            "url": "https://www.imagemagick.org/download/binaries/digest.rdf"
+            "url": "https://imagemagick.org/download/binaries/digest.rdf"
         }
     }
 }


### PR DESCRIPTION
All [Windows Release Binaries](https://imagemagick.org/script/download.php#windows) download links are without `www` now.