### PR TITLE
pypy(2, 3): fix download url

### DIFF
--- a/bucket/pypy2.json
+++ b/bucket/pypy2.json
@@ -3,7 +3,7 @@
     "description": "A fast, compliant alternative implementation of the Python language.",
     "homepage": "https://www.pypy.org",
     "license": "MIT",
-    "url": "https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.3.1-win32.zip",
+    "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.1-win32.zip",
     "hash": "e3c0dfb385d9825dd7723f26576d55d43ed92f1178f2399ab39e9fa11621a47b",
     "extract_dir": "pypy2.7-v7.3.1-win32",
     "bin": [
@@ -15,7 +15,7 @@
         "regex": "pypy(?<py>2[\\d.]+)-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://bitbucket.org/pypy/pypy/downloads/pypy$matchPy-v$version-win32.zip",
+        "url": "https://downloads.python.org/pypy$matchPy-v$version-win32.zip",
         "extract_dir": "pypy$matchPy-v$version-win32",
         "hash": {
             "url": "https://www.pypy.org/download.html"

--- a/bucket/pypy3.json
+++ b/bucket/pypy3.json
@@ -3,7 +3,7 @@
     "description": "A fast, compliant alternative implementation of the Python language.",
     "homepage": "https://www.pypy.org",
     "license": "MIT",
-    "url": "https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.3.1-win32.zip",
+    "url": "https://downloads.python.org/pypy/pypy3.6-v7.3.1-win32.zip",
     "hash": "752fbe8c4abee6468e5ce22af82818f821daded36faa65f3d69423f9c217007a",
     "extract_dir": "pypy3.6-v7.3.1-win32",
     "bin": [
@@ -15,7 +15,7 @@
         "regex": "pypy(?<py>3[\\d.]+)-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://bitbucket.org/pypy/pypy/downloads/pypy$matchPy-v$version-win32.zip",
+        "url": "https://downloads.python.org/pypy/pypy$matchPy-v$version-win32.zip",
         "extract_dir": "pypy$matchPy-v$version-win32",
         "hash": {
             "url": "https://www.pypy.org/download.html"


### PR DESCRIPTION
Bitbucket download url is broken.
Because pypy repository move to https://foss.heptapod.net/pypy/pypy