### PR TITLE
Add conemu app manifest

### DIFF
--- a/bucket/conemu.json
+++ b/bucket/conemu.json
@@ -1,0 +1,44 @@
+{
+    "version": "20.07.13",
+    "description": "Customizable Windows terminal with tabs, splits, quake-style, hotkeys and more.",
+    "homepage": "https://conemu.github.io/",
+    "license": "BSD-3-Clause",
+    "url": "https://github.com/Maximus5/ConEmu/releases/download/v20.07.13/ConEmuPack.200713.7z",
+    "hash": "1d3ce9c478719cc76bc4c8cf37b9dbf7bf27cac173a702885c4739d8b3c9e2a1",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "ConEmu64.exe",
+                    "ConEmu"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "ConEmu64.exe",
+                    "ConEmu"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": [
+                [
+                    "ConEmu.exe",
+                    "ConEmu"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "ConEmu.exe",
+                    "ConEmu"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/Maximus5/ConEmu"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Maximus5/ConEmu/releases/download/v$version/ConEmuPack.$cleanVersion.7z"
+    }
+}


### PR DESCRIPTION
Conemu is a popular terminal replacement for windows. I realized that this was not available on scoop. So adding it here.