### PR TITLE
python: persist user installed libs and scripts

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -79,6 +79,10 @@
             "idle3"
         ]
     ],
+    "persist": [
+        "Scripts",
+        "Lib\\site-packages"
+    ],
     "env_add_path": [
         "Scripts",
         "."

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -46,7 +46,7 @@
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\setup.exe\" \"$dir\\_tmp\"",
-            "@('launcher.msi', 'path.msi', 'pip.msi') | ForEach-Object {",
+            "@('path.msi', 'pip.msi') | ForEach-Object {",
             "    Remove-Item \"$dir\\_tmp\\AttachedContainer\\$_\"",
             "}",
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -67,8 +67,6 @@
         ]
     },
     "bin": [
-        "python.exe",
-        "pythonw.exe",
         [
             "python.exe",
             "python3"


### PR DESCRIPTION
This PR add the folders `Scripts` and `Lib\\site-packages` to the list to persist.

Resolve #1680, #772

Overhauls PR #1483