### PR TITLE
telegraf: Fix hash extract from download page

### DIFF
--- a/bucket/telegraf.json
+++ b/bucket/telegraf.json
@@ -28,7 +28,7 @@
         },
         "hash": {
             "url": "https://portal.influxdata.com/downloads/",
-            "regex": "(?sm)<!--h4>Windows Binaries (64-bit)</h4 -->.*?>$sha256</.*?wget $url"
+            "regex": "(?sm)<!--h4>Windows Binaries \(64-bit\)</h4 -->.*?>$sha256</.*?wget $url"
         }
     }
 }

--- a/bucket/telegraf.json
+++ b/bucket/telegraf.json
@@ -28,7 +28,7 @@
         },
         "hash": {
             "url": "https://portal.influxdata.com/downloads/",
-            "regex": "(?sm)<!--h4>Windows Binaries \(64-bit\)</h4 -->.*?>$sha256</.*?wget $url"
+            "regex": "(?sm)<!--h4>Windows Binaries \\(64-bit\\)</h4 -->.*?>$sha256</.*?wget $url"
         }
     }
 }

--- a/bucket/telegraf.json
+++ b/bucket/telegraf.json
@@ -28,7 +28,7 @@
         },
         "hash": {
             "url": "https://portal.influxdata.com/downloads/",
-            "regex": "(?sm)Windows Binaries.*?>$sha256</.*?wget $url"
+            "regex": "(?sm)<!--h4>Windows Binaries (64-bit)</h4 -->.*?>$sha256</.*?wget $url"
         }
     }
 }


### PR DESCRIPTION
original regex matches some random hash from page (eg docker image hash)