### PR TITLE
git: Use Git Credential Manager Core

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -13,7 +13,7 @@
             "hash": "7479d7de99175e6fc5277fda14af240089bbd96fd60603e517dfb960213a679d"
         }
     },
-    "post_install": "git config --global credential.helper manager",
+    "post_install": "git config --global credential.helper manager-core",
     "bin": [
         "cmd\\git.exe",
         "cmd\\gitk.exe",


### PR DESCRIPTION
This PR updates the `post-install` step of the git manifest to set the default `credential.helper` to `manager-core`. This matches the changes performed in Git for Windows 2.29 ([change](https://github.com/git-for-windows/build-extra/pull/305/files#diff-b1bc3036e6b6e15d36f016775a046b33fe502165d659b34611e6f10cb37f7e51R111), [pull-request](https://github.com/git-for-windows/build-extra/pull/305), [announcement](https://github.blog/2020-07-02-git-credential-manager-core-building-a-universal-authentication-experience/)).