### PR TITLE
Updated AVR-GCC to version 10.2.0-1

### DIFF
--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -47,7 +47,10 @@
         "bin\\avr-strings.exe",
         "bin\\avr-strip.exe"
     ],
-    "checkver": "avr-gcc ([\\d.]+)",
+    "checkver": {
+        "url": "https://www.lumito.net/lumito-avr-gcc-releases",
+        "regex": "Latest release: avr-gcc ([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -1,18 +1,18 @@
 {
-    "version": "10.2.0-1",
+    "version": "10.2.0.1",
     "description": "AVR toolchain for Windows by Lumito (based on Zak Kemble's one)",
     "homepage": "https://www.lumito.net/lumito-avr-gcc-releases",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://dl.lumito.net/public/projects/avr-gcc/10.2.0-1/avr-gcc-10.2.0-1-x64-windows.7z",
-            "hash": "5b0ffeca1143be230f9e85594e84d7c1a8c316ac252018f9f5a61fb362257057",
-            "extract_dir": "avr-gcc-10.2.0-1-x64-windows"
+            "url": "https://dl.lumito.net/public/projects/avr-gcc/10.2.0.1/avr-gcc-10.2.0.1-x64-windows.7z",
+            "hash": "b3b87d81f10370ad6ce9bef1f519c7aa3457d309b79fa4157710a9a6b9916506",
+            "extract_dir": "avr-gcc-10.2.0.1-x64-windows"
         },
         "32bit": {
-            "url": "https://dl.lumito.net/public/projects/avr-gcc/10.2.0-1/avr-gcc-10.2.0-1-x86-windows.7z",
-            "hash": "11ddd5f4a5a74658f96ece2e5ff8748f4b512d9c669baa51925c04112f73687c",
-            "extract_dir": "avr-gcc-10.2.0-1-x86-windows"
+            "url": "https://dl.lumito.net/public/projects/avr-gcc/10.2.0.1/avr-gcc-10.2.0.1-x86-windows.7z",
+            "hash": "e615b3fa0c823c484821db425af67badf3d3c20e78cfb65a1da66706e2acff43",
+            "extract_dir": "avr-gcc-10.2.0.1-x86-windows"
         }
     },
     "bin": [
@@ -47,10 +47,7 @@
         "bin\\avr-strings.exe",
         "bin\\avr-strip.exe"
     ],
-    "checkver": {
-        "url": "https://www.lumito.net/lumito-avr-gcc-releases",
-        "regex": "Latest release: avr-gcc ([\\d.]+)"
-    },
+    "checkver": "avr-gcc ([\\d.]+)",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -37,7 +37,6 @@
         "bin\\avr-ld.bfd.exe",
         "bin\\avr-ld.exe",
         "bin\\avr-lto-dump.exe",
-        "bin\\avr-man",
         "bin\\avr-nm.exe",
         "bin\\avr-objcopy.exe",
         "bin\\avr-objdump.exe",

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -1,7 +1,7 @@
 {
     "version": "10.2.0.1",
     "description": "AVR toolchain for Windows by Lumito (based on Zak Kemble's one)",
-    "homepage": "https://www.lumito.net/lumito-avr-gcc-releases",
+    "homepage": "https://www.lumito.net/2021/03/20/lumito-avr-gcc-releases/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -47,6 +47,10 @@
         "bin\\avr-strings.exe",
         "bin\\avr-strip.exe"
     ],
+    "checkver": {
+        "url": "https://dl.lumito.net/public/projects/avr-gcc",
+        "regex": "([\\d.]+)"
+    },
     "checkver": "avr-gcc ([\\d.]+)",
     "autoupdate": {
         "architecture": {

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -37,7 +37,7 @@
         "bin\\avr-ld.bfd.exe",
         "bin\\avr-ld.exe",
         "bin\\avr-lto-dump.exe",
-        "bin\\avr-man"
+        "bin\\avr-man",
         "bin\\avr-nm.exe",
         "bin\\avr-objcopy.exe",
         "bin\\avr-objdump.exe",

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -47,19 +47,15 @@
         "bin\\avr-strings.exe",
         "bin\\avr-strip.exe"
     ],
-    "checkver": {
-        "url": "https://dl.lumito.net/public/projects/avr-gcc",
-        "regex": "([\\d.]+)"
-    },
     "checkver": "avr-gcc ([\\d.]+)",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.lumito.net/public/projects/avr-gcc/latest/avr-gcc-$version-x64-windows.7z",
+                "url": "https://dl.lumito.net/public/projects/avr-gcc/$version/avr-gcc-$version-x64-windows.7z",
                 "extract_dir": "avr-gcc-$version-x64-windows"
             },
             "32bit": {
-                "url": "https://dl.lumito.net/public/projects/avr-gcc/latest/avr-gcc-$version-x86-windows.7z",
+                "url": "https://dl.lumito.net/public/projects/avr-gcc/$version/avr-gcc-$version-x86-windows.7z",
                 "extract_dir": "avr-gcc-$version-x86-windows"
             }
         }

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -1,18 +1,18 @@
 {
-    "version": "10.2.0",
+    "version": "10.2.0-1",
     "description": "AVR toolchain for Windows by Lumito (based on Zak Kemble's one)",
-    "homepage": "https://www.lumito.net/2020/11/02/released-avr-gcc-10-2-0/",
+    "homepage": "https://www.lumito.net/lumito-avr-gcc-releases",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/10.2.0/avr-gcc-10.2.0-x64-windows.7z",
-            "hash": "c72e1adf1ac2d79766e2eb4b7316bf8232335b0be6cdb1c04395d943d702f15e",
-            "extract_dir": "avr-gcc-10.2.0-x64-windows"
+            "url": "https://dl.lumito.net/public/projects/avr-gcc/10.2.0-1/avr-gcc-10.2.0-1-x64-windows.7z",
+            "hash": "5b0ffeca1143be230f9e85594e84d7c1a8c316ac252018f9f5a61fb362257057",
+            "extract_dir": "avr-gcc-10.2.0-1-x64-windows"
         },
         "32bit": {
-            "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/10.2.0/avr-gcc-10.2.0-x86-windows.7z",
-            "hash": "01c97759ced85b8a23d511dfef6554d6e64806a10de3bd2034629a67b5feb068",
-            "extract_dir": "avr-gcc-10.2.0-x86-windows"
+            "url": "https://dl.lumito.net/public/projects/avr-gcc/10.2.0-1/avr-gcc-10.2.0-1-x86-windows.7z",
+            "hash": "11ddd5f4a5a74658f96ece2e5ff8748f4b512d9c669baa51925c04112f73687c",
+            "extract_dir": "avr-gcc-10.2.0-1-x86-windows"
         }
     },
     "bin": [
@@ -37,6 +37,7 @@
         "bin\\avr-ld.bfd.exe",
         "bin\\avr-ld.exe",
         "bin\\avr-lto-dump.exe",
+        "bin\\avr-man"
         "bin\\avr-nm.exe",
         "bin\\avr-objcopy.exe",
         "bin\\avr-objdump.exe",
@@ -51,11 +52,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/$version/avr-gcc-$version-x64-windows.7z",
+                "url": "https://dl.lumito.net/public/projects/avr-gcc/latest/avr-gcc-$version-x64-windows.7z",
                 "extract_dir": "avr-gcc-$version-x64-windows"
             },
             "32bit": {
-                "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/$version/avr-gcc-$version-x86-windows.7z",
+                "url": "https://dl.lumito.net/public/projects/avr-gcc/latest/avr-gcc-$version-x86-windows.7z",
                 "extract_dir": "avr-gcc-$version-x86-windows"
             }
         }


### PR DESCRIPTION
Changes from previous release: https://www.lumito.net/2021/03/20/released-avr-gcc-10-2-0-1/

Also, this release does not use Bintray. It downloads the files from my server.