### PR TITLE
Change LLVM update URL to GitHub Releases and update to 11.0.1

### DIFF
--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -1,16 +1,16 @@
 {
-    "version": "11.0.0",
+    "version": "11.0.1",
     "description": "Collection of modular and reusable compiler and toolchain technologies.",
     "homepage": "https://www.llvm.org",
     "license": "NCSA",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe#/dl.7z",
-            "hash": "a773ee3519ecc8d68d91f0ec72ee939cbed8ded483ba8e10899dc19bccba1e22"
+            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/LLVM-11.0.1-win64.exe#/dl.7z",
+            "hash": "d17bd0e556115c30ff45e30a3f9a623af89ad6a345a5df3ac47aa8b9eabab9a7"
         },
         "32bit": {
-            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win32.exe#/dl.7z",
-            "hash": "4584e589e0633e2f0749d6e38db1ce29e875cc2ce5a8f608c8c5d708d64cfa8a"
+            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/LLVM-11.0.1-win32.exe#/dl.7z",
+            "hash": "76886461d2638ed16625a5e2dee35eae2202814fa9f9d99bd983f12d50f581ae"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse",

--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -66,8 +66,8 @@
         "bin\\wasm-ld.exe"
     ],
     "checkver": {
-        "url": "https://llvm.org/",
-        "regex": "([\\d.]+):"
+        "github": "https://github.com/llvm/llvm-project",
+        "regex": "tag/llvmorg-([\\d._]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/releases/latest

LLVM is quite possibly now that they have completed a move to GitHub are not maintaining their website.

LLVM 11.0.1 while is listed as a release on GitHub Releases, is not listed as a release on their website

Since they are using GitHub releases, I think it would be best to update the project via GitHub Releases as well.