### PR TITLE
uncrustify: Fix path

### DIFF
--- a/bucket/uncrustify.json
+++ b/bucket/uncrustify.json
@@ -13,7 +13,7 @@
             "hash": "sha1:239cdb0f93f206ceffc369651462d90a064bcf36"
         }
     },
-    "bin": "uncrustify.exe",
+    "bin": "bin\\uncrustify.exe",
     "checkver": {
         "url": "https://sourceforge.net/projects/uncrustify/rss?path=/",
         "regex": "/uncrustify-([\\d.]+)_"


### PR DESCRIPTION
λ  scoop install uncrustify
Installing 'uncrustify' (0.73.0) [64bit]
Loading uncrustify-0.73.0_f-win64.zip from cache
Checking hash of uncrustify-0.73.0_f-win64.zip ... ok.
Extracting uncrustify-0.73.0_f-win64.zip ... done.
Linking ~\scoop\apps\uncrustify\current => ~\scoop\apps\uncrustify\0.73.0
Creating shim for 'uncrustify'.
Can't shim 'uncrustify.exe': File doesn't exist.