### PR TITLE
git: add less.exe bin

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -17,6 +17,7 @@
         "cmd\\git.exe",
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
+        "usr\\bin\\less.exe",
         "usr\\bin\\tig.exe",
         "git-bash.exe"
     ],


### PR DESCRIPTION
`less` is relied upon by popular diff viewers such as [delta] or [diff-so-fancy], so including it makes sense. Furthermore, less v551
bundled with Git fixes issues in older versions. For instance, v394 bundled with Gow has [problems with UTF-8] and [an update seems unlikely], sadly.

[delta]: https://github.com/dandavison/delta
[diff-so-fancy]: https://github.com/so-fancy/diff-so-fancy
[problems with UTF-8]: https://github.com/dandavison/delta/issues/271
[an update seems unlikely]: https://github.com/bmatzelle/gow/issues/250