### PR TITLE
Add postinstall to deno

### DIFF
--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -10,6 +10,7 @@
         }
     },
     "bin": "deno.exe",
+    "post_install": ["deno upgrade"],
     "checkver": {
         "github": "https://github.com/denoland/deno"
     },


### PR DESCRIPTION
Deno has it's own way of updating, it runs a command `deno upgrade`, so I made a postinstall to automatically run this.
Because update uninstall then reinstalls the app, this will be effective.