### PR TITLE
Latest PyPy 3 release is not 3.6 but 3.7

### DIFF
--- a/bucket/pypy3.json
+++ b/bucket/pypy3.json
@@ -3,9 +3,9 @@
     "description": "A fast, compliant alternative implementation of the Python language.",
     "homepage": "https://www.pypy.org",
     "license": "MIT",
-    "url": "https://downloads.python.org/pypy/pypy3.6-v7.3.2-win32.zip",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.2-win32.zip",
     "hash": "13a39d46340afed20f11de24e9068968386e4bb7c8bd168662711916e2bf1da6",
-    "extract_dir": "pypy3.6-v7.3.2-win32",
+    "extract_dir": "pypy3.7-v7.3.2-win32",
     "bin": [
         "pypy3.exe",
         "pypy3w.exe"


### PR DESCRIPTION
I will expect PyPy3 to be 3.7 but it is installing latest 3.6 version.