### PR TITLE
Set working directory to $HOME in pwsh post-install

### DIFF
--- a/bucket/pwsh.json
+++ b/bucket/pwsh.json
@@ -20,6 +20,13 @@
             "PowerShell Core"
         ]
     ],
+     "post_install": [
+        "$shell=new-object -com wscript.shell",
+        "$path=$env:appdata+'/Microsoft/Windows/Start Menu/Programs/Scoop Apps/PowerShell Core.lnk'",
+        "$s=$shell.createshortcut($path)",
+        "$s.workingdirectory=$HOME",
+        "$s.save()"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
In the post-install script, set the WorkingDirectory property of the default start menu shortcut to point to $HOME.