### PR TITLE
avr-gcc: Update to 11.1.0

### DIFF
--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -15,6 +15,38 @@
             "extract_dir": "avr-gcc-11.1.0-x86-windows"
         }
     },
+    "bin": [
+        "bin\\avr-addr2line.exe",
+        "bin\\avr-ar.exe",
+        "bin\\avr-as.exe",
+        "bin\\avr-c++.exe",
+        "bin\\avr-c++filt.exe",
+        "bin\\avr-cpp.exe",
+        "bin\\avr-elfedit.exe",
+        "bin\\avr-g++.exe",
+        "bin\\avr-gcc-11.1.0.exe",
+        "bin\\avr-gcc-ar.exe",
+        "bin\\avr-gcc-nm.exe",
+        "bin\\avr-gcc-ranlib.exe",
+        "bin\\avr-gcc.exe",
+        "bin\\avr-gcov-dump.exe",
+        "bin\\avr-gcov-tool.exe",
+        "bin\\avr-gcov.exe",
+        "bin\\avr-gdb.exe",
+        "bin\\avr-gprof.exe",
+        "bin\\avr-ld.bfd.exe",
+        "bin\\avr-ld.exe",
+        "bin\\avr-lto-dump.exe",
+        "bin\\avr-nm.exe",
+        "bin\\avr-objcopy.exe",
+        "bin\\avr-objdump.exe",
+        "bin\\avr-ranlib.exe",
+        "bin\\avr-readelf.exe",
+        "bin\\avr-run.exe",
+        "bin\\avr-size.exe",
+        "bin\\avr-strings.exe",
+        "bin\\avr-strip.exe"
+    ],
     "checkver": "avr-gcc ([\\d.]+)",
     "autoupdate": {
         "architecture": {

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -1,61 +1,29 @@
 {
-    "version": "10.2.0",
-    "description": "AVR toolchain for Windows by Lumito (based on Zak Kemble's one)",
-    "homepage": "https://www.lumito.net/2020/11/02/released-avr-gcc-10-2-0/",
+    "version": "11.1.0",
+    "description": "AVR toolchain for Windows by Zak Kemble.",
+    "homepage": "https://blog.zakkemble.net/avr-gcc-builds/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/10.2.0/avr-gcc-10.2.0-x64-windows.7z",
-            "hash": "c72e1adf1ac2d79766e2eb4b7316bf8232335b0be6cdb1c04395d943d702f15e",
-            "extract_dir": "avr-gcc-10.2.0-x64-windows"
+            "url": "https://blog.zakkemble.net/download/avr-gcc-11.1.0-x64-windows.zip",
+            "hash": "md5:3043B0659163DD116D02FE3470D404D5",
+            "extract_dir": "avr-gcc-11.1.0-x64-windows"
         },
         "32bit": {
-            "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/10.2.0/avr-gcc-10.2.0-x86-windows.7z",
-            "hash": "01c97759ced85b8a23d511dfef6554d6e64806a10de3bd2034629a67b5feb068",
-            "extract_dir": "avr-gcc-10.2.0-x86-windows"
+            "url": "https://blog.zakkemble.net/download/avr-gcc-11.1.0-x86-windows.zip",
+            "hash": "md5:B6459D9048B0870A96544330E54B66AE",
+            "extract_dir": "avr-gcc-11.1.0-x86-windows"
         }
     },
-    "bin": [
-        "bin\\avr-addr2line.exe",
-        "bin\\avr-ar.exe",
-        "bin\\avr-as.exe",
-        "bin\\avr-c++.exe",
-        "bin\\avr-c++filt.exe",
-        "bin\\avr-cpp.exe",
-        "bin\\avr-elfedit.exe",
-        "bin\\avr-g++.exe",
-        "bin\\avr-gcc-10.2.0.exe",
-        "bin\\avr-gcc-ar.exe",
-        "bin\\avr-gcc-nm.exe",
-        "bin\\avr-gcc-ranlib.exe",
-        "bin\\avr-gcc.exe",
-        "bin\\avr-gcov-dump.exe",
-        "bin\\avr-gcov-tool.exe",
-        "bin\\avr-gcov.exe",
-        "bin\\avr-gdb.exe",
-        "bin\\avr-gprof.exe",
-        "bin\\avr-ld.bfd.exe",
-        "bin\\avr-ld.exe",
-        "bin\\avr-lto-dump.exe",
-        "bin\\avr-nm.exe",
-        "bin\\avr-objcopy.exe",
-        "bin\\avr-objdump.exe",
-        "bin\\avr-ranlib.exe",
-        "bin\\avr-readelf.exe",
-        "bin\\avr-run.exe",
-        "bin\\avr-size.exe",
-        "bin\\avr-strings.exe",
-        "bin\\avr-strip.exe"
-    ],
     "checkver": "avr-gcc ([\\d.]+)",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/$version/avr-gcc-$version-x64-windows.7z",
+                "url": "https://blog.zakkemble.net/download/avr-gcc-$version-x64-windows.zip",
                 "extract_dir": "avr-gcc-$version-x64-windows"
             },
             "32bit": {
-                "url": "https://dl.bintray.com/lumito/public/projects/avr-gcc/$version/avr-gcc-$version-x86-windows.7z",
+                "url": "https://blog.zakkemble.net/download/avr-gcc-$version-x86-windows.zip",
                 "extract_dir": "avr-gcc-$version-x86-windows"
             }
         }


### PR DESCRIPTION
Fixes broken avr-gcc package and updates it to use the official [Zak Kemble](https://blog.zakkemble.net/avr-gcc-builds/)'s repository which is updated regularly.

Fixes issues:
* https://github.com/lukesampson/scoop/issues/4371 (main scoop repo)
* https://github.com/tinygo-org/tinygo/issues/1323#issuecomment-850894969 (Tinygo)

```
$ scoop install avr-gcc.json
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
Installing 'avr-gcc' (11.1.0) [64bit]
Loading avr-gcc-11.1.0-x64-windows.zip from cache.
Checking hash of avr-gcc-11.1.0-x64-windows.zip ... ok.
Extracting avr-gcc-11.1.0-x64-windows.zip ... done.
Linking ~\scoop\apps\avr-gcc\current => ~\scoop\apps\avr-gcc\11.1.0
Creating shim for 'avr-addr2line'.
Creating shim for 'avr-ar'.
Creating shim for 'avr-as'.
Creating shim for 'avr-c++'.
Creating shim for 'avr-c++filt'.
Creating shim for 'avr-cpp'.
Creating shim for 'avr-elfedit'.
Creating shim for 'avr-g++'.
Creating shim for 'avr-gcc-11.1.0'.
Creating shim for 'avr-gcc-ar'.
Creating shim for 'avr-gcc-nm'.
Creating shim for 'avr-gcc-ranlib'.
Creating shim for 'avr-gcc'.
Creating shim for 'avr-gcov-dump'.
Creating shim for 'avr-gcov-tool'.
Creating shim for 'avr-gcov'.
Creating shim for 'avr-gdb'.
Creating shim for 'avr-gprof'.
Creating shim for 'avr-ld.bfd'.
Creating shim for 'avr-ld'.
Creating shim for 'avr-lto-dump'.
Creating shim for 'avr-nm'.
Creating shim for 'avr-objcopy'.
Creating shim for 'avr-objdump'.
Creating shim for 'avr-ranlib'.
Creating shim for 'avr-readelf'.
Creating shim for 'avr-run'.
Creating shim for 'avr-size'.
Creating shim for 'avr-strings'.
Creating shim for 'avr-strip'.
'avr-gcc' (11.1.0) was installed successfully!
```
And subsequently:

```
$ avr-gcc --version
avr-gcc.exe (GCC) 11.1.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Please refrain from changing the repository from this to others as Zak does update this library frequently!