### PR TITLE
cmder: shortcut to start in home dir (`%USERPROFILE%`)

### DIFF
--- a/bucket/cmder-full.json
+++ b/bucket/cmder-full.json
@@ -14,7 +14,8 @@
     "shortcuts": [
         [
             "Cmder.exe",
-            "Cmder"
+            "Cmder",
+            "/start %USERPROFILE%"
         ]
     ],
     "persist": [

--- a/bucket/cmder.json
+++ b/bucket/cmder.json
@@ -14,7 +14,8 @@
     "shortcuts": [
         [
             "Cmder.exe",
-            "Cmder"
+            "Cmder",
+            "/start %USERPROFILE%"
         ]
     ],
     "persist": [


### PR DESCRIPTION
When launched from the start menu shortcut, cmder starts in
`%SCOOP%\apps\cmder\current`, which is not ideal behaviour for a
terminal program. This patch makes the shortcut always start
in the home directory with the argument '/start'.

When started from the shim or directly, cmder starts in your
current directory anyway, which is expected behaviour. 