### PR TITLE
Update tre-command to 0.3.4

### DIFF
--- a/bucket/tre-command.json
+++ b/bucket/tre-command.json
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dduan/tre/releases/download/v0.3.3/tre-v0.3.3-x86_64-pc-windows-msvc.zip",
-            "hash": "14003404f94da3bd9b5a42e7ce065258e67ba983e238ab781f3cd5a2d541fcfb"
+            "url": "https://github.com/dduan/tre/releases/download/v0.3.4/tre-v0.3.4-x86_64-pc-windows-msvc.zip",
+            "hash": "ee189250021f7b9545f078c40e9b0fc9bd5ad1ea919c0adceb9eefcfbc0c4866"
         },
         "32bit": {
-            "url": "https://github.com/dduan/tre/releases/download/v0.3.3/tre-v0.3.3-i686-pc-windows-msvc.zip",
-            "hash": "1da924695fddfdba70f948e2d2103e9c9ffd649a6ddec4a88c7068f056c1ad36"
+            "url": "https://github.com/dduan/tre/releases/download/v0.3.4/tre-v0.3.4-i686-pc-windows-msvc.zip",
+            "hash": "c484be9418573d1bad7482a887a0ea2b1c730340ab008e1b7ebf9abe686aef52"
         }
     },
     "bin": "tre.exe",


### PR DESCRIPTION
Release note: https://github.com/dduan/tre/releases/tag/v0.3.4