### PR TITLE
telegraf: Fix update and hash logic

### DIFF
--- a/bucket/telegraf.json
+++ b/bucket/telegraf.json
@@ -16,19 +16,18 @@
         "TELEGRAF_CONFIG_PATH": "$persist_dir/telegraf.conf"
     },
     "checkver": {
-        "url": "https://portal.influxdata.com/downloads",
-        "regex": ">Telegraf v([\\d.]+)<"
+        "github": "https://github.com/influxdata/telegraf"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://dl.influxdata.com/telegraf/releases/telegraf-$version_windows_amd64.zip",
-                "extract_dir": "telegraf-$version"
+                "extract_dir": "telegraf-$version",
+                "hash": {
+                    "url": "https://github.com/influxdata/telegraf/releases/tag/v$version",
+                    "regex": "(?s)<td>amd64.+?<td>Windows.+?<code>$sha256</code>"
+                }
             }
-        },
-        "hash": {
-            "url": "https://portal.influxdata.com/downloads/",
-            "regex": "(?sm)Windows Binaries.*?>$sha256</.*?wget $url"
         }
     }
 }


### PR DESCRIPTION
The current Telegraf update logic is brittle and currently broken, this PR swaps the logic to use GitHub to detect releases and then a regex to extract the correct checksum. I have tested that this works correctly to automatically generate the last release from the previous one.

Fixes #2082.
Fixes #2191.
Fixes #2224.
Fixes #2286.
Fixes #2299.
Fixes #2441.
Fixes #2555.
Closes #2083.
Closes #2192.
Closes #2225.
Closes #2300.
Closes #2442.
Closes #2443.
Closes #2556.