### PR TITLE
fzf: Updated to version 0.24.1 (+ update url)

### DIFF
--- a/bucket/fzf.json
+++ b/bucket/fzf.json
@@ -1,22 +1,22 @@
 {
-    "version": "0.23.1",
+    "version": "0.24.1",
     "description": "A general-purpose command-line fuzzy finder",
     "homepage": "https://github.com/junegunn/fzf",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/junegunn/fzf-bin/releases/download/0.23.1/fzf-0.23.1-windows_amd64.zip",
-            "hash": "87f4d87c8065cac1ecc81bb8cee5dffd18f00d07d132f0eb15a4dc0034350bdf"
+            "url": "https://github.com/junegunn/fzf/releases/download/0.24.1/fzf-0.24.1-windows_amd64.zip",
+            "hash": "1f1e5c7b8f77c54e532bf03c74f459adf93a32b1c60a74cad92ee7e2b56b2255"
         }
     },
     "bin": "fzf.exe",
     "checkver": {
-        "github": "https://github.com/junegunn/fzf-bin"
+        "github": "https://github.com/junegunn/fzf"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/junegunn/fzf-bin/releases/download/$version/fzf-$version-windows_amd64.zip"
+                "url": "https://github.com/junegunn/fzf/releases/download/$version/fzf-$version-windows_amd64.zip"
             }
         }
     }


### PR DESCRIPTION
fzf's binary repository moved from junegunn/fzf-bin to junegunn/fzf

From [github.com/junegunn/fzf-bin](https://github.com/junegunn/fzf-bin):

> DEPRECATED
>
> Since 0.24.0, new releases will be available in https://github.com/junegunn/fzf/releases

