### PR TITLE
adjust env_add_path field to solve some problems.

### DIFF
--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -17,7 +17,7 @@
         }
     },
     "bin": "dotnet.exe",
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "env_set": {
         "DOTNET_ROOT": "$dir",
         "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"

--- a/bucket/gitui.json
+++ b/bucket/gitui.json
@@ -6,7 +6,7 @@
     "depends": "git",
     "url": "https://github.com/extrawurst/gitui/releases/download/v0.11.0/gitui-win.tar.gz",
     "hash": "08ceab5041ac4052807127ab3ad76437b84093d64d30fa98f9103ca42ebf868c",
-    "extract_dir": ".",
+    "extract_dir": "\\",
     "bin": "gitui.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/gerardog/gsudo/releases/download/v0.7.3/gsudo.v0.7.3.zip",
     "hash": "a663510ff1754d20504ba989622a7a6077b435ecc17f361b3003a393fc98c191",
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "bin": [
         [
             "gsudo.exe",

--- a/bucket/haxe-dev.json
+++ b/bucket/haxe-dev.json
@@ -28,7 +28,7 @@
     "env_set": {
         "HAXEPATH": "$dir"
     },
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "persist": "lib",
     "checkver": {
         "url": "https://github.com/HaxeFoundation/haxe/releases",

--- a/bucket/haxe.json
+++ b/bucket/haxe.json
@@ -28,7 +28,7 @@
     "env_set": {
         "HAXEPATH": "$dir"
     },
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "persist": "lib",
     "checkver": {
         "github": "https://github.com/HaxeFoundation/haxe"

--- a/bucket/invoke-build.json
+++ b/bucket/invoke-build.json
@@ -6,7 +6,7 @@
     "url": "https://nuget.org/api/v2/package/Invoke-Build/5.6.5#/dl.7z",
     "hash": "14691eb3a5ecd65f636aa3824fead5d8db8642fcbfbf8e04c75c7efc9f03415b",
     "extract_dir": "tools",
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "checkver": {
         "url": "https://github.com/nightroman/Invoke-Build/releases",
         "regex": "releases/tag/v([\\d.]+)"

--- a/bucket/msmpi.json
+++ b/bucket/msmpi.json
@@ -28,7 +28,7 @@
         "Remove-Item -Recurse \"$dir\\tmp\"",
         "Remove-Item \"$dir\\msmpisetup.exe\""
     ],
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "checkver": {
         "github": "https://github.com/Microsoft/Microsoft-MPI"
     },

--- a/bucket/neko.json
+++ b/bucket/neko.json
@@ -21,7 +21,7 @@
         "nekoml.exe",
         "nekotools.exe"
     ],
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "env_set": {
         "NEKO_INSTPATH": "$dir"
     },

--- a/bucket/node-chakracore.json
+++ b/bucket/node-chakracore.json
@@ -21,7 +21,7 @@
     ],
     "env_add_path": [
         "bin",
-        "."
+        "\\"
     ],
     "persist": [
         "bin",

--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -21,7 +21,7 @@
     ],
     "env_add_path": [
         "bin",
-        "."
+        "\\"
     ],
     "post_install": [
         "# Set npm prefix to install modules inside bin and npm cache so they persist",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -21,7 +21,7 @@
     ],
     "env_add_path": [
         "bin",
-        "."
+        "\\"
     ],
     "post_install": [
         "# Set npm prefix to install modules inside bin and npm cache so they persist",

--- a/bucket/openssl-mingw.json
+++ b/bucket/openssl-mingw.json
@@ -16,7 +16,7 @@
         }
     },
     "bin": "openssl.exe",
-    "env_add_path": ".",
+    "env_add_path": "\\",
     "env_set": {
         "OPENSSL_CONF": "$dir\\openssl.cnf"
     },

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -81,7 +81,7 @@
     ],
     "env_add_path": [
         "Scripts",
-        "."
+        "\\"
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",

--- a/bucket/unxutils.json
+++ b/bucket/unxutils.json
@@ -12,7 +12,7 @@
         "3f442b5d2a84cf112f3688ef21ab7cf8be0a905529e90fd33ec2370d3e263f80"
     ],
     "extract_to": [
-        ".",
+        "\\",
         "usr\\local\\wbin"
     ],
     "bin": [


### PR DESCRIPTION
duplicate paths when use dot(.) to point to the app directory.

but using \ does not have the problem.

example ( python / pycharm)
before:
https://imgur.com/47LjPSn
after:
https://imgur.com/yiBTYHy
