### PR TITLE
nvs: make it work in non-powershell shells

### DIFF
--- a/bucket/nvs.json
+++ b/bucket/nvs.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jasongin/nvs/releases/download/v1.6.0/nvs-1.6.0.msi",
     "hash": "95b0fdff01142d5aa56217e32f79fe27c12ee9ac976a1c4e160b0fd6e8db320f",
     "extract_dir": "nvs",
-    "bin": "nvs.ps1",
+    "env_add_path": ".",
     "persist": "nodejs",
     "env_set": {
         "NVS_HOME": "$dir\\nodejs"


### PR DESCRIPTION
The current method (before this PR) adds a shim which delegates nvs to the `nvs.ps1` script. 

NVS actually needs to modify the current shell's PATH on-the-fly, so calling the nvs shim from shells other than PowerShell (cmd.exe, Git Bash) does nothing. The solution is to add nvs.cmd, nvs (bash script) and nvs.ps1 all to the PATH so that they can be called directly. This is what the MSI installer of NVS does too.