### PR TITLE
rakudo-star: Change description and add ZEF to bin

### DIFF
--- a/bucket/rakudo-star.json
+++ b/bucket/rakudo-star.json
@@ -1,7 +1,7 @@
 {
     "version": "2020.05.1-01",
-    "description": "Raku compiler for the MoarVM and JVM",
-    "homepage": "https://rakudo.org",
+    "description": "The Rakudo Star Bundle contains the Rakudo Compiler, a collection of modules from the Raku ecosystem, and the language documentation.",
+    "homepage": "https://rakudo.org/star",
     "license": "Artistic-2.0",
     "architecture": {
         "64bit": {
@@ -13,7 +13,9 @@
     "bin": [
         "bin\\perl6.exe",
         "bin\\raku.exe",
-        "bin\\rakudo.exe"
+        "bin\\rakudo.exe",
+        "share\\perl6\\site\\bin\\zef",
+        "share\\perl6\\site\\bin\\zef.bat"
     ],
     "checkver": {
         "url": "https://rakudo.org/downloads/star",

--- a/bucket/rakudo-star.json
+++ b/bucket/rakudo-star.json
@@ -14,8 +14,7 @@
         "bin\\perl6.exe",
         "bin\\raku.exe",
         "bin\\rakudo.exe",
-        "share\\perl6\\site\\bin\\zef",
-        "share\\perl6\\site\\bin\\zef.bat"
+        "share\\perl6\\site\\bin\\zef"
     ],
     "checkver": {
         "url": "https://rakudo.org/downloads/star",

--- a/bucket/rakudo-star.json
+++ b/bucket/rakudo-star.json
@@ -14,7 +14,7 @@
         "bin\\perl6.exe",
         "bin\\raku.exe",
         "bin\\rakudo.exe",
-        "share\\perl6\\site\\bin\\zef"
+        "share\\perl6\\site\\bin\\zef.bat"
     ],
     "checkver": {
         "url": "https://rakudo.org/downloads/star",


### PR DESCRIPTION
taking the the description from https://rakudo.org/star and adding the **_zef_** tool to the bin / path to enable RAKU module management.