### PR TITLE
Added VULKAN_SDK path

### DIFF
--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -27,6 +27,9 @@
             ]
         }
     },
+    "env_set": {
+        "VULKAN_SDK": "$persist_dir\\scoop\apps\vulkan\current\"
+    },
     "checkver": {
         "url": "https://vulkan.lunarg.com/sdk/home.dhtml",
         "regex": "/VulkanSDK-([\\d.]+)-Installer\\.exe"

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -28,7 +28,7 @@
         }
     },
     "env_set": {
-        "VULKAN_SDK": "$persist_dir\\scoop\apps\vulkan\current\"
+        "VULKAN_SDK": "$persist_dir\\scoop\\apps\\vulkan\\current\"
     },
     "checkver": {
         "url": "https://vulkan.lunarg.com/sdk/home.dhtml",

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -28,7 +28,7 @@
         }
     },
     "env_set": {
-        "VULKAN_SDK": "$persist_dir\\scoop\\apps\\vulkan\\current\"
+        "VULKAN_SDK": "$persist_dir\\scoop\\apps\\vulkan\\current"
     },
     "checkver": {
         "url": "https://vulkan.lunarg.com/sdk/home.dhtml",


### PR DESCRIPTION
I am not sure if this is the best method but VULKAN_SDK path should be automatically added so that any tools looking for Vulkan can do so with ease :)

normally something like this works [Environment]::SetEnvironmentVariable("VULKAN_SDK", "$env:USERPROFILE/scoop/apps/vulkan/current/", "Machine")
assuming scoop is in userprofile and not elsewhere.