### PR TITLE
Add mob 1.1.0

### DIFF
--- a/bucket/mob.json
+++ b/bucket/mob.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.1.0",
+    "description": "Swift git handover with mob",
+    "homepage": "https://mob.sh",
+    "license": "MIT",
+    "url": "https://github.com/remotemobprogramming/mob/releases/download/v1.1.0/mob_v1.1.0_windows_amd64.tar.gz",
+    "hash": "md5:f6655da1ac933b326d8155f6cdad911a",
+    "bin": "mob.exe",
+    "checkver": {
+        "github": "https://github.com/remotemobprogramming/mob"
+    },
+    "autoupdate": {
+        "url": "https://github.com/remotemobprogramming/mob/releases/download/v$version/mob_v$version_windows_amd64.tar.gz",
+        "hash": {
+            "url": "$baseurl/mob_v$version_windows_amd64_checksum.txt"
+        }
+    }
+}


### PR DESCRIPTION
Adds [mob](https://github.com/remotemobprogramming/mob) to scoop. 

Mob is a tool for fast git handover while mob programming.
I hope I included everything which is needed. I also verified that autoupdate works using `checkver.ps1`
In case something is off, let me know. 