### PR TITLE
k6@0.33.0: Github link fix

### DIFF
--- a/bucket/k6.json
+++ b/bucket/k6.json
@@ -5,19 +5,19 @@
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/loadimpact/k6/releases/download/v0.33.0/k6-v0.33.0-windows-amd64.zip",
+            "url": "https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-windows-amd64.zip",
             "hash": "8d6327673c5ffd9ca6c7b42e46a1b6d5ef429b780ec61dd022ce83daa90067ee",
             "extract_dir": "k6-v0.33.0-windows-amd64"
         }
     },
     "bin": "k6.exe",
     "checkver": {
-        "github": "https://github.com/loadimpact/k6"
+        "github": "https://github.com/grafana/k6"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-windows-amd64.zip",
+                "url": "https://github.com/grafana/k6/releases/download/v$version/k6-v$version-windows-amd64.zip",
                 "extract_dir": "k6-v$version-windows-amd64"
             }
         },


### PR DESCRIPTION
Fix link to github project for k6 since [acquired by Grafana Labs](https://github.com/grafana/k6/releases/tag/v0.33.0).