### PR TITLE
Fix pypy2 7.3.2 URL

### DIFF
--- a/bucket/pypy2.json
+++ b/bucket/pypy2.json
@@ -3,7 +3,7 @@
     "description": "A fast, compliant alternative implementation of the Python language.",
     "homepage": "https://www.pypy.org",
     "license": "MIT",
-    "url": "https://downloads.python.org/pypy2.7-v7.3.2-win32.zip",
+    "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.2-win32.zip",
     "hash": "0fd62265e0421a02432f10a294a712a5e784a8e061375e6d8ea5fd619be1be62",
     "extract_dir": "pypy2.7-v7.3.2-win32",
     "bin": [


### PR DESCRIPTION
previous URL missed the pypy folder