### PR TITLE
fix(actions): Migrate to 'main' branch

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -7,7 +7,7 @@ jobs:
     name: PullRequestHandler
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: PullRequestHandler
       uses: Ash258/Scoop-GithubActions@stable
       if: startsWith(github.event.comment.body, '/verify')

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,7 @@ jobs:
     name: IssueHandler
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: IssueHandler
       uses: Ash258/Scoop-GithubActions@stable
       if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     name: PullRequestHandler
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: PullRequestHandler
       uses: Ash258/Scoop-GithubActions@stable
       env:


### PR DESCRIPTION
Looks like GitHub is moving toward non-racist naming convention on all their actions

![image](https://user-images.githubusercontent.com/13260377/88195471-62748c80-cc40-11ea-90d9-307c64ffb7a7.png)
