### PR TITLE
zoxide: Add version 0.4.3

### DIFF
--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -3,6 +3,7 @@
     "description": "A faster way to navigate your filesystem",
     "homepage":  "https://github.com/ajeetdsouza/zoxide",
     "license":  "MIT",
+    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload"
     "architecture": {
         "64bit": {
             "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.4.3/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe",
@@ -21,6 +22,5 @@
                 "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe"
             }
         }
-    },
-    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload"
+    }
 }

--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -3,7 +3,7 @@
     "description": "A faster way to navigate your filesystem",
     "homepage":  "https://github.com/ajeetdsouza/zoxide",
     "license":  "MIT",
-    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload"
+    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.4.3/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe",

--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -3,13 +3,24 @@
     "description": "A faster way to navigate your filesystem.",
     "homepage":  "https://github.com/ajeetdsouza/zoxide",
     "license":  "MIT",
-    "url":  "https://github.com/ajeetdsouza/zoxide/releases/download/v0.4.3/zoxide-x86_64-pc-windows-msvc.exe",
-    "hash":  "502e858569ea2dd31b08db5e6621330f36abdc9b90186c915c102fbd2c7b0c1a",
-    "notes": "You'll need to add zoxide to PowerShell after installation: https://github.com/ajeetdsouza/zoxide#powershell",
-    "pre_install": "Rename-Item -Path \"$dir\\zoxide-x86_64-pc-windows-msvc.exe\" -NewName \"zoxide.exe\"",
+    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for automatic profile configuration",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.4.3/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe",
+            "hash": "502e858569ea2dd31b08db5e6621330f36abdc9b90186c915c102fbd2c7b0c1a"
+        }
+    },
     "bin": "zoxide.exe",
+    "env_set": {
+        "_ZO_DATA_DIR": "$dir\\data"
+    },
+    "persist": "data",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-x86_64-pc-windows-msvc.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe"
+            }
+        }
     }
 }

--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -1,0 +1,15 @@
+{
+    "version":  "0.4.3",
+    "description": "A faster way to navigate your filesystem.",
+    "homepage":  "https://github.com/ajeetdsouza/zoxide",
+    "license":  "MIT",
+    "url":  "https://github.com/ajeetdsouza/zoxide/releases/download/v0.4.3/zoxide-x86_64-pc-windows-msvc.exe",
+    "hash":  "502e858569ea2dd31b08db5e6621330f36abdc9b90186c915c102fbd2c7b0c1a",
+    "notes": "You'll need to add zoxide to PowerShell after installation: https://github.com/ajeetdsouza/zoxide#powershell",
+    "pre_install": "Rename-Item -Path \"$dir\\zoxide-x86_64-pc-windows-msvc.exe\" -NewName \"zoxide.exe\"",
+    "bin": "zoxide.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-x86_64-pc-windows-msvc.exe"
+    }
+}

--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -1,9 +1,8 @@
 {
     "version":  "0.4.3",
-    "description": "A faster way to navigate your filesystem.",
+    "description": "A faster way to navigate your filesystem",
     "homepage":  "https://github.com/ajeetdsouza/zoxide",
     "license":  "MIT",
-    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for automatic profile configuration",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.4.3/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe",
@@ -22,5 +21,6 @@
                 "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-x86_64-pc-windows-msvc.exe#/zoxide.exe"
             }
         }
-    }
+    },
+    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload"
 }


### PR DESCRIPTION
[`zoxide`](https://github.com/ajeetdsouza/zoxide) is a command line filesystem navigator written in rust. It's similar to [autojump](https://github.com/wting/autojump) and [z](https://github.com/rupa/z) with native Windows and PowerShell support.