### PR TITLE
winfetch: Add v2.2.0

### DIFF
--- a/bucket/winfetch.json
+++ b/bucket/winfetch.json
@@ -1,0 +1,13 @@
+{
+    "version": "2.2.0",
+    "description": "A command-line system information utility for Windows",
+    "homepage": "https://github.com/kiedtl/winfetch",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/kiedtl/winfetch/v2.2.0/winfetch.ps1",
+    "hash": "569a4a9c87948a663540b93fbf3b8cc4e283a3f7e64c9a5d602c95b4fb38c3bc",
+    "bin": "winfetch.ps1",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/kiedtl/winfetch/v$version/winfetch.ps1"
+    }
+}


### PR DESCRIPTION
This manifest already exists in the extras bucket. It wasn't very robust and/or popular when this tool was created, but it is now. So I'm thinking of promoting it to the Main bucket. Once this PR gets merged, I'll make a PR to the extras bucket to have it removed from there to avoid any duplication.

Here are some additional reasons why winfetch would fit nicely in the Main bucket:
- No pre/post install scripts
- CLI tool, no GUI
- No dependencies
- No binary blobs/executables (the manifest downloads a single script from GitHub which anyone can read) - this eliminates risk of any malware
- Fairly popular (375 stars, 12 contributors, which, frankly is way more than [some](https://github.com/pviotti/sayit) [of](https://github.com/arsham/rainbow) [the](https://github.com/evansmurithi/cloak) [apps](https://github.com/dduan/tre) currently in Main bucket :))
- Is 3 years old (as of now)
- Fun fact: it is 200-250 times faster than neofetch (currently in Main bucket)

**Disclaimer**: I'm currently a maintainer of winfetch :)

A previous PR #2662 of mine was closed abruptly, which I understand as I didn't provide any justification. So I've tried to give as much details here.

