### PR TITLE
sqlite: Fix license

### DIFF
--- a/bucket/sqlite.json
+++ b/bucket/sqlite.json
@@ -2,7 +2,7 @@
     "version": "3.36.0",
     "description": "A small, fast, self-contained, high-reliability and full-featured SQL database engine",
     "homepage": "https://www.sqlite.org/",
-    "license": "Public Domain",
+    "license": "blessing",
     "url": "https://www.sqlite.org/2021/sqlite-tools-win32-x86-3360000.zip",
     "hash": "b0c0625997ab19fa99022dad9226c7ef5f312d241ea75e430e7c49f7be0a91ae",
     "extract_dir": "sqlite-tools-win32-x86-3360000",


### PR DESCRIPTION
The SQLite Blessing is an [official spdx license](https://spdx.org/licenses/blessing.html) now, and the manifest should be updated accordingly.

This also fixes the link when you run `scoop info sqlite`.

Before:

```
Name: sqlite
Description: A small, fast, self-contained, high-reliability and full-featured SQL database engine
Version: 3.36.0
Website: https://www.sqlite.org/
License: Public Domain (https://spdx.org/licenses/Public Domain.html)
Manifest:
  C:\Users\<user>\scoop\buckets\main\bucket\sqlite.json
Installed: No
Binaries:
  sqlite3.exe sqldiff.exe sqlite3_analyzer.exe
```

After:

```
Name: sqlite
Description: A small, fast, self-contained, high-reliability and full-featured SQL database engine
Version: 3.36.0
Website: https://www.sqlite.org/
License: blessing (https://spdx.org/licenses/blessing.html)
Manifest:
  C:\Users\<user>\scoop\buckets\main\bucket\sqlite.json
Installed: No
Binaries:
  sqlite3.exe sqldiff.exe sqlite3_analyzer.exe
```