### PR TITLE
android-clt: Update tools path

### DIFF
--- a/bucket/android-clt.json
+++ b/bucket/android-clt.json
@@ -14,7 +14,7 @@
         "    New-Item \"$dir\\platform-tools\" -ItemType Junction -Target \"$(appdir adb $global)\\current\\platform-tools\" | Out-Null",
         "}"
     ],
-    "env_add_path": "tools\\bin",
+    "env_add_path": "cmdline-tools\\bin",
     "env_set": {
         "ANDROID_SDK_ROOT": "$dir"
     },


### PR DESCRIPTION
The path to bin has changed:

![image](https://user-images.githubusercontent.com/4580066/114733948-11637600-9d44-11eb-8322-d81ac11f00c3.png)
