### PR TITLE
Update checksum for latextindent.json

### DIFF
--- a/bucket/latexindent.json
+++ b/bucket/latexindent.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/cmhughes/latexindent.pl",
     "license": "GPL-3.0-only",
     "url": "http://mirrors.ctan.org/support/latexindent.zip",
-    "hash": "22ce4b961e0bae77ad054adcbf96bcd91936fe8a89906caa55e2268ad2fac708",
+    "hash": "baf6dba674e2ece042c03df8679a935d824c2c09055fded0902b1d9e0adecd54",
     "extract_dir": "latexindent",
     "bin": "latexindent.exe",
     "checkver": {


### PR DESCRIPTION
It looks like the hash in latexindent.json is not the expected value. Upon trying to install it, I
get this error message below:
```
Checking hash of latexindent.zip ... ERROR Hash check failed!
App:         main/latexindent
First bytes: 50 4B 03 04 0A 00 00 00
Expected:    22ce4b961e0bae77ad054adcbf96bcd91936fe8a89906caa55e2268ad2fac708
Actual:      baf6dba674e2ece042c03df8679a935d824c2c09055fded0902b1d9e0adecd54
```
When I `Get-FileHash` on the zip file, this is the value I get `BAF6DBA674E2ECE042C03DF8679A935D824C2C09055FDED0902B1D9E0ADECD54`, which is what scoop is expecting.