### PR TITLE
Installs PEP-397, resolves #2181, resolves #377

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -46,7 +46,7 @@
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\setup.exe\" \"$dir\\_tmp\"",
-            "@('launcher.msi', 'path.msi', 'pip.msi') | ForEach-Object {",
+            "@('path.msi', 'pip.msi') | ForEach-Object {",
             "    Remove-Item \"$dir\\_tmp\\AttachedContainer\\$_\"",
             "}",
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
@@ -67,6 +67,7 @@
         ]
     },
     "bin": [
+        "py.exe",
         "python.exe",
         "pythonw.exe",
         [


### PR DESCRIPTION
Not sure why the launcher is excluded.

Also not sure why install-pep-514.reg / uninstall-pep-514.reg aren't called automatically in post_install / uninstall for user's convenience.