### PR TITLE
Fix mtn v3.4 extract_dir

### DIFF
--- a/bucket/mtn.json
+++ b/bucket/mtn.json
@@ -8,7 +8,7 @@
     },
     "url": "https://bitbucket.org/wahibre/mtn/downloads/mtn-3.4.0-win32.zip",
     "hash": "006c4c5999035d49a54ba5115f2f153080483605cb3f34edb8c276e68d996886",
-    "extract_dir": "mtn-3.4",
+    "extract_dir": "mtn-win32",
     "bin": "bin\\mtn.exe",
     "checkver": {
         "url": "https://bitbucket.org/wahibre/mtn/downloads/?tab=downloads",


### PR DESCRIPTION
The folder structure for 3.4 if different so the installation breaks