### PR TITLE
add tblock.json

### DIFF
--- a/bucket/tblock.json
+++ b/bucket/tblock.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.3.2",
+    "description": "An anti-capitalist ad-blocker that uses the hosts file",
+    "homepage": "https://tblock.codeberg.page",
+    "license": "GPL-3.0",
+    "url": "https://codeberg.org/tblock/tblock/releases/download/1.3.2/tblock-windows-64bit.zip",
+    "hash": "99efd8246b561e404fe22995b3ef85cc97e2f4a5f99306a45eb055756c5666c7",
+    "bin": [
+        "tblock\\tblock.exe",
+        "tblock\\tblockc.exe"
+    ],
+    "checkver": "https://codeberg.org/tblock/tblock",
+    "autoupdate": {
+        "url": "https://codeberg.org/tblock/tblock/releases/download/$version/tblock-windows-64bit.zip"
+    }
+}


### PR DESCRIPTION
TBlock is an ad-blocker that uses the hosts file and that is compatible with a lot of filter lists formats, such as adblock plus, hosts file or domains blocklist