### PR TITLE
fix: caddy github organization

### DIFF
--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -5,18 +5,18 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v2.2.1/caddy_2.2.1_windows_amd64.zip",
+            "url": "https://github.com/caddyserver/caddy/releases/download/v2.2.1/caddy_2.2.1_windows_amd64.zip",
             "hash": "sha512:e5c5fba6af33a0e1b48cbabc106e907dc7171c2cc337ee5c7cbbad07587dc4970c3f49812b3938dee43209b7fe293c74b36274fd809730ecec0041dd6b1fa93d"
         }
     },
     "bin": "caddy.exe",
     "checkver": {
-        "github": "https://github.com/mholt/caddy"
+        "github": "https://github.com/caddyserver/caddy"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_$version_windows_amd64.zip"
+                "url": "https://github.com/caddyserver/caddy/releases/download/v$version/caddy_$version_windows_amd64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Caddy has moved on GitHub to the `caddyserver` org.