### PR TITLE
Add Redis 5.0.10

### DIFF
--- a/bucket/redis5.json
+++ b/bucket/redis5.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://redis.io",
+    "description": "In-memory data structure store, used as a database, cache and message broker.",
+    "version": "5.0.10",
+    "license": "BSD-3-Clause",
+    "url": "https://github.com/tporadowski/redis/releases/download/v5.0.10/Redis-x64-5.0.10.zip",
+    "hash": "F0FA5B8101B286000A9D2B05D300CD0D702B4197A96CDABE6C9D9F859DE44566",
+    "bin": [
+        "redis-benchmark.exe",
+        "redis-check-aof.exe",
+        "redis-cli.exe",
+        "redis-server.exe"
+    ],
+    "checkver": {
+        "url": "https://github.com/tporadowski/redis/releases/",
+        "re": ">v(\\d+\\.\\d+\\.\\d+)<"
+    }
+}

--- a/bucket/redis5.json
+++ b/bucket/redis5.json
@@ -12,7 +12,10 @@
         "redis-server.exe"
     ],
     "checkver": {
-        "url": "https://github.com/tporadowski/redis/releases/",
-        "re": ">v(\\d+\\.\\d+\\.\\d+)<"
+        "github": "https://github.com/tporadowski/redis",
+        "regex": ">v(\\d+\\.\\d+\\.\\d+)<"
+    },
+    "autoupdate": {
+        "url": "https://github.com/tporadowski/redis/releases/download/v$version/Redis-x64-$version.zip"
     }
 }

--- a/bucket/redis5.json
+++ b/bucket/redis5.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://redis.io",
     "description": "In-memory data structure store, used as a database, cache and message broker.",
-    "version": "5.0.10",
+    "version": "5.0.9",
     "license": "BSD-3-Clause",
-    "url": "https://github.com/tporadowski/redis/releases/download/v5.0.10/Redis-x64-5.0.10.zip",
+    "url": "https://github.com/tporadowski/redis/releases/download/v5.0.9/Redis-x64-5.0.9.zip",
     "hash": "F0FA5B8101B286000A9D2B05D300CD0D702B4197A96CDABE6C9D9F859DE44566",
     "bin": [
         "redis-benchmark.exe",

--- a/bucket/redis5.json
+++ b/bucket/redis5.json
@@ -4,7 +4,7 @@
     "version": "5.0.9",
     "license": "BSD-3-Clause",
     "url": "https://github.com/tporadowski/redis/releases/download/v5.0.9/Redis-x64-5.0.9.zip",
-    "hash": "F0FA5B8101B286000A9D2B05D300CD0D702B4197A96CDABE6C9D9F859DE44566",
+    "hash": "B09565B22B50C505A5FAA86A7E40B6683AFB22F3C17C5E6A5E35FC9B7C03F4C2",
     "bin": [
         "redis-benchmark.exe",
         "redis-check-aof.exe",

--- a/bucket/redis5.json
+++ b/bucket/redis5.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://redis.io",
     "description": "In-memory data structure store, used as a database, cache and message broker.",
-    "version": "5.0.9",
+    "version": "5.0.10",
     "license": "BSD-3-Clause",
-    "url": "https://github.com/tporadowski/redis/releases/download/v5.0.9/Redis-x64-5.0.9.zip",
-    "hash": "B09565B22B50C505A5FAA86A7E40B6683AFB22F3C17C5E6A5E35FC9B7C03F4C2",
+    "url": "https://github.com/tporadowski/redis/releases/download/v5.0.10/Redis-x64-5.0.10.zip",
+    "hash": "f0fa5b8101b286000a9d2b05d300cd0d702b4197a96cdabe6c9d9f859de44566",
     "bin": [
         "redis-benchmark.exe",
         "redis-check-aof.exe",


### PR DESCRIPTION
- create new entry for redis 5.0.10 (redis5) as default redis 3.2 of main bucket is out dated
- related to #1525 