### PR TITLE
ispc: Add version 1.13.0

### DIFF
--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -4,7 +4,7 @@
     "homepage": "https://ispc.github.io/",
     "license": "BSD-3-Clause",
     "url": "https://github.com/ispc/ispc/releases/download/v1.13.0/ispc-v1.13.0-windows.zip",
-    "hash": "sha256:B0A3A96BAF426845FD1A38CA5C1DCCA094354BEA99A3BC3F8E3A741BF07E6608",
+    "hash": "B0A3A96BAF426845FD1A38CA5C1DCCA094354BEA99A3BC3F8E3A741BF07E6608",
     "extract_dir": "bin",
     "bin": "ispc.exe",
     "checkver": {

--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.13.0",
+    "description": "Intel SPMD Program Compiler",
+    "homepage": "https://ispc.github.io/",
+    "license": "BSD-3-Clause",
+    "url": "https://github.com/ispc/ispc/releases/download/v1.13.0/ispc-v1.13.0-windows.zip",
+    "hash": "sha512:9B16E25822548BAF14B475764C48D0A36D6E6656623EAC36F769CCB116E2865659CEDFD210CF8D8CE0EE18E754773F39B4213612887DB974FFEBD677EB6B3C00",
+    "extract_dir": "bin",
+    "bin": "ispc.exe",
+    "checkver": {
+        "github": "https://github.com/ispc/ispc"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ispc/ispc/releases/download/v$version/ispc-v$version-windows.zip",
+        "hash": {
+            "url": "$url.sha512"
+        }
+    }
+}

--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -1,6 +1,6 @@
 {
     "version": "1.13.0",
-    "description": "Intel SPMD Program Compiler",
+    "description": "Intel® Implicit SPMD (Single Program Multiple Data) Compiler",
     "homepage": "https://ispc.github.io/",
     "license": "BSD-3-Clause",
     "url": "https://github.com/ispc/ispc/releases/download/v1.13.0/ispc-v1.13.0-windows.zip",

--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -13,6 +13,7 @@
     "autoupdate": {
         "url": "https://github.com/ispc/ispc/releases/download/v$version/ispc-v$version-windows.zip",
         "hash": {
+            "mode": "extract",
             "url": "$url.sha512"
         }
     }

--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -11,6 +11,6 @@
         "github": "https://github.com/ispc/ispc"
     },
     "autoupdate": {
-        "url": "https://github.com/ispc/ispc/releases/download/v$version/ispc-v$version-windows.zip",
+        "url": "https://github.com/ispc/ispc/releases/download/v$version/ispc-v$version-windows.zip"
     }
 }

--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -4,7 +4,7 @@
     "homepage": "https://ispc.github.io/",
     "license": "BSD-3-Clause",
     "url": "https://github.com/ispc/ispc/releases/download/v1.13.0/ispc-v1.13.0-windows.zip",
-    "hash": "sha512:9B16E25822548BAF14B475764C48D0A36D6E6656623EAC36F769CCB116E2865659CEDFD210CF8D8CE0EE18E754773F39B4213612887DB974FFEBD677EB6B3C00",
+    "hash": "sha256:B0A3A96BAF426845FD1A38CA5C1DCCA094354BEA99A3BC3F8E3A741BF07E6608",
     "extract_dir": "bin",
     "bin": "ispc.exe",
     "checkver": {

--- a/bucket/ispc.json
+++ b/bucket/ispc.json
@@ -12,9 +12,5 @@
     },
     "autoupdate": {
         "url": "https://github.com/ispc/ispc/releases/download/v$version/ispc-v$version-windows.zip",
-        "hash": {
-            "mode": "extract",
-            "url": "$url.sha512"
-        }
     }
 }


### PR DESCRIPTION
- Closes #1054

Adds ISPC (https://ispc.github.io/). For more information:

> Intel's ISPC (Implicit SPMD Program Compiler) is an LLVM-based OSS (BSD-3) compiler for a C-like language designed to be used in conjunction with standard C/C++ programs to provide a reliable and clean means of optimizing programs using appropriate vector processing hardware instructions on the CPU as an alternative to the potentially more cumbersome approaches of inline assembly and compiler intrinsics.