### PR TITLE
Updated heimdal to 7.7.0-2

### DIFF
--- a/bucket/openssh.json
+++ b/bucket/openssh.json
@@ -8,8 +8,8 @@
             "url": [
                 "http://repo.msys2.org/msys/x86_64/bash-4.4.023-2-x86_64.pkg.tar.xz",
                 "http://repo.msys2.org/msys/x86_64/gcc-libs-9.3.0-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/heimdal-7.7.0-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/heimdal-libs-7.7.0-1-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/heimdal-7.7.0-2-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/heimdal-libs-7.7.0-2-x86_64.pkg.tar.xz",
                 "http://repo.msys2.org/msys/x86_64/libcrypt-2.1-2-x86_64.pkg.tar.xz",
                 "http://repo.msys2.org/msys/x86_64/libdb-5.3.28-2-x86_64.pkg.tar.xz",
                 "http://repo.msys2.org/msys/x86_64/libedit-20191231_3.1-1-x86_64.pkg.tar.xz",
@@ -24,8 +24,8 @@
             "hash": [
                 "ed17af38e37e0790b467b9887b98bdfb4c711279d067a34b440cdb583ebc12ea",
                 "79a74bb1ef1d7f4eb12f7437ac24371ec9e41a3d96b653a2ec7f09d1e7aa9c63",
-                "78b685b9cc163469252f6faa81c74f6ab64090b3f6d2eb03938eab0cc6d3c1c9",
-                "114c94f89bf55676c8fcbf20dafd427815d4a9039f643de93e0b7bc14c333d35",
+                "e64fcf00ddd4158ac56dc3b282698d616bedeece3466376bc03ff61f09a0c044",
+                "eda2132707ef438db009613c011b47217cb00ee4d4a28ad4f6cb10ad1845f74e",
                 "333b5089ea0d27c167e7bcf786bf0ceb2192d76c18f338379d771adda18bda3e",
                 "2e96a2883d56a3909938ac160c2922e30cd7edb1fe733b8452bb24fbf7ec09a7",
                 "236bedb6a8a90c0ecb70c1bc9c90ccd347f2f1ae96df11aa9af8e6878a606fe3",


### PR DESCRIPTION
Updated heimdal and heimdal-libs from 7.7.0-1 to 7.7.0-2

Fixing:
```
The remote server returned an error: (404) Not Found.
URL http://repo.msys2.org/msys/x86_64/heimdal-7.7.0-1-x86_64.pkg.tar.xz is not valid
```