### PR TITLE
azure-cli: Set AzureCLIPath environment variable

### DIFF
--- a/bucket/azure-cli.json
+++ b/bucket/azure-cli.json
@@ -13,5 +13,9 @@
     },
     "autoupdate": {
         "url": "https://azurecliprod.azureedge.net/msi/azure-cli-$version.msi"
+    },
+    "env_set": {
+        "AzureCLIPath": "$dir",
+        "AZURE_CLI_PATH": "$dir"
     }
 }


### PR DESCRIPTION
As identified in, e.g., [the Azure Go SDK][1] and [other Azure SDKs][2], the Azure CLI program can be resolved using an environment variable called AzureCLIPath or AZURE_CLI_PATH if the program is not installed to the default locations. Setting this environment variable allows programs which build on the Azure SDKs to resolve the CLI program when it has been installed with Scoop.

  [1]: https://github.com/Azure/go-autorest/blob/afe17657e2844fc0def7ffbf572d7d869ffedb4d/autorest/azure/cli/token.go#L151
  [2]: https://github.com/search?q=org%3AAzure+AzureCLIPath&type=code