### PR TITLE
temporary ffmpeg.json patch.

### DIFF
--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -5,36 +5,14 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-4.3.1-win64-static.zip",
+            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2020-09-20-14-26/ffmpeg-n4.3.1-17-gdae6d75a31-win64-gpl-4.3.zip",
             "hash": "f33a409dc61df9448dcd0505c6d1614a1c161397b3e5ceaebf8f5c0287374108",
-            "extract_dir": "ffmpeg-4.3.1-win64-static"
-        },
-        "32bit": {
-            "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.3.1-win32-static.zip",
-            "hash": "589e2dedd5bba34dede84c9513505768f4042a33b5bf21d90b97901da635a245",
-            "extract_dir": "ffmpeg-4.3.1-win32-static"
+            "extract_dir": "ffmpeg-n4.3.1-17-gdae6d75a31-win64-gpl-4.3"
         }
     },
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",
         "bin\\ffprobe.exe"
-    ],
-    "checkver": {
-        "url": "https://ffmpeg.zeranoe.com/builds/win64/static/",
-        "regex": "ffmpeg-([\\d.]+)-win64-static\\.zip",
-        "reverse": true
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-$version-win64-static.zip",
-                "extract_dir": "ffmpeg-$version-win64-static"
-            },
-            "32bit": {
-                "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-$version-win32-static.zip",
-                "extract_dir": "ffmpeg-$version-win32-static"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
idk much about making scoop packages, but this will work until the next version of ffmpeg for sure.

if you don't understand *why* this patch is required, it's because zeranoe shut down recently, making the current ffmpeg package broken. this fixes issue #1415 .