### PR TITLE
postgresql@13.3: update download URL

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://get.enterprisedb.com/postgresql/postgresql-13.3-1-windows-x64-binaries.zip",
-            "hash": "cb1692d7a42cebb9d617bb51d9e8b940fad77e529e8714eec3e3baf26a73a227"
+            "url": "https://get.enterprisedb.com/postgresql/postgresql-13.3-2-windows-x64-binaries.zip",
+            "hash": "b9027435bbfe1a10f25dac0689c09fe541f26a381c15aec37bc4636e09e537c3"
         }
     },
     "extract_dir": "pgsql",


### PR DESCRIPTION
Correct details:

"url": "https://get.enterprisedb.com/postgresql/postgresql-13.3-2-windows-x64-binaries.zip",
"hash": "b9027435bbfe1a10f25dac0689c09fe541f26a381c15aec37bc4636e09e537c3"
