### PR TITLE
Update xray.json

### DIFF
--- a/bucket/xray.json
+++ b/bucket/xray.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/XTLS/Xray-core/releases/download/v1.4.3/Xray-windows-64.zip",
-            "hash": "sha512:c4d62829a61f9c21f422a823d076d1ced784b5c0b2adec43772e9c93bb8013566131e264db9b6e097f655ba387723d1c56bd7ad7002ef0986631e7f9cc383688"
+            "hash": "sha512:4d9750495c1cb4d5cd6f14964ebd5c204b9a2807bc5468d4060ba18f8c2e43529b3ed481a5697b9d98de497f56bc5cae8fc7c45a70a3acbf25323f09d8e0b63d"
         },
         "32bit": {
             "url": "https://github.com/XTLS/Xray-core/releases/download/v1.4.3/Xray-windows-32.zip",
-            "hash": "sha512:8589fecd1530de37ed4d8d9d8a08ff8eaf080a31dfb8c5f234e3dff554a20a5bab8a1d427cfad0aa1216757c37051e650e52269c9ecfad8782c0f55a25681824"
+            "hash": "sha512:8d86ae134fde59aeb985f7c5af7ac3ee90f7828eaa0cb6a69202f4099235cd8e484dbfb2477511469daeff2505721431d1cf08e9abd81d2fb0e8fe7de2756248"
         }
     },
     "bin": "xray.exe",


### PR DESCRIPTION
Fix sha512 for Xray's releaseing a new version with same version number 1.4.3