### PR TITLE
Add sourcegraph-cli to bucket

### DIFF
--- a/bucket/sourcegraph-cli.json
+++ b/bucket/sourcegraph-cli.json
@@ -1,0 +1,17 @@
+{
+    "version": "3.27.1",
+    "description": "Command line interface to Sourcegraph",
+    "homepage": "https://github.com/sourcegraph/src-cli",
+    "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src_windows_amd64.exe",
+    "hash": "46edfff495948df804cb17e5b93d56388335c15627b472dc3b0d6b89ce67dd11",
+    "bin": [ [ "src_windows_amd64.exe", "src" ] ],
+    "license": "Apache-2.0",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src_windows_amd64.exe",
+        "hash": {
+            "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src-cli_$version_checksums.txt",
+            "regex": "^(\\w+)\\s+src_windows_amd64\\.exe$"
+        }
+    }
+}

--- a/bucket/sourcegraph-cli.json
+++ b/bucket/sourcegraph-cli.json
@@ -1,15 +1,20 @@
 {
-    "version": "3.27.1",
+    "version": "3.34.2",
     "description": "Command line interface to Sourcegraph",
     "homepage": "https://github.com/sourcegraph/src-cli",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src-cli_3.27.1_windows_amd64.tar.gz",
-            "hash": "2478aa8c4e565a3ef786d5ceb5fea28b0d755a71813e13833caf514a5cdf2625"
+            "url": "https://github.com/sourcegraph/src-cli/releases/download/3.34.2/src-cli_3.34.2_windows_amd64.tar.gz",
+            "hash": "13cb8c9383a1bab5c6117fe6e036cd40f612f10d73821b86f386a6cebbc4b1ae"
         }
     },
-    "bin": [ [ "src_windows_amd64.exe", "src" ] ],
+    "bin": [
+        [
+            "src_windows_amd64.exe",
+            "src"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src-cli_$version_windows_amd64.tar.gz",

--- a/bucket/sourcegraph-cli.json
+++ b/bucket/sourcegraph-cli.json
@@ -5,17 +5,17 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src_windows_amd64.exe",
-            "hash": "46edfff495948df804cb17e5b93d56388335c15627b472dc3b0d6b89ce67dd11"
+            "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src-cli_3.27.1_windows_amd64.tar.gz",
+            "hash": "2478aa8c4e565a3ef786d5ceb5fea28b0d755a71813e13833caf514a5cdf2625"
         }
     },
     "bin": [ [ "src_windows_amd64.exe", "src" ] ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src_windows_amd64.exe",
+        "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src-cli_$version_windows_amd64.tar.gz",
         "hash": {
             "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src-cli_$version_checksums.txt",
-            "regex": "^(\\w+)\\s+src_windows_amd64\\.exe$"
+            "regex": "^(\\w+)\\s+src-cli_$version_windows_amd64\\.tar\\.gz$"
         }
     }
 }

--- a/bucket/sourcegraph-cli.json
+++ b/bucket/sourcegraph-cli.json
@@ -9,12 +9,7 @@
             "hash": "13cb8c9383a1bab5c6117fe6e036cd40f612f10d73821b86f386a6cebbc4b1ae"
         }
     },
-    "bin": [
-        [
-            "src_windows_amd64.exe",
-            "src"
-        ]
-    ],
+    "bin": "src.exe",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src-cli_$version_windows_amd64.tar.gz",

--- a/bucket/sourcegraph-cli.json
+++ b/bucket/sourcegraph-cli.json
@@ -2,10 +2,10 @@
     "version": "3.27.1",
     "description": "Command line interface to Sourcegraph",
     "homepage": "https://github.com/sourcegraph/src-cli",
+    "license": "Apache-2.0",
     "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src_windows_amd64.exe",
     "hash": "46edfff495948df804cb17e5b93d56388335c15627b472dc3b0d6b89ce67dd11",
     "bin": [ [ "src_windows_amd64.exe", "src" ] ],
-    "license": "Apache-2.0",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/sourcegraph/src-cli/releases/download/$version/src_windows_amd64.exe",

--- a/bucket/sourcegraph-cli.json
+++ b/bucket/sourcegraph-cli.json
@@ -3,8 +3,12 @@
     "description": "Command line interface to Sourcegraph",
     "homepage": "https://github.com/sourcegraph/src-cli",
     "license": "Apache-2.0",
-    "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src_windows_amd64.exe",
-    "hash": "46edfff495948df804cb17e5b93d56388335c15627b472dc3b0d6b89ce67dd11",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sourcegraph/src-cli/releases/download/3.27.1/src_windows_amd64.exe",
+            "hash": "46edfff495948df804cb17e5b93d56388335c15627b472dc3b0d6b89ce67dd11"
+        }
+    },
     "bin": [ [ "src_windows_amd64.exe", "src" ] ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
I created an app for [SourceGraph CLI](https://github.com/sourcegraph/src-cli), a command-line interface for interacting with [SourceGraph](https://about.sourcegraph.com/). I thought it fit the [criteria for being included here](https://github.com/lukesampson/scoop/wiki/Criteria-for-including-apps-in-the-main-bucket), let me know if you think otherwise or have any input on the app itself. The only complex part was the `hash` regexp for `autoupdate`, but I think I got it right and [tested it according to the instructions](https://github.com/lukesampson/scoop/wiki/App-Manifest-Autoupdate#testing-and-running-autoupdate) 

![image](https://user-images.githubusercontent.com/1032755/118677082-3e4ff080-b7fc-11eb-87c7-acb639a99a71.png)

