### PR TITLE
starship: suggest installing vcredist

### DIFF
--- a/bucket/starship.json
+++ b/bucket/starship.json
@@ -7,6 +7,9 @@
         "Usage: Add 'Invoke-Expression (&starship init powershell)' to the end of your PowerShell $PROFILE.",
         "Prerequisites: A Powerline font installed and enabled in your terminal."
     ],
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/starship/starship/releases/download/v0.46.2/starship-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
starship silently fails running without VCRUNTIME140.dll when installed with scoop (starship/starship#1173).

Suggest installing vcredist on install to prevent users from running into this problem.