### PR TITLE
Add aws_completer.exe into the path

### DIFF
--- a/bucket/aws.json
+++ b/bucket/aws.json
@@ -10,7 +10,7 @@
         }
     },
     "extract_dir": "Amazon\\AWSCLIV2",
-    "bin": "aws.exe",
+    "bin": [ "aws.exe", "aws_completer.exe" ]
     "checkver": {
         "url": "https://api.github.com/repos/aws/aws-cli/tags",
         "jsonpath": "$[0].name"


### PR DESCRIPTION
Enable aws_completer as a binary to add to the path to support tooling that enables auto completion on the command line.