### PR TITLE
Add gdb-9.1-3 for gcc package

### DIFF
--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -25,7 +25,23 @@
                 "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-pkg-config-0.29.2-1-any.pkg.tar.xz",
                 "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-windows-default-manifest-6.4-3-any.pkg.tar.xz",
                 "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-winpthreads-git-8.0.0.5680.0df6b89f-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-7-any.pkg.tar.xz"
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-7-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libsystre-1.0.1-4-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libtre-git-r128.6fb7206-2-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libtasn1-4.9-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-p11-kit-0.23.9-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-ca-certificates-20190110-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-openssl-1.1.1.g-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-termcap-1.3.1-5-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-mpdecimal-2.4.2-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-bzip2-1.0.8-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-sqlite3-3.31.1-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libffi-3.3-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-ncurses-6.2-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-python-3.8.2-2-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-readline-8.0.004-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-xxhash-0.7.3-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gdb-9.1-3-any.pkg.tar.xz"
             ],
             "hash": [
                 "c2c23fc704639f0e30a6aa094130f12028fd722d5961ef29df503f241d0bd93e",
@@ -47,11 +63,31 @@
                 "f69c6a4f83164db254178821009e69877855a5dfbfc6b7c5a796cb79964ddaf0",
                 "6c0ea4adcef503dc8174e9d4d70a10aee8295d620db4494f78fa512df0589dcf",
                 "0a28e994a8fb25bc2d55de41d5db893363e0b1e98f9ac1c0db07716b386b3a5c",
-                "1decf05b8ae6ab10ddc9035929014837c18dd76da825329023da835aec53cec2"
+                "1decf05b8ae6ab10ddc9035929014837c18dd76da825329023da835aec53cec2",
+                "c1b9ae045e24a91f261dc654d390ac63254d0ca5882d76b52d7722a9d49fef0c",
+                "fd2c0e426a85c4193d34eea19411166495cb2fde58d0fac4e85422399062e336",
+                "c2ddbae9f6cc6decfe75b08aeebefed2de7b72a7857b7cfd6529bda7e776af02",
+                "00c4a450e7feffa227013db0c08aaea4af577a0f6d1de1fd4d97a8deafa7cc81",
+                "b88d18f030d81aa637042ee6c5adec02c69cb5a3a1d03600bafa80958fa94bf2",
+                "8e18dbfadb4261fd0882ef8edb7eb58d9129d31d8d9921a4431e55dc7b33fd10",
+                "93d369ef5ed802dc041e570f27a352247c209dad88a6fa1f8d90106d4f8e79a7",
+                "3e40d68e794d0390857e9a3dc808e42e4b48c13d2807081343fd07a07fbf14f9",
+                "cedb53a160aa2aa57e2e231e34e626241db0bf72116d06ed77d0a447c36bf6c6",
+                "7ec12a527edc44f06a751e894baf68b570884b4eca5d97df0d88a196f3d7aca6",
+                "ad933888ccf421e341fa6de179c66ba40ea509f8c4f9c4e55d2b9c9039445017",
+                "7c8b6ae5f2d567785c61f3e5752d8085cb8a45100c4e24250e11a1668931f94b",
+                "47fe3be25879151677e9827e08eb3d17eb97cf4d3508163fb92b352052cb0432",
+                "cbad5350c3f92ad3092e4a178d7f2b522e4f033e62c35ee6ccf10633a6e4f80b",
+                "056ecc41369a1c13b10365b35169b4fed5dba2f08d3ca414c88d7e7fc9e791df",
+                "d1ccb1a5ab8e6eb83f7ca4561ccfe45e1dd4630a343c50b2722c22c01279873f"
             ],
             "pre_install": [
                 "Move-Item -Path \"$dir\\mingw64\\*\" -Destination \"$dir\"",
                 "Remove-Item -Path \"$dir\\mingw64\", \"$dir\\.*\""
+            ],
+            "post_install": [
+                "New-Item \"$dir\\bin\\bak\" -ItemType \"directory\"",
+                "Move-Item -Path \"$dir\\bin\\python*.exe\" -Destination \"$dir\\bin\\bak\""
             ]
         },
         "32bit": {
@@ -75,7 +111,23 @@
                 "http://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-1-any.pkg.tar.xz",
                 "http://repo.msys2.org/mingw/i686/mingw-w64-i686-windows-default-manifest-6.4-3-any.pkg.tar.xz",
                 "http://repo.msys2.org/mingw/i686/mingw-w64-i686-winpthreads-git-8.0.0.5680.0df6b89f-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-7-any.pkg.tar.xz"
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-7-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libsystre-1.0.1-4-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libtre-git-r128.6fb7206-2-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libtasn1-4.9-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-p11-kit-0.23.9-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-ca-certificates-20190110-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-openssl-1.1.1.g-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-termcap-1.3.1-5-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-mpdecimal-2.4.2-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-bzip2-1.0.8-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-sqlite3-3.31.1-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libffi-3.3-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-ncurses-6.2-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-python-3.8.2-2-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-readline-8.0.004-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-xxhash-0.7.3-1-any.pkg.tar.xz",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gdb-9.1-3-any.pkg.tar.xz"
             ],
             "hash": [
                 "234396201fb4078ef8463497c04151c7826f0313dcb4b40c9b82aea3a282e819",
@@ -97,11 +149,31 @@
                 "39e07e61d739ba8f066605a109a19db397be6f7ddd81e5172f49ed253fdbe49f",
                 "56323bc39c7de0ff727915c09c4aaa25b8396efc0d7eda0006d5951bb6a6b983",
                 "e69339fda92b19469d5a4e0a1d5f50af8d8a420dc66f823d653ac8b536240493",
-                "addf6c52134027407640f1cbdf4efc5b64430f3a286cb4e4c4f5dbb44ce55a42"
+                "addf6c52134027407640f1cbdf4efc5b64430f3a286cb4e4c4f5dbb44ce55a42",
+                "3a400210f7f366c63d000d910203257643b4de1409d09d12da86e76acb4dd407",
+                "cc8ec470688c20d7b6da4ccc5dbaa275edb20242a058041b3b62a1b795ab8048",
+                "dcbef111ed907bb3a13a500bd0a3bd12402fdbfc9533053394022705205fa082",
+                "e62d73f7d63b5c3d557b509bf05ab2932564711b840787cb2f7b8af92e0df034",
+                "55e5c8c36fc0c62afc83f1d5dc6fcc6623643f50fc130d31b2b1d4483929af7d",
+                "6e3434019a7acebcf344489718a35ec40b815e67a6cd4f9b8dd3980d1c6f4f9d",
+                "70387a50939c3c9ad891d7f92e0a9ae92a4b30144303e55144c864b3a6ed49ce",
+                "5c1c64552a680b6e222751a732b724e62de5ee7b511190e81b2dd252c64807df",
+                "598bbaba996ed920a0d210c8182edbdf73a9df33b0c80b20fad1fb4a06a3fed0",
+                "af28533cd56fb615a1cfce499a61514f031504fb4fdc51ff1920f852ad500267",
+                "5bc5811941e88522cdd5fc255b724b0f444feb6c59ccf9f10ad35a0ed62124b0",
+                "822345fe69818dae56d80260e010ebc53e4472e3ca05a8a6ed1988b1425847e0",
+                "e08c7855b32a0b021244ec10ba6aa8cdf8bdf6132dd1606e80e273d10fce1882",
+                "79252f337255054f4ebc34128ca30b2a02bdd1d1018959db4726448d1bdd46e0",
+                "0fb85b09f3aea7a6e6c8dd27bf23d58f36bbb2895c5ca4559ef88c793a62fd87",
+                "db8875055155f0c64c08d025f1b718778f07ab0a6249475f3ae3b46e09d8e956"
             ],
             "pre_install": [
                 "Move-Item -Path \"$dir\\mingw32\\*\" -Destination \"$dir\"",
                 "Remove-Item -Path \"$dir\\mingw32\", \"$dir\\.*\""
+            ],
+            "post_install": [
+                "New-Item \"$dir\\bin\\bak\" -ItemType \"directory\"",
+                "Move-Item -Path \"$dir\\bin\\python*.exe\" -Destination \"$dir\\bin\\bak\""
             ]
         }
     },


### PR DESCRIPTION
It seems a good idea to install gcc and gdb together since they are essential for development.

Both of them are provided by mingw in the same repository.