### PR TITLE
gsudo: Add post install script (to clear gsudo credentials cache)

### DIFF
--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -12,6 +12,7 @@
             "sudo"
         ]
     ],
+    "post_install": "& $dir\\gsudo.exe -k 2>&1 | out-null",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.v$version.zip"


### PR DESCRIPTION
Clear `gsudo` credentials cache on install / upgrade.
Related: gerardog/gsudo#99

Tested with:
```
C:\git\Main\bucket>scoop uninstall gsudo
Uninstalling 'gsudo' (1.0.1).
Removing shim for 'sudo'.
Unlinking ~\scoop\apps\gsudo\current
Removing ~\scoop\apps\gsudo\current from your path.
'gsudo' was uninstalled.

C:\git\Main\bucket>scoop install C:\git\Main\bucket\gsudo.json
Installing 'gsudo' (1.0.1) [64bit]
Loading gsudo.v1.0.1.zip from cache
Checking hash of gsudo.v1.0.1.zip ... ok.
Extracting gsudo.v1.0.1.zip ... done.
Linking ~\scoop\apps\gsudo\current => ~\scoop\apps\gsudo\1.0.1
Creating shim for 'sudo'.
Running post-install script...
'gsudo' (1.0.1) was installed successfully!
```

Also gsudo cache-clear verified ok.
