### PR TITLE
poppler: Update to version 0.90

### DIFF
--- a/bucket/poppler.json
+++ b/bucket/poppler.json
@@ -3,8 +3,12 @@
     "description": "PDF rendering library",
     "homepage": "https://anaconda.org/conda-forge/poppler",
     "license": "GPL-2.0-only",
-    "url": "https://anaconda.org/conda-forge/poppler/0.90.1/download/win-64/poppler-0.90.1-h5d62644_0.tar.bz2",
-    "hash": "0074377d022a23503f64b781bdd0cd925df429c25474c237538565712a80746f",
+    "architecture": {
+        "64bit": {
+            "url": "https://anaconda.org/conda-forge/poppler/0.90.1/download/win-64/poppler-0.90.1-h5d62644_0.tar.bz2",
+            "hash": "0074377d022a23503f64b781bdd0cd925df429c25474c237538565712a80746f"
+        }
+    },
     "extract_dir": "Library",
     "bin": [
         "bin/pdfattach.exe",
@@ -25,6 +29,10 @@
         "re": ">win-64/poppler-([a-z0-9_\\-.]+)\\.tar\\.bz2</a>"
     },
     "autoupdate": {
-        "url": "https://anaconda.org/conda-forge/poppler/$matchHead/download/win-64/poppler-$version.tar.bz2"
+        "architecture": {
+            "64bit": {
+                "url": "https://anaconda.org/conda-forge/poppler/$matchHead/download/win-64/poppler-$version.tar.bz2"
+            }
+        }
     }
 }

--- a/bucket/poppler.json
+++ b/bucket/poppler.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.68.0",
+    "version": "0.90.1-h5d62644_0",
     "description": "PDF rendering library",
-    "homepage": "http://blog.alivate.com.au/poppler-windows/",
+    "homepage": "https://anaconda.org/conda-forge/poppler",
     "license": "GPL-2.0-only",
-    "extract_dir": "poppler-0.68.0",
-    "url": "http://blog.alivate.com.au/wp-content/uploads/2018/10/poppler-0.68.0_x86.7z",
-    "hash": "6a8fd0c4e7284dfa208c6f435a0a5cfd6d7445e59f29cae76e79dc079abf74d4",
-    "checkver": "Latest.*uploads/(?<date>\\d{4}/\\d{2})/poppler-(?<version>[\\d.]+)_x86.7z",
+    "url": "https://anaconda.org/conda-forge/poppler/0.90.1/download/win-64/poppler-0.90.1-h5d62644_0.tar.bz2",
+    "hash": "0074377d022a23503f64b781bdd0cd925df429c25474c237538565712a80746f",
+    "extract_dir": "Library",
     "bin": [
+        "bin/pdfattach.exe",
         "bin/pdfdetach.exe",
         "bin/pdffonts.exe",
         "bin/pdfimages.exe",
@@ -20,8 +20,11 @@
         "bin/pdftotext.exe",
         "bin/pdfunite.exe"
     ],
+    "checkver": {
+        "url": "https://anaconda.org/conda-forge/poppler/files",
+        "re": ">win-64/poppler-([a-z0-9_\\-.]+)\\.tar\\.bz2</a>"
+    },
     "autoupdate": {
-        "url": "http://blog.alivate.com.au/wp-content/uploads/$matchDate/poppler-$version_x86.7z",
-        "extract_dir": "poppler-$version"
+        "url": "https://anaconda.org/conda-forge/poppler/$matchHead/download/win-64/poppler-$version.tar.bz2"
     }
 }

--- a/bucket/poppler.json
+++ b/bucket/poppler.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.90.1-h5d62644_0",
+    "version": "20.09.0-h5d62644_0",
     "description": "PDF rendering library",
     "homepage": "https://anaconda.org/conda-forge/poppler",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://anaconda.org/conda-forge/poppler/0.90.1/download/win-64/poppler-0.90.1-h5d62644_0.tar.bz2",
-            "hash": "0074377d022a23503f64b781bdd0cd925df429c25474c237538565712a80746f"
+            "url": "https://anaconda.org/conda-forge/poppler/20.09.0/download/win-64/poppler-20.09.0-h5d62644_0.tar.bz2",
+            "hash": "6abd4ab9659c236d50074beae3a0cc8ce28e1f4107be2bde68d5709a6b79a2ca"
         }
     },
     "extract_dir": "Library",


### PR DESCRIPTION
Fixes #1046 

The current source (https://blog.alivate.com.au/poppler-windows) has not been updated in over 2 years. This modifies the poppler manifest to download the latest binaries from anaconda.org (https://anaconda.org/conda-forge/poppler/files). Latest version came out a week back.

As mentioned in #1046, anaconda.org only has 64-bit binaries, while the earlier source only has 32-bit. Not sure if this will be an issue.