### PR TITLE
fossil: Update to version 2.12.1

### DIFF
--- a/bucket/fossil.json
+++ b/bucket/fossil.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.11.1",
+    "version": "2.12.1",
     "description": "A simple, high-reliability, distributed software configuration management system.",
     "homepage": "https://www.fossil-scm.org/",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w64-2.11.1.zip",
-            "hash": "b43f3ef2d85a1f0de1f7bfc7b698dee5382a224aaa41ec939a18eb3868f57410"
+            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w64-2.12.zip",
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         },
         "32bit": {
-            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w32-2.11.1.zip",
-            "hash": "1e371555c9570be470249f2a9f020f7acbba5667bbc5ece71fa55d79c77ee874"
+            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w32-2.12.zip",
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         }
     },
     "bin": "fossil.exe",


### PR DESCRIPTION
- Closes #1365

PR #1345 is out of date, which is why the hashes do not match. The application was updated on 2020-08-19.