### PR TITLE
Update bind.json

### DIFF
--- a/bucket/bind.json
+++ b/bucket/bind.json
@@ -2,11 +2,11 @@
     "homepage": "https://www.isc.org/bind/",
     "description": "Versatile, classic, complete name server software.",
     "license": "MPL-2.0",
-    "version": "9.16.7",
+    "version": "9.17.5",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.isc.org/isc/bind9/9.16.7/BIND9.16.7.x64.zip",
-            "hash": "916ca01bf0deab6eeb74d9653e650935e2777f1a6b27305cd624a0ab3408a9fb"
+            "url": "https://downloads.isc.org/isc/bind9/9.17.5/BIND9.17.5.x64.zip",
+            "hash": "58E97038C859442E4EFECEB1E257FD390D00E31109E8C9637E2A303B324C7430"
         }
     },
     "env_add_path": "bin",
@@ -28,6 +28,6 @@
         }
     },
     "suggest": {
-        "vcredist": "extras/vcredist2017"
+        "vcredist": "extras/vcredist2019"
     }
 }


### PR DESCRIPTION
it already includes vcredist2017 (newer than scoop knows, but I've updated that), but it could simply just use latest vcredist2019 instead