### PR TITLE
Add manifest for Nym.

### DIFF
--- a/bucket/nym.json
+++ b/bucket/nym.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.1.0",
+    "description": "Manipulate files en masse using patterns.",
+    "homepage": "https://github.com/olson-sean-k/nym",
+    "license": "MIT",
+    "suggest": {
+        "less": "less"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/olson-sean-k/nym/releases/download/v0.1.0r1/nym_v0.1.0r1_x86_64-pc-windows-gnu.zip",
+            "hash": "8fe650acc0531f604c960bd6e82ed30efb6a63eac5c6b1df99fc5a20dcdace7b",
+            "extract_dir": "nym_v0.1.0r1_x86_64-pc-windows-gnu"
+        }
+    },
+    "bin": "nym.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/olson-sean-k/nym/releases/download/v$version/nym_v$version_x86_64-pc-windows-gnu.zip",
+                "extract_dir": "nym_v$version_x86_64-pc-windows-gnu"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change adds a manifest for [Nym](https://github.com/olson-sean-k/nym), a CLI tool for manipulating files with patterns. I'm not sure if this is acceptable in the main bucket; please take a look and let me know if this belongs in the extra bucket instead. Thanks!