### PR TITLE
solidity: Add version 0.8.7

### DIFF
--- a/bucket/solidity.json
+++ b/bucket/solidity.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.8.7",
+    "description": "A statically typed, contract-oriented, high-level language for implementing smart contracts on the Ethereum platform.",
+    "homepage": "https://soliditylang.org",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ethereum/solidity/releases/download/v0.8.7/solc-windows.exe#/solc.exe",
+            "hash": "82db83111c6e2c892179486cb7050d85f1517bf851027607eb7f4e589e714bc5"
+        }
+    },
+    "bin": "solc.exe",
+    "checkver": {
+        "github": "https://github.com/ethereum/solidity"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ethereum/solidity/releases/download/v$version/solc-windows.exe#/solc.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
A manifest for this exists in the extras bucket. However, it is extremely out of date, the download URL gives 404, has no checkver and no autoupdate.

I've fixed those things and updated it to the latest version. I think this is another good fit for the Main bucket as:
- CLI only, no GUI
- Very popular (12000 stars, 415 contributors)
- No pre/post install script
- single binary

Once this gets merged, I'll send a PR to remove the manifest from extras.