### PR TITLE
puppet-bolt: fix issue with missing gems

### DIFF
--- a/bucket/puppet-bolt.json
+++ b/bucket/puppet-bolt.json
@@ -9,6 +9,12 @@
             "hash": "82471b668eb9f8c43cf62e3a9184fdca903e2d657d78c0d702b15716cc5f6789"
         }
     },
+    "post_install": [
+        "if (Test-Path \"$dir\\share\\install-tarballs\\ruby*.tgz\") {",
+        "   Write-Host -F yellow \"Extract tarball of gems...\"",
+        "   Expand-7zipArchive \"$dir\\share\\install-tarballs\\ruby*.tgz\" \"$dir\"",
+        "}"
+    ],
     "extract_dir": "Puppet Labs\\Bolt",
     "bin": "bin\\bolt.bat",
     "checkver": {


### PR DESCRIPTION
Add post-install script for tarball of gems to fix the issue https://github.com/ScoopInstaller/Main/issues/1364

The PowerShell module relies on a registry entry which can't be set without elevated privileges. Therefore it won't be part of this fix.