### PR TITLE
Bump poppler version to 21.02.0

### DIFF
--- a/bucket/poppler.json
+++ b/bucket/poppler.json
@@ -1,15 +1,15 @@
 {
-    "version": "21.01.0",
+    "version": "21.02.0",
     "description": "PDF rendering library",
     "homepage": "https://github.com/oschwartz10612/poppler-windows",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oschwartz10612/poppler-windows/releases/download/v21.01.0/Release-21.01.0.zip",
-            "hash": "a70d51d7f1fa26dd9a25aaecb67e0f15dbd7460e4510167a7dc863956d632849"
+            "url": "https://github.com/oschwartz10612/poppler-windows/releases/download/v20.02.0/Release-21.02.0.zip",
+            "hash": "d3797a22afec34128c9b2ef29e861e65bd16d8e81b5ae32d3dd268c82480b508"
         }
     },
-    "extract_dir": "poppler-21.01.0\\Library",
+    "extract_dir": "poppler-21.02.0\\Library",
     "bin": [
         "bin\\pdfattach.exe",
         "bin\\pdfdetach.exe",


### PR DESCRIPTION
This also fixes #1833 #1819 and makes #1820 not needed anymore