### PR TITLE
fossil: Update to version 2.12.1

### DIFF
--- a/bucket/fossil.json
+++ b/bucket/fossil.json
@@ -1,22 +1,22 @@
 {
-    "version": "2.11.1",
+    "version": "2.12.1",
     "description": "A simple, high-reliability, distributed software configuration management system.",
     "homepage": "https://www.fossil-scm.org/",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w64-2.11.1.zip",
-            "hash": "b43f3ef2d85a1f0de1f7bfc7b698dee5382a224aaa41ec939a18eb3868f57410"
+            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w64-2.12.1.zip",
+            "hash": "c9087087eb915fe32dba3d110bb733a847df1d870f5866ea203b045f3330e81e"
         },
         "32bit": {
-            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w32-2.11.1.zip",
-            "hash": "1e371555c9570be470249f2a9f020f7acbba5667bbc5ece71fa55d79c77ee874"
+            "url": "https://www.fossil-scm.org/index.html/uv/fossil-w32-2.12.1.zip",
+            "hash": "1f1deb004a8d00ad4bc863b45a334c837e914712155e14e54bea9df14c6d1368"
         }
     },
     "bin": "fossil.exe",
     "checkver": {
         "url": "https://www.fossil-scm.org/index.html/uv/download.js",
-        "regex": "Version ([\\d.]+)\""
+        "regex": "p=version-([0-9.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Closes #1353
- Closes #1365
- Closes #1373
- Closes #1374

this commit fixes also the error message: 

fossil: couldn't match 'Version ([\d.]+)"' in https://www.fossil-scm.org/index.html/uv/download.js

Root cause is a format change of the title format of download.js, which now also contains a timestamp:
```
   "title":     "Version 2.12.1 (2020-08-20)",
```
I have changed the regex to parse the history field now, which may also be more resistant against breaks in future:
```
   "history":   "../timeline?p=version-2.12.1&bt=version-2.11&n=all"},
    new regex:              "p=version-([0-9.]+)"
```
