### PR TITLE
Update to latest QEMU installer to fix firmware file lookup issues

### DIFF
--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -5,8 +5,8 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://qemu.weilnetz.de/w64/2021/qemu-w64-setup-20210203.exe#/dl.7z",
-            "hash": "sha512:f93423fb42086fbd770bb8dee4e8fdaaaef46bdea178fb4407823d0a8463ad06eac07d2f7894e301dcf80a2d2eb25204c9f48b05d475ef0b56dad27e6b3565e0"
+            "url": "https://qemu.weilnetz.de/w64/2021/qemu-w64-setup-20210208.exe#/dl.7z",
+            "hash": "sha512:175a1a35ccf53503a579cc905b42f401496016aa7bccf573339ce90d24dfb64022fa8d9bd6f6cb68acb6e150b364c63c23b95022a1168e813c6b50cb36ad20dc"
         },
         "32bit": {
             "url": "https://qemu.weilnetz.de/w32/2021/qemu-w32-setup-20210203.exe#/dl.7z",


### PR DESCRIPTION
This should include a fix for https://bugs.launchpad.net/qemu/+bug/1915794