### PR TITLE
Update nano.json to include `pkg_` prefix in path

### DIFF
--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -20,10 +20,10 @@
     },
     "architecture": {
         "64bit": {
-            "bin": "x86_64-w64-mingw32\\bin\\nano.exe"
+            "bin": "pkg-x86_64-w64-mingw32\\bin\\nano.exe"
         },
         "32bit": {
-            "bin": "i686-w64-mingw32\\bin\\nano.exe"
+            "bin": "pkg-i686-w64-mingw32\\bin\\nano.exe"
         }
     },
     "autoupdate": {

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -20,10 +20,10 @@
     },
     "architecture": {
         "64bit": {
-            "bin": "pkg-x86_64-w64-mingw32\\bin\\nano.exe"
+            "bin": "pkg_x86_64-w64-mingw32\\bin\\nano.exe"
         },
         "32bit": {
-            "bin": "pkg-i686-w64-mingw32\\bin\\nano.exe"
+            "bin": "pkg_i686-w64-mingw32\\bin\\nano.exe"
         }
     },
     "autoupdate": {


### PR DESCRIPTION
Get the following when attempting `scoop install nano`:

```
Installing 'nano' (5.6.1-7) [64bit]
nano-win_9513_v5.6.1-7-g1dab3b87.7z (574.8 KB) [===================================================================================================================] 100%
Checking hash of nano-win_9513_v5.6.1-7-g1dab3b87.7z ... ok.
Extracting nano-win_9513_v5.6.1-7-g1dab3b87.7z ... done.
Linking ~\scoop\apps\nano\current => ~\scoop\apps\nano\5.6.1-7
Creating shim for 'nano'.
Can't shim 'x86_64-w64-mingw32\bin\nano.exe': File doesn't exist.
```

I then did `ls .\scoop\apps\nano\5.6.1-7\` which showed:

```
    Directory: C:\Users\User\scoop\apps\nano\5.6.1-7

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d----          16/03/2021    17:48                pkg_i686-w64-mingw32
d----          16/03/2021    17:48                pkg_x86_64-w64-mingw32
-a---          11/03/2021    02:08          10194 .nanorc
```