### PR TITLE
go-jsonnet: Add version 0.17.0

### DIFF
--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.17.0",
+    "description": "A data templating language for app and tool developers",
+    "homepage": "https://github.com/google/go-jsonnet",
+    "license": "Apache-2.0",
+    "architecture" : {
+        "64bit": {
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
+            "hash": "d4d56a4e81752b53b301d92066678d036571224383da268896149c087e5a3c03",
+            "extract_dir": "go-jsonnet_0.17.0_Windows_x86_64"
+        }
+    },
+    "bin": [
+        "jsonnet.exe",
+        "jsonnetfmt.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz",
+                "extract_dir": "go-jsonnet_$version_Windows_x86_64"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Moved from scoop-extras to main bucket as instructed in https://github.com/lukesampson/scoop-extras/pull/5957