### PR TITLE
Update nu.json to 0.25.0

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.24.1",
+    "version": "0.25.0",
     "description": "A modern shell written in Rust",
     "homepage": "https://www.nushell.sh",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/nushell/nushell/releases/download/0.24.1/nu_0_24_1_windows.zip",
-            "hash": "81460405d11a9b48e10fe120185dc8cb5b2004057b60d7dc119b825a7b50cae9",
-            "extract_dir": "nu_0_24_1_windows\\nushell-0.24.1"
+            "url": "https://github.com/nushell/nushell/releases/download/0.25.0/nu_0_25_0_windows.zip",
+            "hash": "ddf877d7e6493de340acf1e64beaa39a6020cf0c95d73d6655b0871d9e267974",
+            "extract_dir": "nu_0_25_0_windows\\nushell-0.25.0"
         }
     },
     "pre_install": [


### PR DESCRIPTION
https://github.com/nushell/nushell/releases/tag/0.25.0

hash created by downloading by browser, then running: 
```
❯ certutil.exe -hashfile .\nu_0_25_0_windows.zip sha256
SHA256 hash of .\nu_0_25_0_windows.zip:
ddf877d7e6493de340acf1e64beaa39a6020cf0c95d73d6655b0871d9e267974
CertUtil: -hashfile command completed successfully.
```