### PR TITLE
nodejs(*): reorder env_add_path

### DIFF
--- a/bucket/node-chakracore.json
+++ b/bucket/node-chakracore.json
@@ -20,8 +20,8 @@
         "cache"
     ],
     "env_add_path": [
-        ".",
-        "bin"
+        "bin",
+        "."
     ],
     "post_install": [
         "# Set npm prefix to install modules inside bin and npm cache so they persist",

--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -20,8 +20,8 @@
         "cache"
     ],
     "env_add_path": [
-        ".",
-        "bin"
+        "bin",
+        "."
     ],
     "post_install": [
         "# Set npm prefix to install modules inside bin and npm cache so they persist",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -20,8 +20,8 @@
         "cache"
     ],
     "env_add_path": [
-        ".",
-        "bin"
+        "bin",
+        "."
     ],
     "post_install": [
         "# Set npm prefix to install modules inside bin and npm cache so they persist",


### PR DESCRIPTION
Since this [issue](https://github.com/lukesampson/scoop/issues/3785) was fixed, the order of the environmental variables has changed.
So `bin` should be above `.`, otherwise `pnpm global install` will create shortcut in `scoop/apps/nodejs/current`, not in `scoop/persist/nodejs/bin`.