### PR TITLE
pandoc: Update to 2.11.0.2 and remove pandoc-citeproc.exe shim

### DIFF
--- a/bucket/pandoc.json
+++ b/bucket/pandoc.json
@@ -1,18 +1,17 @@
 {
-    "version": "2.11.0.1",
+    "version": "2.11.0.2",
     "description": "Universal markup converter",
     "homepage": "https://pandoc.org",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jgm/pandoc/releases/download/2.11.0.1/pandoc-2.11.0.1-windows-x86_64.zip",
-            "hash": "ccbf910508e67d4a1e4820df3fe442260ef266e931e82a9be72d2cefe04ba323"
+            "url": "https://github.com/jgm/pandoc/releases/download/2.11.0.2/pandoc-2.11.0.2-windows-x86_64.zip",
+            "hash": "47a804d269ce85b1ec36f981dc0d59cc00989149cde40805d42883b97da32c06"
         }
     },
-    "extract_dir": "pandoc-2.11.0.1",
+    "extract_dir": "pandoc-2.11.0.2",
     "bin": [
-        "pandoc.exe",
-        "pandoc-citeproc.exe"
+        "pandoc.exe"
     ],
     "checkver": {
         "github": "https://github.com/jgm/pandoc"


### PR DESCRIPTION
λ  scoop install pandoc
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
Installing 'pandoc' (2.11.0.1) [64bit]
Loading pandoc-2.11.0.1-windows-x86_64.zip from cache.
Checking hash of pandoc-2.11.0.1-windows-x86_64.zip ... ok.
Extracting pandoc-2.11.0.1-windows-x86_64.zip ... done.
Linking ~\scoop\apps\pandoc\current => ~\scoop\apps\pandoc\2.11.0.1
Creating shim for 'pandoc'.
Creating shim for 'pandoc-citeproc'.
Can't shim 'pandoc-citeproc.exe': File doesn't exist.