### PR TITLE
Update tre-command to 0.3.3

### DIFF
--- a/bucket/tre-command.json
+++ b/bucket/tre-command.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/dduan/tre/releases/download/v0.3.3/tre-v0.3.3-x86_64-pc-windows-msvc.zip",
-            "hash": "0a13bee0d81098bea6bb06c0520c1999bdf5b812df21085b72150c46acc6504b"
+            "hash": "14003404f94da3bd9b5a42e7ce065258e67ba983e238ab781f3cd5a2d541fcfb"
         },
         "32bit": {
             "url": "https://github.com/dduan/tre/releases/download/v0.3.3/tre-v0.3.3-i686-pc-windows-msvc.zip",
-            "hash": "ae8e4d3cbdeca0de3b3e21d522bf3c121eb623647fa55e21a39751907006c926"
+            "hash": "1da924695fddfdba70f948e2d2103e9c9ffd649a6ddec4a88c7068f056c1ad36"
         }
     },
     "bin": "tre.exe",


### PR DESCRIPTION
Release note: https://github.com/dduan/tre/releases/tag/v0.3.3