### PR TITLE
MailHog: Add MailHog v1.0.1

### DIFF
--- a/bucket/mailhog.json
+++ b/bucket/mailhog.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.0.1",
+    "description": "Web and API based SMTP testing.",
+    "homepage": "https://github.com/mailhog/MailHog",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_windows_amd64.exe#/MailHog.exe",
+            "hash": "b217990446e97a60ff09ec21d3f86e54415595148904a7f7737f5019d01671ce"
+        },
+        "32bit": {
+            "url": "https://github.com/mailhog/MailHog/releases/download/v1.0.1/MailHog_windows_386.exe#/MailHog.exe",
+            "hash": "aa8c1f415da193d81d46e0662c86cb4fb271596fda32172cfdd44b68a37d1b8a"
+        }
+    },
+    "bin": "MailHog.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mailhog/MailHog/releases/download/v$version/MailHog_windows_amd64.exe#/MailHog.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/mailhog/MailHog/releases/download/v$version/MailHog_windows_386.exe#/MailHog.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
MailHog is an email-testing tool with a fake SMTP server underneath, similar to MailCatcher.