### PR TITLE
qemu: Remove shims for removed binaries

### DIFF
--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -46,8 +46,6 @@
         "qemu-system-mipsel.exe",
         "qemu-system-mipselw.exe",
         "qemu-system-mipsw.exe",
-        "qemu-system-moxie.exe",
-        "qemu-system-moxiew.exe",
         "qemu-system-nios2.exe",
         "qemu-system-nios2w.exe",
         "qemu-system-or1k.exe",


### PR DESCRIPTION
QEMU 6.1 removed `moxie` <https://qemu-project.gitlab.io/qemu/about/removed-features.html> and the shims must be updated to avoid an error from missing target.