### PR TITLE
xray: Add version 1.0.0

### DIFF
--- a/bucket/xray.json
+++ b/bucket/xray.json
@@ -2,7 +2,7 @@
 	"version": "1.0.0",
 	"description": "Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support. Fully compatible configuration.",
 	"homepage": "https://github.com/XTLS/Xray-core",
-	"license": "MPL",
+	"license": "MPL-2.0",
 	"architecture": {
 		"64bit": {
 			"url": "https://github.com/XTLS/Xray-core/releases/download/v1.0.0/Xray-windows-64.zip",

--- a/bucket/xray.json
+++ b/bucket/xray.json
@@ -1,0 +1,22 @@
+{
+	"version": "1.0.0",
+	"description": "Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support. Fully compatible configuration.",
+	"homepage": "https://github.com/XTLS/Xray-core",
+	"license": "MPL",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/XTLS/Xray-core/releases/download/v1.0.0/Xray-windows-64.zip",
+			"hash": "9B525F9945AAC08A0752055CFD3EFA7779A8D86DC2D4BC1EDFA49B6300593CD1"
+		},
+		"32bit": {
+			"url": "https://github.com/XTLS/Xray-core/releases/download/v1.0.0/Xray-windows-32.zip",
+			"hash": "18E099E12B9DCEAAE546D840C2BEEE00A3BB2D47EB390B347CF33E3372E2F9B6"
+		}
+	},
+	"bin": [
+		"xray.exe"
+	],
+	"checkver": {
+		"github": "https://github.com/XTLS/Xray-core"
+	}
+}


### PR DESCRIPTION
Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support. Fully compatible configuration.
