### PR TITLE
Add AWS SAM CLI

### DIFF
--- a/bucket/aws-sam.json
+++ b/bucket/aws-sam.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.15.0",
+    "description": "The AWS SAM CLI is a command line tool that operates on an AWS SAM template and application code. With the AWS SAM CLI, you can invoke Lambda functions locally, create a deployment package for your serverless application, deploy your serverless application to the AWS Cloud, and so on.",
+    "homepage": "https://aws.amazon.com/serverless/sam/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "AWS CLI": "aws"
+    },
+    "url": "https://github.com/aws/aws-sam-cli/releases/download/v1.15.0/AWS_SAM_CLI_64_PY3.msi",
+    "hash": "6f9f3e078d51f7d411f37e9dead90cae339b50d0c782af821ce5877876ab8c29",
+    "extract_dir": "Amazon\\AWSSAMCLI",
+    "bin": "bin\\sam.cmd",
+    "checkver": {
+        "github": "https://github.com/aws/aws-sam-cli"
+    },
+    "autoupdate": {
+        "url": "https://github.com/aws/aws-sam-cli/releases/download/v$version/AWS_SAM_CLI_64_PY3.msi"
+    }
+}


### PR DESCRIPTION
The AWS SAM CLI is a command line tool that operates on an AWS SAM template and application code. With the AWS SAM CLI, you can invoke Lambda functions locally, create a deployment package for your serverless application, deploy your serverless application to the AWS Cloud, and so on.

Description from [here](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-reference.html#serverless-sam-cli)

