### PR TITLE
latex: Add start menu shortcut for miktex console

### DIFF
--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -20,7 +20,7 @@
             "shortcuts": [
                 [
                     "MiKTeX Console",
-                    "texmfs\\install\\miktex\\bin\\x64\\miktex-console.exe",
+                    "texmfs\\install\\miktex\\bin\\x64\\miktex-console.exe"
                 ]
             ],
             "env_add_path": "texmfs\\install\\miktex\\bin\\x64"


### PR DESCRIPTION
The MiKTeX console is a GUI application used to manage some settings, etc.
It is available as a command line tool, but it also makes sense to expose with
a start menu shortcut -- it is designed to be run that way, after all.