### PR TITLE
octopustools: Add version 7.4.3379

### DIFF
--- a/bucket/octopustools.json
+++ b/bucket/octopustools.json
@@ -8,7 +8,7 @@
     "hash": "md5:2db9a915b86ab793387ed650c9440f6f",
     "checkver": {
         "url": "https://octopus.com/downloads/octopuscli",
-        "regex": "OctopusTools.(?<version>[\\d]+\\.[\\d]+\\.[\\d]+).win-x64.zip"
+        "regex": "OctopusTools\\.([\\d.]+)\\.win-x64\\.zip"
     },
     "autoupdate": {
         "url": "https://download.octopusdeploy.com/octopus-tools/$version/OctopusTools.$version.win-x64.zip",


### PR DESCRIPTION
- Closes #2632
- Closes #2621

I included `checkver` and `autoupdate`.

Note that they do not push Windows binaries to their GitHub releases.

Disclaimer: I work for Octopus Deploy.
