### PR TITLE
Add tcping 0.39

### DIFF
--- a/bucket/tcping.json
+++ b/bucket/tcping.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.39",
+    "description": "A console application that operates similarly to 'ping', however it works over a tcp port.",
+    "homepage": "https://www.elifulkerson.com/projects/tcping.php",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.elifulkerson.com/files/tcping/0.39/x64/tcping64.exe",
+            "hash": "AF3C12DA527E88C9DB3774F5F12BAECC2D211C801AE4421C7B16E80F6440ED35",
+            "bin": [
+                [
+                    "tcping64.exe",
+                    "tcping"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://download.elifulkerson.com/files/tcping/0.39/tcping.exe",
+            "hash": "9F04C46E0CDAA5BCE32D98065E1E510A5F174E51B399D6408F2446444CCCD5FF",
+            "bin": [
+                [
+                    "tcping.exe",
+                    "tcping"
+                ]
+            ]
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.elifulkerson.com//files/tcping/$version/x64/tcping64.exe",
+                "hash": {
+                    "url": "$baseurl/files/tcping/$version/x64/tcping64.exe.sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://download.elifulkerson.com//files/tcping/$version/tcping.exe",
+                "hash": {
+                    "url": "$baseurl/files/tcping/$version/tcping.exe.sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
tcping.exe - ping over a tcp connection
"tcping.exe is a console application that operates similarly to 'ping', however it works over a tcp port."

https://www.elifulkerson.com/projects/tcping.php