### PR TITLE
fixes vulkan sdk environment variables

### DIFF
--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -28,7 +28,8 @@
         }
     },
     "env_set": {
-        "VULKAN_SDK": "$persist_dir\\scoop\\apps\\vulkan\\current"
+        "VULKAN_SDK": "$dir",
+        "VK_SDK_PATH": "$dir"
     },
     "checkver": {
         "url": "https://vulkan.lunarg.com/sdk/home.dhtml",


### PR DESCRIPTION
The current `VULKAN_SDK` environment variable points to the incorrect path. The _persist_ folder does not exist for this scoop install.

Additionally, this PR adds the `VK_SDK_PATH` environment variable.