### PR TITLE
python: Full PEP514 registration

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -13,7 +13,7 @@
             ],
             "hash": [
                 "md5:cc3eabc1f9d6c703d1d2a4e7c041bc1d",
-                "5d9d7a604c057e67973e1d4b3b488ae20a0e5ee5496d03b5cf091410e33e39ed",
+                "c2611c8010979a47cdeea1af17d5061d8df40c5356fd8c2f3ba9492d516a99d1",
                 "d9309423b693ed63aea6b1fbfc0c34f16842cdca22a1b3edef283b87567a53b9"
             ],
             "pre_install": [
@@ -41,7 +41,7 @@
             ],
             "hash": [
                 "md5:0d949bdfdbd0c8c66107a980a95efd85",
-                "5d9d7a604c057e67973e1d4b3b488ae20a0e5ee5496d03b5cf091410e33e39ed",
+                "c2611c8010979a47cdeea1af17d5061d8df40c5356fd8c2f3ba9492d516a99d1",
                 "d9309423b693ed63aea6b1fbfc0c34f16842cdca22a1b3edef283b87567a53b9"
             ],
             "pre_install": [

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -15,6 +15,22 @@
                 "md5:cc3eabc1f9d6c703d1d2a4e7c041bc1d",
                 "5d9d7a604c057e67973e1d4b3b488ae20a0e5ee5496d03b5cf091410e33e39ed",
                 "d9309423b693ed63aea6b1fbfc0c34f16842cdca22a1b3edef283b87567a53b9"
+            ],
+            "pre_install": [
+                "$py_root = \"$dir\".Replace('\\', '\\\\')",
+                "'install-pep-514.reg', 'uninstall-pep-514.reg' | ForEach-Object {",
+                "    $py_version = ($version -split '\\.')[0..1] -join '.'",
+                "    $content = Get-Content \"$dir\\$_\"",
+                "    $content = $content.Replace('$py_root', $py_root)",
+                "    $content = $content.Replace('$py_version', $py_version)",
+                "    $content = $content.Replace('$py_fullversion', $version)",
+                "    $content = $content.Replace('$py_cleanVersion', $version -replace '\\.')",
+                "    $content = $content.Replace('$py_arch', \"64\")",
+                "    if ($global) {",
+                "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+                "    }",
+                "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
+                "}"
             ]
         },
         "32bit": {
@@ -27,22 +43,25 @@
                 "md5:0d949bdfdbd0c8c66107a980a95efd85",
                 "5d9d7a604c057e67973e1d4b3b488ae20a0e5ee5496d03b5cf091410e33e39ed",
                 "d9309423b693ed63aea6b1fbfc0c34f16842cdca22a1b3edef283b87567a53b9"
+            ],
+            "pre_install": [
+                "$py_root = \"$dir\".Replace('\\', '\\\\')",
+                "'install-pep-514.reg', 'uninstall-pep-514.reg' | ForEach-Object {",
+                "    $py_version = ($version -split '\\.')[0..1] -join '.'",
+                "    $content = Get-Content \"$dir\\$_\"",
+                "    $content = $content.Replace('$py_root', $py_root)",
+                "    $content = $content.Replace('$py_version', $py_version)",
+                "    $content = $content.Replace('$py_fullversion', $version)",
+                "    $content = $content.Replace('$py_cleanVersion', $version -replace '\\.')",
+                "    $content = $content.Replace('$py_arch', \"32\")",
+                "    if ($global) {",
+                "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+                "    }",
+                "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
+                "}"
             ]
         }
     },
-    "pre_install": [
-        "$py_root = \"$dir\".Replace('\\', '\\\\')",
-        "'install-pep-514.reg', 'uninstall-pep-514.reg' | ForEach-Object {",
-        "    $py_version = ($version -split '\\.')[0..1] -join '.'",
-        "    $content = Get-Content \"$dir\\$_\"",
-        "    $content = $content.Replace('$py_root', $py_root)",
-        "    $content = $content.Replace('$py_version', $py_version)",
-        "    if ($global) {",
-        "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
-        "    }",
-        "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
-        "}"
-    ],
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\setup.exe\" \"$dir\\_tmp\"",

--- a/scripts/python/install-pep-514.reg
+++ b/scripts/python/install-pep-514.reg
@@ -5,7 +5,15 @@ Windows Registry Editor Version 5.00
 "SupportUrl"="https://www.python.org/"
 
 [HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version]
-"DisplayName"="Python $py_version"
+"DisplayName"="Python $py_version ($py_arch-bit)"
+"SupportUrl"="https://www.python.org/"
+"Version"="$py_fullversion"
+"SysVersion"="$py_version"
+"SysArchitecture"="$py_archbit"
+
+[HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version\Help\Main Python Documentation]
+@="$py_root\\Doc\\python$py_cleanVersion.chm"
+"DisplayName"="Python $py_fullversion Documentation"
 
 [HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version\InstallPath]
 @="$py_root"


### PR DESCRIPTION
fix https://github.com/ScoopInstaller/Main/issues/2633

set all keys and values according to the official sample.

https://www.python.org/dev/peps/pep-0514/
sample:
```
HKEY_CURRENT_USER\Software\Python\PythonCore
    (Default) = (value not set)
    DisplayName = "Python Software Foundation"
    SupportUrl = "http://www.python.org/"

HKEY_CURRENT_USER\Software\Python\PythonCore\3.6
    (Default) = (value not set)
    DisplayName = "Python 3.6 (64-bit)"
    SupportUrl = "http://www.python.org/"
    Version = "3.6.0"
    SysVersion = "3.6"
    SysArchitecture = "64bit"

HKEY_CURRENT_USER\Software\Python\PythonCore\3.6\Help\Main Python Documentation
    (Default) = "C:\Users\Me\AppData\Local\Programs\Python\Python36\Doc\python360.chm"
    DisplayName = "Python 3.6.0 Documentation"

HKEY_CURRENT_USER\Software\Python\PythonCore\3.6\InstallPath
    (Default) = "C:\Users\Me\AppData\Local\Programs\Python\Python36\"
    ExecutablePath = "C:\Users\Me\AppData\Local\Programs\Python\Python36\python.exe"
    WindowedExecutablePath = "C:\Users\Me\AppData\Local\Programs\Python\Python36\pythonw.exe"
```