### PR TITLE
Add PG_LIB_DIR and PG_INCLUDE_DIR env vars

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -28,7 +28,9 @@
     ],
     "env_add_path": "bin",
     "env_set": {
-        "PGDATA": "$dir\\data"
+        "PGDATA": "$dir\\data",
+        "PG_LIB_DIR": "$dir\\lib",
+        "PG_INCLUDE_DIR": "$dir\\include"
     },
     "persist": "data",
     "checkver": {


### PR DESCRIPTION
On most linux distros, you can just install postgresql-dev from whatever package manager.

This PR hopes to replicate that process but for Windows instead, as I believe Scoop can really pave the way for Windows development.

The new env variables provded:
* PG_LIB_DIR
* PG_INCLUDE_DIR