### PR TITLE
Julia x64 hash fix

### DIFF
--- a/bucket/julia.json
+++ b/bucket/julia.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://julialang-s3.julialang.org/bin/winnt/x64/1.5/julia-1.5.2-win64.exe",
-            "hash": "a49c9c2c42b8d6486e86151b4ada79948266f63d5d9039422dedb8c983b92e10"
+            "hash": "7f6deda3132795a646934fe9aa5446b6932c31bd70e34a2dd4d0ead5be915a2a"
         },
         "32bit": {
             "url": "https://julialang-s3.julialang.org/bin/winnt/x86/1.5/julia-1.5.2-win32.exe",


### PR DESCRIPTION
Correct hash can be found at https://julialang-s3.julialang.org/bin/checksums/julia-1.5.2.sha256