### PR TITLE
cygwin: Fix and update hash logic

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -10,11 +10,11 @@
     "architecture": {
         "64bit": {
             "url": "https://cygwin.com/setup-x86_64.exe#/cygwin-setup.exe",
-            "hash": "sha512:4d86a04959464eb31c259dca04e679a42de31a1cc5e742984f09ebb35e0d7925609241ba09895933ce08facf0bce7f8616fcb15d3e5f8ac16a787aeb3dd6d019"
+            "hash": "b9219acd1241ffa4d38e19587f1ccc2854f951e451f3858efc9d2e1fe19d375c"
         },
         "32bit": {
             "url": "https://cygwin.com/setup-x86.exe#/cygwin-setup.exe",
-            "hash": "sha512:e18ca429aa1745b2186e1ff7498e5bd73230ec09c0147e1acf5b22d4c37f735cfc2cb3b1c0009f39e18e6ba581298ebfcdd57587690fedb882d92e85a09d2b01"
+            "hash": "ff20b6440ba750dc70e92b5ca24bda40543f1c68800931425c16fd428abe21fc"
         }
     },
     "checkver": {
@@ -29,9 +29,6 @@
             "32bit": {
                 "url": "https://cygwin.com/setup-x86.exe#/cygwin-setup.exe"
             }
-        },
-        "hash": {
-            "url": "https://cygwin.com/sha512.sum"
         }
     },
     "bin": [


### PR DESCRIPTION
The current implementation of the auto update hash logic for cygwin is brittle, as can be attested by the number of open issues, so should be swapped out for a stable implementation.

Fixes 43 issues and closes 6 PRs.