### PR TITLE
Update tre-command to 0.3.2

### DIFF
--- a/bucket/tre-command.json
+++ b/bucket/tre-command.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Improved Tree command",
     "homepage": "https://github.com/dduan/tre",
     "license": "MIT",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dduan/tre/releases/download/v0.3.1/tre-v0.3.1-x86_64-pc-windows-msvc.zip",
-            "hash": "29d1bc1f296a93a5bed2737a6b2c63a830e45ac9c612fca0f5de7d62e241a8a1"
+            "url": "https://github.com/dduan/tre/releases/download/v0.3.2/tre-v0.3.2-x86_64-pc-windows-msvc.zip",
+            "hash": "7c97beac7b75bb2b53ba9bd712d6ac2bd5ff4497589f64077ca07e0a22e4a643"
         },
         "32bit": {
-            "url": "https://github.com/dduan/tre/releases/download/v0.3.1/tre-v0.3.1-i686-pc-windows-msvc.zip",
-            "hash": "61b3c1d7af45d0cdee987e4436f91c55b172668a6f85537a9e70e98a700abb2d"
+            "url": "https://github.com/dduan/tre/releases/download/v0.3.2/tre-v0.3.2-i686-pc-windows-msvc.zip",
+            "hash": "8248b475d2ff5142bb1130e7e09ada2e9aae98119c042bd5fd9c9b5b0ca83333"
         }
     },
     "bin": "tre.exe",


### PR DESCRIPTION
Release note: https://github.com/dduan/tre/releases/tag/v0.3.2