### PR TITLE
python: persist 'Scripts' folder

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -66,6 +66,9 @@
             "}"
         ]
     },
+    "persist": [
+        "Scripts"
+    ],
     "bin": [
         "python.exe",
         "pythonw.exe",


### PR DESCRIPTION
python: persist 'Scripts' folder to avoid re-downloading scripts after every update.