### PR TITLE
scoop-search: add version 1.0.1

### DIFF
--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.1",
+    "description": "Fast scoop search drop-in replacement",
+    "homepage": "https://github.com/shilangyu/scoop-search",
+    "license": "MIT",
+    "url": "https://github.com/shilangyu/scoop-search/releases/download/v1.0.1/scoop-search.exe",
+    "hash": "c6e5551a396d6f601d6a0f198552ac53f207454bac9ae2f7c30e2308e801fccf",
+    "bin": "scoop-search.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/shilangyu/scoop-search/releases/download/v$version/scoop-search.exe"
+    },
+    "notes": "To replace built-in scoop search, add this to $PROFILE: Invoke-Expression (&scoop-search --hook)"
+}


### PR DESCRIPTION
https://github.com/shilangyu/scoop-search is a drop-in search replacement by @shilangyu that makes `scoop search` actually faster than googling the manifest. 

Closes https://github.com/shilangyu/scoop-search/issues/10