### PR TITLE
clink.json: notes: correct the "clink autorun"

### DIFF
--- a/bucket/clink.json
+++ b/bucket/clink.json
@@ -13,7 +13,7 @@
     "persist": "profile",
     "notes": [
         "Run 'clink inject' to start clink on the current cmd",
-        "Run 'clink autorun' to auto start clink"
+        "Run 'clink autorun install' to auto start clink"
     ],
     "autoupdate": {
         "url": "https://github.com/mridgers/clink/releases/download/$version/clink_$version.zip",


### PR DESCRIPTION
C:> clink autorun
ERROR: Invalid arguments. Run 'clink autorun --help' for info.