### PR TITLE
android-clt: Add version 6609375

### DIFF
--- a/bucket/android-clt.json
+++ b/bucket/android-clt.json
@@ -1,0 +1,40 @@
+{
+    "version": "6609375",
+    "description": "The official Android command line tools",
+    "homepage": "https://developer.android.com/studio#command-tools",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://developer.android.com/studio/terms.html"
+    },
+    "notes": "You need to launch sdkmanager with --sdk_root=$env:ANDROID_SDK_ROOT.",
+    "url": "https://dl.google.com/android/repository/commandlinetools-win-6609375_latest.zip",
+    "hash": "40bba20275180194bebf89bb58c74d712bb93cc401f36bd2f8f32383acf9826c",
+    "post_install": [
+        "if (Test-Path \"$(appdir adb $global)\") {",
+        "    New-Item \"$dir\\platform-tools\" -ItemType Junction -Target \"$(appdir adb $global)\\current\\platform-tools\" | Out-Null",
+        "}"
+    ],
+    "env_add_path": "tools\\bin",
+    "env_set": {
+        "ANDROID_SDK_ROOT": "$dir"
+    },
+    "persist": [
+        "build-tools",
+        "emulator",
+        "extras",
+        "licenses",
+        "patcher",
+        "platforms",
+        "sources"
+    ],
+    "checkver": {
+        "regex": "commandlinetools-win-(\\d+)"
+    },
+    "autoupdate": {
+        "url": "https://dl.google.com/android/repository/commandlinetools-win-$version_latest.zip",
+        "hash": {
+            "url": "https://developer.android.com/studio",
+            "find": "commandlinetools-win(?:.*\\n){3}.*<td>($sha256)"
+        }
+    }
+}


### PR DESCRIPTION
Android Command Line Tools (`android-clt`, the name can be discussed) is the successor of [`android-sdk`](https://github.com/lukesampson/scoop-extras/blob/master/bucket/android-sdk.json).

If this gets merged we probably want to modify [what `android-studio` suggests](https://github.com/lukesampson/scoop-extras/blob/02d4c9f9a0780e6e7fba618ac929bcd5af0b9466/bucket/android-studio.json#L33) too.

###### Originally lukesampson/scoop-extras#4237