### PR TITLE
Helix: Add version 0.4.1

### DIFF
--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -1,14 +1,14 @@
 {
-    "version": "0.3.0",
+    "version": "0.4.1",
     "description": "A post-modern modal text editor",
     "homepage": "https://helix-editor.com",
     "license": {
-        "identifier": "MPL 2.0",
+        "identifier": "MPL-2.0",
         "url": "https://github.com/helix-editor/helix/blob/master/LICENSE"
     },
-    "url": "https://github.com/helix-editor/helix/releases/download/v0.3.0/helix-v0.3.0-x86_64-windows.zip",
-    "hash": "933ad9adf082bf10d2d5c25f7302d13acf08776d621ba81a8151252edb9527f5",
-    "extract_dir": "helix-v0.3.0-x86_64-windows",
+    "url": "https://github.com/helix-editor/helix/releases/download/v0.4.1/helix-v0.4.1-x86_64-windows.zip",
+    "hash": "e9ff91d6212abf5daaf31bdf201ef138dc62c2d0628b4b0fe768e8ecb64611d7",
+    "extract_dir": "helix-v0.4.1-x86_64-windows",
     "bin": "hx.exe",
     "checkver": {
         "github": "https://github.com/helix-editor/helix"

--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.3.0",
+    "description": "A post-modern modal text editor",
+    "homepage": "https://helix-editor.com",
+    "license": {
+        "identifier": "MPL 2.0",
+        "url": "https://github.com/helix-editor/helix/blob/master/LICENSE"
+    },
+    "url": "https://github.com/helix-editor/helix/releases/download/v0.3.0/helix-v0.3.0-x86_64-windows.zip",
+    "hash": "933ad9adf082bf10d2d5c25f7302d13acf08776d621ba81a8151252edb9527f5",
+    "extract_dir": "helix-v0.3.0-x86_64-windows",
+    "bin": "hx.exe",
+    "checkver": {
+        "github": "https://github.com/helix-editor/helix"
+    },
+    "autoupdate": {
+        "url": "https://github.com/helix-editor/helix/releases/download/v$version/helix-v$version-x86_64-windows.zip",
+        "extract_dir": "helix-v$version-x86_64-windows"
+    }
+}


### PR DESCRIPTION
- Adding helix editor to main bucket
- Currently only supports 64bit architecture through GitHub releases
- Requested as by https://github.com/helix-editor/helix/issues/277