### PR TITLE
far: update hashes

### DIFF
--- a/bucket/far.json
+++ b/bucket/far.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://farmanager.com/files/Far30b5800.x64.20210519.7z",
-            "hash": "5ccc2293f5ce8a5b05a47c41485854d162dac1ef6a00047e6894e40942c30ac0"
+            "hash": "4f2795b8887aa79958ce88b6e31bfd5374175b1b67adc9388170c51e2bb285ff"
         },
         "32bit": {
             "url": "https://farmanager.com/files/Far30b5800.x86.20210519.7z",
-            "hash": "0822402d17abb9b6ade02c6c0ac9c87ea097b38dd2d4ad12846f4969ce98607b"
+            "hash": "e432963de12c685a3610010969b2b1f8a3cdd2f27c0eb004a40049ee3ba8a160"
         }
     },
     "bin": "far.exe",


### PR DESCRIPTION
Far cannot be installed/updated because of incorrect hashes