### PR TITLE
nheko: Add version 0.8.1

### DIFF
--- a/bucket/nheko.json
+++ b/bucket/nheko.json
@@ -1,0 +1,41 @@
+{
+    "version": "0.8.1",
+    "description": "Desktop client for Matrix using Qt and C++17.",
+    "homepage": "https://nheko-reborn.github.io/",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Nheko-Reborn/nheko/releases/download/v0.8.1/nheko-v0.8.1-installer.exe",
+            "hash": "9ec1d97a37ddee9ab4426632bc3d746586489b481afa37627750a0dfd449a2d9"
+        }
+    },
+    "installer": {
+        "args": [
+            "install",
+            "--root",
+            "$original_dir",
+            "--confirm-command",
+            "--accept-licenses",
+            "--auto-answer",
+            "OverwriteTargetDirectory=Yes"
+        ]
+    },
+    "uninstaller": {
+        "file": "maintenancetool.exe",
+        "args": [
+            "purge",
+            "--confirm-command"
+        ]
+    },
+    "bin": "nheko.exe",
+    "checkver": {
+        "github": "https://github.com/Nheko-Reborn/nheko"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Nheko-Reborn/nheko/releases/download/v$version/nheko-v$version-installer.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
*IMPORTANT* This is still incomplete because I wanted to ask some questions.
I didn't find any example of qt installer framework and I could not disable the operations that create the shortcuts, do you have any idea on how to do it? Maybe I could add a post install to delete the shortcuts and allow scoop to create its own shortcuts that point to the right paths.