### PR TITLE
Fix cygwin 64 sha512 hash

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -10,7 +10,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cygwin.com/setup-x86_64.exe#/cygwin-setup.exe",
-            "hash": "sha512:4d86a04959464eb31c259dca04e679a42de31a1cc5e742984f09ebb35e0d7925609241ba09895933ce08facf0bce7f8616fcb15d3e5f8ac16a787aeb3dd6d019"
+            "hash": "sha512:a188a44e285f0e7db6dbcf93acaa8e6252a6c65e858019acfa083f1b6f55ac3e3c4dd7df018d9b94f27f2fb4959188b2a11a78c07785ff909b5a00bcb5f425c4"
         },
         "32bit": {
             "url": "https://cygwin.com/setup-x86.exe#/cygwin-setup.exe",


### PR DESCRIPTION
Hi, I tried to install cygwin and found that 64bits hash is not matching. I updated the sha512.