### PR TITLE
naiveproxy: Add version 83.0.4103.61-1

### DIFF
--- a/bucket/naiveproxy.json
+++ b/bucket/naiveproxy.json
@@ -1,0 +1,36 @@
+{
+    "version": "83.0.4103.61-1",
+    "description": "A proxy using Chrome's network stack to camouflage traffic with strong censorship resistence and low detectablility",
+    "homepage": "https://github.com/klzgrad/naiveproxy",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v83.0.4103.61-1/naiveproxy-v83.0.4103.61-1-win-x64.zip",
+            "hash": "38fdf53bba76752dee2b8893b2e5b5b14202bde4ad5cace4a60c8ca8bb567a4f",
+            "extract_dir": "naiveproxy-v83.0.4103.61-1-win-x64"
+        },
+        "32bit": {
+            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v83.0.4103.61-1/naiveproxy-v83.0.4103.61-1-win-x86.zip",
+            "hash": "6f175880f9bd42e85456304d0dead66dbdb3f4e4c20493f6d59928d6ce0f1c42",
+            "extract_dir": "naiveproxy-v83.0.4103.61-1-win-x86"
+        }
+    },
+    "bin": "naive.exe",
+    "persist": "config.json",
+    "checkver": {
+        "url": "https://github.com/klzgrad/naiveproxy/releases/latest",
+        "re": "/tree/v([\\w.-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/klzgrad/naiveproxy/releases/download/v$version/naiveproxy-v$version-win-x64.zip",
+                "extract_dir": "naiveproxy-v$version-win-x64"
+            },
+            "32bit": {
+                "url": "https://github.com/klzgrad/naiveproxy/releases/download/v$version/naiveproxy-v$version-win-x86.zip",
+                "extract_dir": "naiveproxy-v$version-win-x86"
+            }
+        }
+    }
+}

--- a/bucket/naiveproxy.json
+++ b/bucket/naiveproxy.json
@@ -1,6 +1,6 @@
 {
     "version": "83.0.4103.61-1",
-    "description": "A proxy using Chrome's network stack to camouflage traffic with strong censorship resistence and low detectablility",
+    "description": "A proxy using Chrome's network stack to camouflage traffic with strong censorship resistence and low detectablility.",
     "homepage": "https://github.com/klzgrad/naiveproxy",
     "license": "BSD-3-Clause",
     "architecture": {
@@ -18,8 +18,8 @@
     "bin": "naive.exe",
     "persist": "config.json",
     "checkver": {
-        "url": "https://github.com/klzgrad/naiveproxy/releases/latest",
-        "re": "/tree/v([\\w.-]+)"
+        "github": "https://github.com/klzgrad/naiveproxy",
+        "regex": "tag/v([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
[NaïveProxy](https://github.com/klzgrad/naiveproxy) uses Chrome's network stack to camouflage traffic with strong censorship resistence and low detectablility. Reusing Chrome's stack also ensures best practices in performance and security.