### PR TITLE
android-clt: Fix command path error

### DIFF
--- a/bucket/android-clt.json
+++ b/bucket/android-clt.json
@@ -14,7 +14,7 @@
         "    New-Item \"$dir\\platform-tools\" -ItemType Junction -Target \"$(appdir adb $global)\\current\\platform-tools\" | Out-Null",
         "}"
     ],
-    "env_add_path": "tools\\bin",
+    "env_add_path": "cmdline-tools\\bin",
     "env_set": {
         "ANDROID_SDK_ROOT": "$dir"
     },


### PR DESCRIPTION
In current version, command tools directory is change to `cmdline-tools\bin`