### PR TITLE
nu@0.32.0: Fix plugins not being found

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -10,12 +10,7 @@
             "extract_dir": "nu_0_32_0_windows\\nushell-0.32.0"
         }
     },
-    "pre_install": [
-        "ensure \"$dir\\Plugins\" | Out-Null",
-        "Move-Item \"$dir\\nu_plugin_*\" \"$dir\\Plugins\""
-    ],
     "bin": "nu.exe",
-    "env_add_path": "Plugins",
     "checkver": {
         "github": "https://github.com/nushell/nushell"
     },


### PR DESCRIPTION
Fixes #2254

Nu recently (? version) updated to only look for plugins in the same directory as the executable, rather than searching the full PATH. A consequence of this is that the plugins no longer need to be on the path at all.

Removing the `pre_install` and `env_add_path` fields from the app manifest, leaving Scoop to unzip the distribution without modifications, fixes the issue.