### PR TITLE
Updated "git" as depends on legit into suggest

### DIFF
--- a/bucket/legit.json
+++ b/bucket/legit.json
@@ -7,7 +7,10 @@
         "url": "https://github.com/frostming/legit/blob/master/LICENSE"
     },
     "suggest": {
-        "git"
+        "git": [
+            "git",
+            "git-with-openssh"
+        ]
     },
     "url": "https://github.com/frostming/legit/releases/download/1.2.0/legit.exe",
     "hash": "2c4aa8a777141cad9171a7aec9b91d6570443644f7ca040903773620074d361b",

--- a/bucket/legit.json
+++ b/bucket/legit.json
@@ -6,7 +6,9 @@
         "identifier": "Freeware",
         "url": "https://github.com/frostming/legit/blob/master/LICENSE"
     },
-    "depends": "git",
+    "suggest": {
+        "git"
+    },
     "url": "https://github.com/frostming/legit/releases/download/1.2.0/legit.exe",
     "hash": "2c4aa8a777141cad9171a7aec9b91d6570443644f7ca040903773620074d361b",
     "post_install": "'y' | legit --install | Out-Null",


### PR DESCRIPTION
Resolved https://github.com/ScoopInstaller/Main/issues/1247

"Depends" installs the mentioned manifest. This could be trouble some for other that had get `git` installet out of scoop or other variants such as `mingit`.