### PR TITLE
rakudo-star: Update to version 2021.07-01

### DIFF
--- a/bucket/rakudo-star.json
+++ b/bucket/rakudo-star.json
@@ -1,12 +1,12 @@
 {
-    "version": "2020.05.1-01",
+    "version": "2021.07-01",
     "description": "The Rakudo Star Bundle contains the Rakudo Compiler, a collection of modules from the Raku ecosystem, and the language documentation.",
     "homepage": "https://rakudo.org/star",
     "license": "Artistic-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://rakudo.org/dl/star/rakudo-star-2020.05.1-01-win-x86_64-(JIT).msi",
-            "hash": "abbe7e346f617ff34ec5c5cb4f31f3b106e0ff4018d53a560849254aab2386d5"
+            "url": "https://rakudo.org/dl/star/rakudo-star-2021.07-01-win-x86_64-msvc.msi",
+            "hash": "9e2281c53517645efdfab7f519b1fccdb0665f7e92cd85938d0d752db3d9f0aa"
         }
     },
     "extract_dir": "rakudo",
@@ -18,16 +18,13 @@
     ],
     "checkver": {
         "url": "https://rakudo.org/downloads/star",
-        "regex": "rakudo-star-([\\d.-]+)-win-x86_64-\\(JIT\\)\\.msi"
+        "regex": "rakudo-star-([\\d.-]+)-win-x86_64-msvc.msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://rakudo.org/dl/star/rakudo-star-$version-win-x86_64-(JIT).msi"
+                "url": "https://rakudo.org/dl/star/rakudo-star-$version-win-x86_64-msvc.msi"
             }
-        },
-        "hash": {
-            "url": "$url.sha256.txt"
         }
     }
 }


### PR DESCRIPTION
PS. I removed an `.autoupdate.hash` field because rakudo-star's checksum file format changed and I'm not sure if `scoop` properly recognize such format. It looks like this:

https://rakudo.org/dl/star/rakudo-star-2021.07-01-win-x86_64-msvc.msi.checksums.txt

```
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA256

MD5 (rakudo-star-2021.07-01-win-x86_64-msvc.msi) = 3d1623b6a0a7b4773e05b4c725481a25
SHA1 (rakudo-star-2021.07-01-win-x86_64-msvc.msi) = 0229765b7f8e0aae6ba302c6e387ae726976af51
SHA224 (rakudo-star-2021.07-01-win-x86_64-msvc.msi) = 35dbe5fe2b24e7ed7f130b2c2cb90e09c34178af98d5fa91b393a601
SHA256 (rakudo-star-2021.07-01-win-x86_64-msvc.msi) = 9e2281c53517645efdfab7f519b1fccdb0665f7e92cd85938d0d752db3d9f0aa
SHA384 (rakudo-star-2021.07-01-win-x86_64-msvc.msi) = afca09e73e1b020c5d15a011743cfaef364bd94342cc86898d81314a78e20137221583eaad5970d0b5f56d92cfb342ad
SHA512 (rakudo-star-2021.07-01-win-x86_64-msvc.msi) = e943efe569106dfa5c29c0c2d09140833cfd011ecc11216084b1964c33983d759ca23acadaf1e6f42d4f861b20d5cfd18fa02ac35906c6460386b33067fa2f34
-----BEGIN PGP SIGNATURE-----

iQEzBAEBCAAdFiEE1S4ka5Qq2LXXbg9CLfoa61TGHTsFAmD+1+IACgkQLfoa61TG
HTvu4wf+M8UnOlxs42ekVXvhiAOU/FachGUlhJAbKaa/7JRQukZwuOUXug0/8KNn
IQ/fhrr3P7s3/V/smfreeOeSBIZpjcZG3fyLpCn222ZgKJdaojcQVMbEA0yRjsTn
ooZwLXYS7Txhwizo4Mygc/EQrVEOXZHLCOetMjLEK2yF59v8XMSo9Lz/w+tEXMT3
oNbGvz/5nkXLYrMSywhk+zpKBWdf8yiRIaDJv9J2g1Xm0DhWGHm/LSB2RL1/vG5n
XzFY3EodB/d2RqVYGR469Mzpc2LNSXHOttaWV9ubOusuYgST1/go2rDjb1yMAMbs
qeGgWUOWYs7R2qVSoNzNrxkt/WJe9w==
=SMv+
-----END PGP SIGNATURE-----
```