### PR TITLE
elm: Change depends to nodejs-lts

### DIFF
--- a/bucket/elm.json
+++ b/bucket/elm.json
@@ -3,7 +3,7 @@
     "description": "Elm language compiler.",
     "homepage": "https://elm-lang.org",
     "license": "BSD-3-Clause",
-    "depends": "nodejs",
+    "depends": "nodejs-lts",
     "url": "https://github.com/elm/compiler/releases/download/0.19.1/installer-for-windows.exe#/dl.7z",
     "hash": "02947d00090f556abcf8f8e95997ac993825bd783abf05786afe8f60a002d496",
     "extract_dir": "bin",

--- a/bucket/elm.json
+++ b/bucket/elm.json
@@ -3,7 +3,7 @@
     "description": "Elm language compiler.",
     "homepage": "https://elm-lang.org",
     "license": "BSD-3-Clause",
-    "depends": "nodejs-lts",
+    "suggest": "nodejs-lts",
     "url": "https://github.com/elm/compiler/releases/download/0.19.1/installer-for-windows.exe#/dl.7z",
     "hash": "02947d00090f556abcf8f8e95997ac993825bd783abf05786afe8f60a002d496",
     "extract_dir": "bin",


### PR DESCRIPTION
To fix this annoying message:

Missing runtime dependencies:
    'elm' requires 'nodejs'