### PR TITLE
Update PyPy2 and PyPy3

### DIFF
--- a/bucket/pypy2.json
+++ b/bucket/pypy2.json
@@ -1,11 +1,11 @@
 {
-    "version": "7.3.3",
+    "version": "7.3.4",
     "description": "A fast, compliant alternative implementation of the Python language.",
     "homepage": "https://www.pypy.org",
     "license": "MIT",
-    "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.3-win32.zip",
-    "hash": "b3e660dae8d25d8278fd6a0db77e76a16ac9a8c1dca22e7e103d39ed696dc69e",
-    "extract_dir": "pypy2.7-v7.3.3-win32",
+    "url": "https://downloads.python.org/pypy/pypy2.7-v7.3.4-win64.zip",
+    "hash": "1080012d7a3cea65182528259b51d52b1f61a3717377c2d9ba11ef36e06162d5",
+    "extract_dir": "pypy2.7-v7.3.4-win64",
     "bin": [
         "pypy.exe",
         "pypyw.exe"
@@ -15,10 +15,10 @@
         "regex": "pypy(?<py>2[\\d.]+)-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://downloads.python.org/pypy/pypy$matchPy-v$version-win32.zip",
+        "url": "https://downloads.python.org/pypy/pypy$matchPy-v$version-win64.zip",
         "hash": {
             "url": "https://www.pypy.org/download.html"
         },
-        "extract_dir": "pypy$matchPy-v$version-win32"
+        "extract_dir": "pypy$matchPy-v$version-win64"
     }
 }

--- a/bucket/pypy3.json
+++ b/bucket/pypy3.json
@@ -1,11 +1,11 @@
 {
-    "version": "7.3.3",
+    "version": "7.3.4",
     "description": "A fast, compliant alternative implementation of the Python language.",
     "homepage": "https://www.pypy.org",
     "license": "MIT",
-    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
-    "hash": "a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649",
-    "extract_dir": "pypy3.7-v7.3.3-win32",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.4-win64.zip",
+    "hash": "0ff4e4653f1ff0653f105680eb101c64c857fa8f828a54a61b02f65c94b5d262",
+    "extract_dir": "pypy3.7-v7.3.4-win64",
     "bin": [
         "pypy3.exe",
         "pypy3w.exe"
@@ -15,10 +15,10 @@
         "regex": "pypy(?<py>3[\\d.]+)-v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://downloads.python.org/pypy/pypy$matchPy-v$version-win32.zip",
+        "url": "https://downloads.python.org/pypy/pypy$matchPy-v$version-win64.zip",
         "hash": {
             "url": "https://www.pypy.org/download.html"
         },
-        "extract_dir": "pypy$matchPy-v$version-win32"
+        "extract_dir": "pypy$matchPy-v$version-win64"
     }
 }


### PR DESCRIPTION
Changed manifests to account for 32bit to 64bit change in PyPy release, updated to the latest version.