### PR TITLE
azure-functions-core-tools: Update to version 3.0.2996

### DIFF
--- a/bucket/azure-functions-core-tools.json
+++ b/bucket/azure-functions-core-tools.json
@@ -1,21 +1,24 @@
 {
     "##": "Rename download file because 7-zip can't decompress it as zip file.",
-    "version": "2.7.3023",
+    "version": "3.0.2996",
     "description": "Microsoft Azure Functions Core Tools",
     "homepage": "https://github.com/Azure/azure-functions-core-tools",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/2.7.3023/Azure.Functions.Cli.win-x64.2.7.3023.zip#/dl.7z",
-            "hash": "91d9dffb29f1bf870835c2ebfab6aa0f1f198eddd436d9fd242c692ac11a5d39"
+            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/3.0.2996/Azure.Functions.Cli.win-x64.3.0.2996.zip#/dl.7z",
+            "hash": "40c38f135200a9b90fee85549df97c76f323916d88b396f006d7263e80b0c748"
         },
         "32bit": {
-            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/2.7.3023/Azure.Functions.Cli.win-x86.2.7.3023.zip#/dl.7z",
-            "hash": "6d16bd247bbf46e51798d88c9b6770384a0ff3a391886c0a176b3f51758b36ab"
+            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/3.0.2996/Azure.Functions.Cli.win-x86.3.0.2996.zip#/dl.7z",
+            "hash": "56697ad253095bed5f4cc8218b0c3826e18c39b33c67d9cf8dadad55d56e932e"
         }
     },
     "bin": "func.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://api.github.com/repos/Azure/azure-functions-core-tools/tags",
+        "regex": "\"name\": *\"([\\d.]+)\""
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -24,6 +27,9 @@
             "32bit": {
                 "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/$version/Azure.Functions.Cli.win-x86.$version.zip#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "$url.sha2"
         }
     }
 }


### PR DESCRIPTION
Address an issue in #150. `azure-functions-core-tools` has `v1`, `v2` and `v3` releasing parallel, and `v3` is recommended. [GitHub Tag API](https://api.github.com/repos/Azure/azure-functions-core-tools/tags) will return tags sorted by name (big to small), i.e. `v3` series are at the top despite of release date.