### PR TITLE
Add  (VM Ware) carvel vendir tool package

### DIFF
--- a/vendir.json
+++ b/vendir.json
@@ -1,0 +1,10 @@
+{
+    "description": "Carvel vendir is a tool that makes it easy to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively",
+    "notes": "See https://carvel.dev/vendir/#examples for some examples",
+    "version": "0.21.1",
+    "homepage": "https://carvel.dev/vendir/",
+    "license": "https://github.com/vmware-tanzu/carvel-vendir/blob/develop/LICENSE",
+    "url": "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.21.1/vendir-windows-amd64.exe#/vendir.exe",
+    "bin": "vendir.exe",
+    "post_install": "vendir version"
+}


### PR DESCRIPTION
# Context

[`vendir`](https://carvel.dev/vendir/) makes it easy to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively.

# Related links

- https://github.com/vmware-tanzu/carvel-vendir/issues/84
- https://github.com/vmware-tanzu/carvel-vendir
- https://carvel.dev/vendir/