### PR TITLE
tinygo: Add version 0.14.1

### DIFF
--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -1,0 +1,17 @@
+{
+    "description": "A Go compiler for small places.",
+    "homepage": "https://tinygo.org/",
+    "version": "0.14.1",
+    "license": "BSD-3-Clause",
+    "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo0.14.1.windows-amd64.zip",
+    "hash": "1E8BC048B2B071AF106C04C2F7E0F4DEF549A232B1FF71104F2E5D81C06CE758",
+    "extract_dir": "tinygo",
+    "bin": "bin\\tinygo.exe",
+    "checkver": {
+        "github": "https://github.com/tinygo-org/tinygo",
+        "regex": "/releases/tag/v[\\d.]+"
+    },
+    "autoupdate": {
+        "url": "https://github.com/tinygo-org/tinygo/releases/download/v$version/tinygo$version.windows-amd64.zip"
+    }
+}

--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -7,10 +7,7 @@
     "hash": "1E8BC048B2B071AF106C04C2F7E0F4DEF549A232B1FF71104F2E5D81C06CE758",
     "extract_dir": "tinygo",
     "bin": "bin\\tinygo.exe",
-    "checkver": {
-        "github": "https://github.com/tinygo-org/tinygo",
-        "regex": "/releases/tag/v[\\d.]+"
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/tinygo-org/tinygo/releases/download/v$version/tinygo$version.windows-amd64.zip"
     }

--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -3,6 +3,9 @@
     "homepage": "https://tinygo.org/",
     "version": "0.14.1",
     "license": "BSD-3-Clause",
+    "suggest": {
+        "Go": "go"
+    },
     "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo0.14.1.windows-amd64.zip",
     "hash": "1E8BC048B2B071AF106C04C2F7E0F4DEF549A232B1FF71104F2E5D81C06CE758",
     "extract_dir": "tinygo",

--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -6,12 +6,22 @@
     "suggest": {
         "Go": "go"
     },
-    "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo0.14.1.windows-amd64.zip",
-    "hash": "1E8BC048B2B071AF106C04C2F7E0F4DEF549A232B1FF71104F2E5D81C06CE758",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo0.14.1.windows-amd64.zip",
+            "hash": "1E8BC048B2B071AF106C04C2F7E0F4DEF549A232B1FF71104F2E5D81C06CE758"
+        }
+    },
     "extract_dir": "tinygo",
     "bin": "bin\\tinygo.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/tinygo-org/tinygo/"
+    },
     "autoupdate": {
-        "url": "https://github.com/tinygo-org/tinygo/releases/download/v$version/tinygo$version.windows-amd64.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tinygo-org/tinygo/releases/download/v$version/tinygo$version.windows-amd64.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds tinygo v0.14.1 to scoop.

TinyGo brings a subset of go to micro-controllers & makes tiny things just go awesome!

Added a suggestion for `go` but if you think it's not required, can remove. Feedback welcome.