### PR TITLE
Make Codecs persist in 7zip

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -24,6 +24,7 @@
             "7-Zip"
         ]
     ],
+    "persist": "Codecs",
     "checkver": {
         "url": "https://www.7-zip.org/download.html",
         "regex": "Download 7-Zip ([\\d.]+)"


### PR DESCRIPTION
According to `CPP/7zip/UI/Common/LoadCodecs.cpp` in source of 7zip:

>   CCodecs::Load() tries to detect the directory with plugins.
>  It stops the checking, if it can find any of the following items:
>    - 7z.dll file
>    - "Formats" subdir
>    - "Codecs"  subdir

It seems useful that a plugin folder "Codecs" persists.