### PR TITLE
gbt: Add version 2.0.0

### DIFF
--- a/bucket/gbt.json
+++ b/bucket/gbt.json
@@ -15,6 +15,11 @@
     },
     "extract_dir": "gbt-2.0.0",
     "bin": "gbt.exe",
+    "suggest": {
+        "NerdFont": [
+            "nerd-fonts/DejaVuSansMono-NF"
+        ]
+    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/gbt.json
+++ b/bucket/gbt.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://github.com/jtyr/gbt",
+    "description": "Highly configurable prompt builder for Bash, ZSH and PowerShell written in Go.",
+    "version": "2.0.0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jtyr/gbt/releases/download/v2.0.0/gbt-2.0.0-windows-amd64.zip",
+            "hash": "cb777db5299da8187f1e94cc5389c980e92f56c1030d6c850724410b87b983d9"
+        },
+        "32bit": {
+            "url": "https://github.com/jtyr/gbt/releases/download/v2.0.0/gbt-2.0.0-windows-386.zip",
+            "hash": "92d0ea961153e82fc63441f4bb9096c0512ac4d142cf81920c526c299b2da2c9"
+        }
+    },
+    "extract_dir": "gbt-2.0.0",
+    "bin": "gbt.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jtyr/gbt/releases/download/v$version/gbt-$version-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/jtyr/gbt/releases/download/v$version/gbt-$version-windows-386.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/gbt-$version-checksums-sha256.txt"
+        },
+        "extract_dir": "gbt-$version"
+    }
+}


### PR DESCRIPTION
GBT is highly configurable prompt builder for Bash, ZSH and PowerShell written in Go.