### PR TITLE
busybox: do not add '-l' flag in bash shim

### DIFF
--- a/bucket/busybox.json
+++ b/bucket/busybox.json
@@ -76,8 +76,7 @@
         [
             "busybox.exe",
             "bash",
-            "bash",
-            "-l"
+            "bash"
         ],
         [
             "busybox.exe",


### PR DESCRIPTION
"bash -l" changes directory to the home directory
instead of remaining in the current working directory.
It should not change directory when "bash -c" is executed
to run a command in the current working directory.