### PR TITLE
Adding Geth (Go Ethereum)

### DIFF
--- a/bucket/geth.json
+++ b/bucket/geth.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.10.3",
+    "description": "Go Ethereum - Official Go implementation of the Ethereum protocol.",
+    "homepage": "https://geth.ethereum.org",
+    "license": "GNU LGPL v3",
+    "architecture": {
+        "64bit": {
+            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.10.3-991384a7.zip",
+            "hash": "md5:e5a30e0fe35242afcf051966b1d3d9d5"
+        },
+        "32bit": {
+            "url": "https://gethstore.blob.core.windows.net/builds/geth-windows-386-1.10.3-991384a7.zip",
+            "hash": "md5:13cd81446cfefc8808f59bdfc3f562ca"
+        }
+    },
+    "bin": [
+        "geth-windows-386-1.10.3-991384a7\\geth.exe"
+    ],
+    "checkver": {
+        "url": "https://geth.ethereum.org/downloads/"
+    }
+}


### PR DESCRIPTION
Introducing geth to scoop.

**Shortname**: geth
**Name**: Go Ethereum
**Version**: 1.10.3
**Publish date**: 05/05/2021
**License**: GNU LGPL v3
**Description**: Official Go implementation of the Ethereum protocol
**Long Description**: 
Go Ethereum is one of the three original implementations (along with C++ and Python) of the Ethereum protocol. It is written in Go, fully open source and licensed under the GNU LGPL v3.

**URL**: [https://geth.ethereum.org](https://geth.ethereum.org)