### PR TITLE
Add go-task

### DIFF
--- a/bucket/go-task.json
+++ b/bucket/go-task.json
@@ -1,0 +1,33 @@
+{
+    "version": "3.3.0",
+    "description": "A task runner / simpler Make alternative written in Go",
+    "homepage": "https://taskfile.dev/",
+    "license": "MIT",
+    "bin": "task.exe",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/go-task/task/releases/download/v3.3.0/task_windows_386.zip",
+            "hash": "a80e006338cda9bbca74b384520275055a0533cd5b3813656bdf3f6553e12540"
+        },
+        "64bit": {
+            "url": "https://github.com/go-task/task/releases/download/v3.3.0/task_windows_amd64.zip",
+            "hash": "a47f3e3e923b4f9093c131492c8edb61daa8fc09ab152fc5a21f049affd6b79d"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/go-task/task/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/go-task/task/releases/download/v$version/task_windows_386.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/go-task/task/releases/download/v$version/task_windows_amd64.zip"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
+    }
+}


### PR DESCRIPTION
Go task is a task runner (like Make or Ant) written in golang.

It's power comes from being fast and lightweight (one 2MB exe file) which even embeds a light shell runner.

Regarding [the criteria for inclussion in the main bucket](https://github.com/lukesampson/scoop/wiki/Criteria-for-including-apps-in-the-main-bucket):

- go-task has 3.2k stars in github,199 forks and 54 contributors. I do not know if that qualifies for "widely used".
- the manifest points to the latest version and includes autoupdate
- it is the full version (open source project)
- install is fairly standard (unzip)
- it is not a GUI tool

A side of those official criteria, I'd add that it is a quite active project. It is my tool of choice for replacing Makefiles on every platform (it's golang, runs everywhere).

If it would be better to submit to the extras bucket just let me know

marc