### PR TITLE
nano: fix shim

### DIFF
--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -20,10 +20,10 @@
     },
     "architecture": {
         "64bit": {
-            "bin": "x86_64-w64-mingw32\\bin\\nano.exe"
+            "bin": "pkg_x86_64-w64-mingw32\\bin\\nano.exe"
         },
         "32bit": {
-            "bin": "i686-w64-mingw32\\bin\\nano.exe"
+            "bin": "pkg_i686-w64-mingw32\\bin\\nano.exe"
         }
     },
     "autoupdate": {


### PR DESCRIPTION
Looks like the upstream packager changed the names of the folder structure in their zip, this fixes it so it will install with Scoop.