### PR TITLE
rink: Add version 0.6.1

### DIFF
--- a/bucket/rink.json
+++ b/bucket/rink.json
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/merklecounty/rget/releases/download/v$version/Rink.CLI.Windows.zip",
+                "url": "https://github.com/tiffany352/rink-rs/releases/download/v$version/Rink.CLI.Windows.zip",
                 "hash": {
                     "url": "$baseurl/SHA256SUMS"
                 }

--- a/bucket/rink.json
+++ b/bucket/rink.json
@@ -14,10 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/tiffany352/rink-rs/releases/download/v$version/Rink.CLI.Windows.zip",
-                "hash": {
-                    "url": "$baseurl/SHA256SUMS"
-                }
+                "url": "https://github.com/tiffany352/rink-rs/releases/download/v$version/Rink.CLI.Windows.zip"
             }
         }
     }

--- a/bucket/rink.json
+++ b/bucket/rink.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.6.1",
+    "description": "A tool for unit conversions, calculations, and dimensionality analysis",
+    "homepage": "https://github.com/tiffany352/rink-rs",
+    "license": "MPL-2.0 AND GPL-3.0+",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tiffany352/rink-rs/releases/download/v0.6.1/Rink.CLI.Windows.zip",
+            "hash": "d54a71da9d6b5b0762dbeb2780b56b9ae68b6e9c2ced1e0e4fb477f3cc1e03e7"
+        }
+    },
+    "bin": "rink.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/merklecounty/rget/releases/download/v$version/Rink.CLI.Windows.zip",
+                "hash": {
+                    "url": "$baseurl/SHA256SUMS"
+                }
+            }
+        }
+    }
+}

--- a/bucket/rink.json
+++ b/bucket/rink.json
@@ -2,7 +2,7 @@
     "version": "0.6.1",
     "description": "A tool for unit conversions, calculations, and dimensionality analysis",
     "homepage": "https://github.com/tiffany352/rink-rs",
-    "license": "MPL-2.0 AND GPL-3.0+",
+    "license": "MPL-2.0,GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/tiffany352/rink-rs/releases/download/v0.6.1/Rink.CLI.Windows.zip",


### PR DESCRIPTION
Version 0.6.1, which is the latest version.

https://github.com/tiffany352/rink-rs

([taken from the criteria list](https://github.com/lukesampson/scoop/wiki/Criteria-for-including-apps-in-the-main-bucket))
- [x] a reasonably well-known and widely used developer tool — 5.7k downloads via crates.io, packaged on Arch Linux and nixOS
- [x] the latest stable version of the program
- [x] the full version i.e. not a trial version
- [x] a fairly standard install (e.g. uses a version-specific download URL, no elaborate pre/post install scripts) — zip file via GitHub releases containing 64bit exe
- [x] a non-GUI tool
