### PR TITLE
ipopt: Add version 3.13.2

### DIFF
--- a/bucket/ipopt.json
+++ b/bucket/ipopt.json
@@ -1,7 +1,7 @@
 {
     "version": "3.13.2",
     "description": "Software package for large-scale nonlinear optimization",
-    "homepage": "https://coin-or.github.io/Ipopt/",
+    "homepage": "https://github.com/coin-or/Ipopt",
     "license": "EPL-1.0",
     "architecture": {
         "64bit": {

--- a/bucket/ipopt.json
+++ b/bucket/ipopt.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://github.com/coin-or/Ipopt",
+    "description": "Software package for large-scale nonlinear optimization.",
+    "version": "3.13.2",
+    "license": "EPL-1.0",
+    "url": "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.2/Ipopt-3.13.2-win64-msvs2019-md.zip",
+    "hash": "54bafce192588c3f43b7d09f948c1a3b9cac74b1b4f61a56c3321e6973b78e63",
+    "extract_dir": "Ipopt-3.13.2-win64-msvs2019-md",
+    "bin": "bin\\ipopt.exe",
+    "env_set": {
+      "IPOPTWINDIR": "$dir"
+    },
+    "checkver": {
+      "url": "https://github.com/coin-or/Ipopt/releases",
+      "regex": "\/releases\/tag\/releases%2F([\\d.]+)"
+    },
+    "autoupdate": {
+      "url": "https://github.com/coin-or/Ipopt/releases/download/releases%2F$version/Ipopt-$version-win64-msvs2019-md.zip",
+      "extract_dir": "Ipopt-$version-win64-msvs2019-md"
+    }
+}

--- a/bucket/ipopt.json
+++ b/bucket/ipopt.json
@@ -1,21 +1,29 @@
 {
-    "homepage": "https://github.com/coin-or/Ipopt",
-    "description": "Software package for large-scale nonlinear optimization.",
     "version": "3.13.2",
+    "description": "Software package for large-scale nonlinear optimization",
+    "homepage": "https://coin-or.github.io/Ipopt/",
     "license": "EPL-1.0",
-    "url": "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.2/Ipopt-3.13.2-win64-msvs2019-md.zip",
-    "hash": "54bafce192588c3f43b7d09f948c1a3b9cac74b1b4f61a56c3321e6973b78e63",
-    "extract_dir": "Ipopt-3.13.2-win64-msvs2019-md",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/coin-or/Ipopt/releases/download/releases%2F3.13.2/Ipopt-3.13.2-win64-msvs2019-md.zip",
+            "hash": "54bafce192588c3f43b7d09f948c1a3b9cac74b1b4f61a56c3321e6973b78e63",
+            "extract_dir": "Ipopt-3.13.2-win64-msvs2019-md"
+        }
+    },
     "bin": "bin\\ipopt.exe",
     "env_set": {
-      "IPOPTWINDIR": "$dir"
+        "IPOPTWINDIR": "$dir"
     },
     "checkver": {
-      "url": "https://github.com/coin-or/Ipopt/releases",
-      "regex": "\/releases\/tag\/releases%2F([\\d.]+)"
+        "github": "https://github.com/coin-or/Ipopt",
+        "regex": "/releases/tag/releases%2F([\\d.]+)"
     },
     "autoupdate": {
-      "url": "https://github.com/coin-or/Ipopt/releases/download/releases%2F$version/Ipopt-$version-win64-msvs2019-md.zip",
-      "extract_dir": "Ipopt-$version-win64-msvs2019-md"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/coin-or/Ipopt/releases/download/releases%2F$version/Ipopt-$version-win64-msvs2019-md.zip",
+                "extract_dir": "Ipopt-$version-win64-msvs2019-md"
+            }
+        }
     }
 }

--- a/bucket/ipopt.json
+++ b/bucket/ipopt.json
@@ -1,7 +1,7 @@
 {
     "version": "3.13.2",
     "description": "Software package for large-scale nonlinear optimization",
-    "homepage": "https://github.com/coin-or/Ipopt",
+    "homepage": "https://coin-or.github.io/Ipopt/",
     "license": "EPL-1.0",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Ipopt is a widely used command-line software package for large-scale nonlinear optimization. The environment variable `IPOPTWINDIR` allows wrappers such as [cyipopt](https://github.com/matthias-k/cyipopt) to find it.