### PR TITLE
tinygo: Update to version 0.15.0

### DIFF
--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.15/tinygo0.15.windows-amd64.zip",
-            "hash": "1e8bc048b2b071af106c04c2f7e0f4def549a232b1ff71104f2e5d81c06ce758"
+            "hash": "8DBAF4D897592EDD93DAD19918AE67A426D8A12CAAFCE30B9302740253C5EEA8"
         }
     },
     "extract_dir": "tinygo",

--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.14.1",
+    "version": "0.15.0",
     "description": "A Go compiler for small places",
     "homepage": "https://tinygo.org",
     "license": "BSD-3-Clause",
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.14.1/tinygo0.14.1.windows-amd64.zip",
+            "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.15/tinygo0.15.windows-amd64.zip",
             "hash": "1e8bc048b2b071af106c04c2f7e0f4def549a232b1ff71104f2e5d81c06ce758"
         }
     },

--- a/bucket/tinygo.json
+++ b/bucket/tinygo.json
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.15/tinygo0.15.windows-amd64.zip",
-            "hash": "8DBAF4D897592EDD93DAD19918AE67A426D8A12CAAFCE30B9302740253C5EEA8"
+            "url": "https://github.com/tinygo-org/tinygo/releases/download/v0.15.0/tinygo0.15.0.windows-amd64.zip",
+            "hash": "9773B3D35ADB73A8ABAB696CC538BAFA9627FBE09A8A3900B48863F71C7483C5"
         }
     },
     "extract_dir": "tinygo",


### PR DESCRIPTION
Updates to the latest [TinyGo 0.15.0](https://github.com/tinygo-org/tinygo/releases/tag/v0.15.0).

```
Download: Status Legend:
Download: (OK):download completed.
Checking hash of tinygo0.15.0.windows-amd64.zip ... ok.
Extracting tinygo0.15.0.windows-amd64.zip ... done.
Linking ~\scoop\apps\tinygo\current => ~\scoop\apps\tinygo\0.15.0
Creating shim for 'tinygo'.
'tinygo' (0.15.0) was installed successfully!
'tinygo' suggests installing 'go'.
```