### PR TITLE
vagrant@2.2.18: Hash fix

### DIFF
--- a/bucket/vagrant.json
+++ b/bucket/vagrant.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://releases.hashicorp.com/vagrant/2.2.18/vagrant_2.2.18_x86_64.msi",
-            "hash": "aed44d72e72d2183354c7e2e0f6118e289becba0491a67eb2e5551701b70d359"
+            "hash": "8ce913bee9debcbf39f313f4255e56f37dac5281cd62458c0c0040e5c76ee93e"
         },
         "32bit": {
             "url": "https://releases.hashicorp.com/vagrant/2.2.18/vagrant_2.2.18_i686.msi",


### PR DESCRIPTION
- Closes #2656
- Closes #2634
- Closes #2618
- Closes #2612
vagrant@2.2.18: Hash fix

```
> scoop install vagrant
Installing 'vagrant' (2.2.18) [64bit]
vagrant_2.2.18_x86_64.msi (253.1 MB) [================================================================================================================] 100%
Checking hash of vagrant_2.2.18_x86_64.msi ... ERROR Hash check failed!
App:         main/vagrant
URL:         https://releases.hashicorp.com/vagrant/2.2.18/vagrant_2.2.18_x86_64.msi
First bytes: D0 CF 11 E0 A1 B1 1A E1
Expected:    aed44d72e72d2183354c7e2e0f6118e289becba0491a67eb2e5551701b70d359
Actual:      8ce913bee9debcbf39f313f4255e56f37dac5281cd62458c0c0040e5c76ee93e
```