### PR TITLE
git-istage@0.3.33: Fix environment variable checking script

### DIFF
--- a/bucket/git-istage.json
+++ b/bucket/git-istage.json
@@ -13,7 +13,7 @@
             "$nugetConfigFile = \"$dir\\nuget.config\"",
             "$nugetConfig | Out-File -Encoding UTF8 \"$nugetConfigFile\"",
             "dotnet tool install git-istage --tool-path \"$dir\" --configfile \"$nugetConfigFile\"",
-            "$runCommand = \"if ($env:DOTNET_ROOT -eq $null) { `$env:DOTNET_ROOT=Split-Path -Parent (Get-Command dotnet).Path } & `\"$dir\\git-istage.exe`\" `$args\"",
+            "$runCommand = \"if ( `$env:DOTNET_ROOT -eq `$null) { `$env:DOTNET_ROOT=Split-Path -Parent (Get-Command dotnet).Path } & `\"$dir\\git-istage.exe`\" `$args\"",
             "$runCommand | Out-File -Encoding UTF8 \"$dir\\run.ps1\""
         ]
     },


### PR DESCRIPTION
The PowerShell script requires a backtick before the `$` to avoid evaluation of the variable when the script is created.