### PR TITLE
Addition Vulkan SDK debug components to the Vulkan manifest

### DIFF
--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -16,7 +16,7 @@
     ],
     "hash": [
         "ada71bb25f5775c648048d22185d65c0bf49678ac1060e9fa79edcafe9816440",
-        "e809df5adb733ad6995c3b050700e5b5d480c48c2c13fb527b062cc63f5f822a"
+        "2146A4D8280F170F661D7AB5D4962D1CAD83B39525A22962EE4917953913D597"
     ],
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstal*\" -Recurse",
     "post_install": "& \"$dir\\install-debug-libs.ps1\" $cachedir $dir $version",

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -10,9 +10,16 @@
         "Make sure you have the vulkan driver installed.",
         "Variety of drivers of different graphic card vendors could be found at the bottom of 'https://www.khronos.org/vulkan/'"
     ],
-    "url": "https://sdk.lunarg.com/sdk/download/1.2.162.1/windows/VulkanSDK-1.2.162.1-Installer.exe#/dl.7z",
-    "hash": "ada71bb25f5775c648048d22185d65c0bf49678ac1060e9fa79edcafe9816440",
+    "url": [
+        "https://sdk.lunarg.com/sdk/download/1.2.162.1/windows/VulkanSDK-1.2.162.1-Installer.exe#/dl.7z",
+        "https://raw.githubusercontent.com/rgozim/Main/master/scripts/vulkan/install-debug-libs.ps1"
+    ],
+    "hash": [
+        "ada71bb25f5775c648048d22185d65c0bf49678ac1060e9fa79edcafe9816440",
+        "e809df5adb733ad6995c3b050700e5b5d480c48c2c13fb527b062cc63f5f822a"
+    ],
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstal*\" -Recurse",
+    "post_install": "& \"$dir\\install-debug-libs.ps1\" $cachedir $dir $version",
     "architecture": {
         "64bit": {
             "env_add_path": [
@@ -32,8 +39,8 @@
         "VK_SDK_PATH": "$dir"
     },
     "checkver": {
-        "url": "https://vulkan.lunarg.com/sdk/home.dhtml",
-        "regex": "/VulkanSDK-([\\d.]+)-Installer\\.exe"
+        "url": "https://vulkan.lunarg.com/sdk/latest/windows.json",
+        "jp": "$.windows"
     },
     "autoupdate": {
         "url": "https://sdk.lunarg.com/sdk/download/$version/windows/VulkanSDK-$version-Installer.exe#/dl.7z",

--- a/scripts/vulkan/install-debug-libs.ps1
+++ b/scripts/vulkan/install-debug-libs.ps1
@@ -1,4 +1,3 @@
-
 <#
 .SYNOPSIS
     Triggers the download of debug
@@ -17,7 +16,7 @@ param(
 )
 
 function GetUrlStatusCode {
-    [OutputType([int])] 
+    [OutputType([int])]
     Param ([string]$url)
 
     try {
@@ -32,7 +31,7 @@ function GetUrlStatusCode {
 function ReplaceMinVersion {
     [OutputType([string])]
     Param ([string]$ver)
-    
+
     [int] $index = $ver.LastIndexOf(".")
     if ($index -eq -1) {
         throw "Version isn't of format {x.x.x.x}"
@@ -84,5 +83,5 @@ foreach ($url in $urlsToTest) {
 
         # And extract it
         Expand-Archive -Path "$download" -DestinationPath $Directory
-    } 
+    }
 }

--- a/scripts/vulkan/install-debug-libs.ps1
+++ b/scripts/vulkan/install-debug-libs.ps1
@@ -1,0 +1,88 @@
+
+<#
+.SYNOPSIS
+    Triggers the download of debug
+    libs and bin files for the VulkanSdk
+.PARAMETER CacheDirectory
+    Current scoop '$cachedir' of the SDK
+.PARAMETER Directory
+    Current scoop '$dir' of the SDK
+.PARAMETER Version
+    Version of the SDK
+#>
+param(
+    [Parameter(Mandatory)][String] $CacheDirectory,
+    [Parameter(Mandatory)][String] $Directory,
+    [Parameter(Mandatory)][String] $Version
+)
+
+function GetUrlStatusCode {
+    [OutputType([int])] 
+    Param ([string]$url)
+
+    try {
+        (Invoke-WebRequest -Uri $Url -UseBasicParsing -DisableKeepAlive -Method Head).StatusCode
+    }
+    catch [Net.WebException] {
+        $_.Exception.Response.StatusCode
+    }
+}
+
+# Replaces x.x.x.1(2(3(etc))) with x.x.x.0
+function ReplaceMinVersion {
+    [OutputType([string])]
+    Param ([string]$ver)
+    
+    [int] $index = $ver.LastIndexOf(".")
+    if ($index -eq -1) {
+        throw "Version isn't of format {x.x.x.x}"
+    }
+    $ver = $ver.Remove($index, $ver.Length - $index);
+    return $ver = $ver + ".0"
+}
+
+# Obtains the filename from the URL
+# https://stackoverflow.com/a/44475621
+function GetDownloadFileName {
+    [OutputType([string])]
+    Param ([string]$url)
+    $(split-path -path "$url" -leaf)
+}
+
+$baseUrl = "https://files.lunarg.com/SDK-"
+$minVersion = ReplaceMinVersion $Version
+Write-Host "Min version $minVersion"
+
+# URL example be https://files.lunarg.com/SDK-1.2.154.1/VulkanSDK-1.2.154.1-DebugLibs.zip
+$urlStandard = "$baseUrl$version/VulkanSDK-$version-DebugLibs.zip"
+
+# URL example be https://files.lunarg.com/SDK-1.2.154.1/VulkanSDK-1.2.154.0-DebugLibs.zip
+$urlMinStandard = "$baseUrl$version/VulkanSDK-$minVersion-DebugLibs.zip"
+
+# URL will be https://files.lunarg.com/SDK-1.2.154.0-1.2.154.1/VulkanSDK-1.2.154.0-DebugLibs.zip
+$urlVersionCurrent = "$baseUrl$minVersion-$version/VulkanSDK-$version-DebugLibs.zip"
+$urlMinCurrent = "$baseUrl$minVersion-$version/VulkanSDK-$minVersion-DebugLibs.zip"
+
+# Find the URl that works
+$urlsToTest = "$urlStandard", $urlMinStandard, "$urlVersionCurrent", "$urlMinCurrent"
+
+# Inform the user of what is going on
+Write-Host "Attempting to find Vulkan debug libs"
+
+foreach ($url in $urlsToTest) {
+    $code = GetUrlStatusCode $url
+    Write-Host "$code - $url"
+
+    if ($code -eq 200) {
+        # Creates the output directory of the file to download and checks
+        # for it's existance in the cache
+        $download = "$CacheDirectory\" + (GetDownloadFileName $url)
+        if (-Not (Test-Path $download)) {
+            # Download the zip file
+            Invoke-WebRequest -Uri $url -UseBasicParsing -DisableKeepAlive -OutFile "$download"
+        }
+
+        # And extract it
+        Expand-Archive -Path "$download" -DestinationPath $Directory
+    } 
+}


### PR DESCRIPTION
This PR adds the ability of the Vulkan manifest to download Vulkan SDK debug components, [located separately](https://files.lunarg.com/SDK-1.2.154.0-1.2.154.1/) from the SDK on Windows.

Unfortunately, the URLs on files.lunarg.com used to host the VulkanSDK-x.x.x.x-DebugLibs.zip are inconsistent between versions. 

| SDK version | Debug URL                                                                          |
|-------------|------------------------------------------------------------------------------------|
| 1.2.154.1   | https://files.lunarg.com/SDK-1.2.154.0-1.2.154.1/VulkanSDK-1.2.154.0-DebugLibs.zip |
| 1.2.148.1   | https://files.lunarg.com/SDK-1.2.148.1/VulkanSDK-1.2.148.0-DebugLibs.zip           |
| 1.2.148.0   | https://files.lunarg.com/SDK-1.2.148.0/VulkanSDK-1.2.148.0-DebugLibs.zip           |

**install-debug-libs.ps1**:
This powershell script iterates over four possible URL formats to find one that corresponds to the version of Vulkan specified within the vulkan.json manifest.

The table below describes the URLs and their order of discovery:

| 1.2.154.1                                                                          |
|------------------------------------------------------------------------------------|
| https://files.lunarg.com/SDK-1.2.154.1/VulkanSDK-1.2.154.1-DebugLibs.zip           |
| https://files.lunarg.com/SDK-1.2.154.1/VulkanSDK-1.2.154.0-DebugLibs.zip           |
| https://files.lunarg.com/SDK-1.2.154.0-1.2.154.1/VulkanSDK-1.2.154.1-DebugLibs.zip |
| https://files.lunarg.com/SDK-1.2.154.0-1.2.154.1/VulkanSDK-1.2.154.0-DebugLibs.zip |



