### PR TITLE
coq: Add coqidetop.opt.exe shim

### DIFF
--- a/bucket/coq.json
+++ b/bucket/coq.json
@@ -13,7 +13,8 @@
     "bin": [
         "bin\\coqtop.exe",
         "bin\\coqc.exe",
-        "bin\\coqchk.exe"
+        "bin\\coqchk.exe",
+        "bin\\coqidetop.opt.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
For VSCode's plugin VSCoq support. Fixes #1716