### PR TITLE
kubeseal: Add version 0.16.0

### DIFF
--- a/bucket/kubeseal.json
+++ b/bucket/kubeseal.json
@@ -1,6 +1,6 @@
 {
     "version": "0.16.0",
-    "description": "The kubeseal utility uses asymmetric crypto to encrypt secrets that only the Kubernetes controller can decrypt.",
+    "description": "With kubeseal you can encrypt your Kubernetes Secret into a SealedSecret, which is safe to store - even to a public repository. The SealedSecret can be decrypted only by the controller running in the target cluster and nobody else (not even the original author) is able to obtain the original Secret from the SealedSecret.",
     "homepage": "https://github.com/bitnami-labs/sealed-secrets",
     "license": "Apache-2.0",
     "architecture": {

--- a/bucket/kubeseal.json
+++ b/bucket/kubeseal.json
@@ -10,9 +10,7 @@
         }
     },
     "bin": "kubeseal.exe",
-    "checkver": {
-        "github": "https://github.com/bitnami-labs/sealed-secrets"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
> **Problem**: "I can manage all my K8s config in git, except Secrets."
> 
> **Solution**: Encrypt your Secret into a SealedSecret, which is safe to store - even to a public repository. The SealedSecret can be decrypted only by the controller running in the target cluster and nobody else (not even the original author) is able to obtain the original Secret from the SealedSecret.
> 
> The `kubeseal` utility uses asymmetric crypto to encrypt secrets that only the Kubernetes controller can decrypt.

Source https://github.com/bitnami-labs/sealed-secrets