### PR TITLE
Update less version

### DIFF
--- a/bucket/less.json
+++ b/bucket/less.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.greenwoodsoftware.com/less/",
     "description": "A terminal pager program used to view (but not change) the contents of a text file one screen at a time, similar to the 'more' command.",
-    "version": "561.1",
+    "version": "562.0",
     "license": "GPL-3.0-only|BSD-3-Clause",
     "bin": [
         "less.exe",
@@ -9,8 +9,8 @@
     ],
     "checkver": "github",
 
-    "hash": [ "a1d778f5f82a2399b0df279b3c182becae5f5474ff6f507f61e78af1dd41a7cd", "25224f351d5c7bebadad62fde950ec851e0df3adba7ba5e3c075ba3caa53634c"],
-    "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v561.1/lesskey.exe" ],
+    "hash": [ "61044f632f5fce2ded86f23db0154d0e87256f840c2930bceeff04db9ee75830", "7cd74ba88d578cd1566c4dd36e869859dae6030fcc9f1dc063145a9d2880151b"],
+    "url": [ "https://github.com/jftuga/less-Windows/releases/download/less-v562.0/less.exe", "https://github.com/jftuga/less-Windows/releases/download/less-v562.0/lesskey.exe" ],
     "autoupdate": {
         "url": "https://github.com/jftuga/less-Windows/releases/download/less-v$version/less.exe",
         "hash": {


### PR DESCRIPTION
A new version of `less` is available from jftuga's repository. This version should fix [this bug](https://github.com/sharkdp/bat/issues/1098) in `bat`.