### PR TITLE
git alternatives: do not set credential manager

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -13,7 +13,6 @@
             "hash": "d6d48e16e3f0ecbc0a45d410ad3ebae15e5618202855ebe72cd9757e4d35b880"
         }
     },
-    "post_install": "git config --global credential.helper manager",
     "bin": [
         "cmd\\git.exe",
         "cmd\\gitk.exe",

--- a/bucket/mingit.json
+++ b/bucket/mingit.json
@@ -21,7 +21,6 @@
             "hash": "871462ccd94315f490197163afe6903ba65b8460081579d8985c434b3531745d"
         }
     },
-    "post_install": "git config --global credential.helper manager",
     "bin": "cmd\\git.exe",
     "env_set": {
         "GIT_INSTALL_ROOT": "$dir"


### PR DESCRIPTION
Stop setting the credential manager as post_install task. Also for _mingit_ and _git-with-openssh_ as suggested by @FriendlyNeighborhoodShane here https://github.com/ScoopInstaller/Main/issues/1617#issuecomment-845171921.

Relates #2200. Sorry for a second PR about the same topic. 😔 