### PR TITLE
Fix checkver for go.json

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.15",
+    "version": "1.16.5",
     "description": "An open source programming language that makes it easy to build simple, reliable, and efficient software.",
     "homepage": "https://golang.org",
     "license": "BSD-3-Clause",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/go/go1.15.windows-amd64.zip",
-            "hash": "dc491314dff5b87ad50bf1cf56715de8f8c54489be30f3e19239bc2ad1af25e3"
+            "url": "https://dl.google.com/go/go1.16.5.windows-amd64.zip",
+            "hash": "0a3fa279ae5b91bc8c88017198c8f1ba5d9925eb6e5d7571316e567c73add39d"
         },
         "32bit": {
-            "url": "https://dl.google.com/go/go1.15.windows-386.zip",
-            "hash": "e0c747610a73030cadba6f6ac319bca33cfff19b1f58c010727ea55fb2b0cab1"
+            "url": "https://dl.google.com/go/go1.16.5.windows-386.zip",
+            "hash": "bee3e7b3dda252725de4df63f5182b30e579bf9f613bda2efe0e0919fe34112d"
         }
     },
     "extract_dir": "go",
@@ -34,7 +34,7 @@
     },
     "checkver": {
         "url": "https://golang.org/dl/",
-        "regex": "go([\\d.]+)\\."
+        "regex": "/dl/go([\\d.]+)\\.windows"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
A recent change on go's download page caused the autoupdate to actually revert to an older version of go, this PR makes `checkver` more explicit to fix the issue.
```html
<script src="/lib/godoc/playground.js" defer></script>
<script>var goVersion = "\"go1.15.12\"";</script>
<script src="/lib/godoc/godocs.js" defer></script>

...

<a class="download downloadBox" href="/dl/go1.16.5.windows-amd64.msi">
<div class="platform">Microsoft Windows</div>
```
