### PR TITLE
ensubst: Add version 1.2.0

### DIFF
--- a/bucket/envsubst.json
+++ b/bucket/envsubst.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.2.0",
+    "description": "Environment variables substitution.",
+    "homepage": "https://github.com/a8m/envsubst",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst.exe",
+            "hash": "9ab45d92fece9ed1cdf5be75bc89f32451fa6d5658e8b493eb1785b170b572a7"
+        }
+    },
+    "bin": "envsubst.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/a8m/envsubst/releases/download/v$version/envsubst.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the [envsubst](https://github.com/a8m/envsubst) package.

From what I can from the project this package is x64 and I've added it accordingly.