### PR TITLE
puppet-bolt: Set GEM_PATH

### DIFF
--- a/bucket/puppet-bolt.json
+++ b/bucket/puppet-bolt.json
@@ -10,7 +10,7 @@
         }
     },
     "extract_dir": "Puppet Labs\\Bolt",
-    "pre_install": "Set-Content \"$dir\\bolt.bat\" '@ECHO OFF', 'SETLOCAL', 'SET GEM_HOME=', '%~dp0bin\\bolt.bat %*' -Encoding Ascii",
+    "pre_install": "Set-Content \"$dir\\bolt.bat\" '@ECHO OFF', 'SETLOCAL', 'SET GEM_HOME=','SET GEM_PATH=', '%~dp0bin\\bolt.bat %*' -Encoding Ascii",
     "post_install": [
         "if (Test-Path \"$dir\\share\\install-tarballs\\ruby*.tgz\") {",
         "   info 'Extract tarball of gems...'",


### PR DESCRIPTION
Like GEM_HOME, GEM_PATH needs to be reset to use the puppet-bolt gems.   

TODO
(can we have multiple pre_install keys?)
We also should create a $dir\\gem.bat file that resets GEM_HOME and GEM_PATH