### PR TITLE
git: do not set credential manager as post_install

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -13,7 +13,6 @@
             "hash": "d6d48e16e3f0ecbc0a45d410ad3ebae15e5618202855ebe72cd9757e4d35b880"
         }
     },
-    "post_install": "git config --global credential.helper manager-core",
     "bin": [
         "cmd\\git.exe",
         "cmd\\gitk.exe",


### PR DESCRIPTION
Stop setting the credential manager as `post_install` task.

Resolve #1617, #1126 and #2190