### PR TITLE
dnscrypt-proxy: Fix configuration files persistence

### DIFF
--- a/bucket/dnscrypt-proxy.json
+++ b/bucket/dnscrypt-proxy.json
@@ -20,10 +20,7 @@
             "extract_dir": "win32"
         }
     },
-    "pre_install": [
-        "'dnscrypt-proxy.toml' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { Copy-Item \"$dir\\example-$_\" \"$dir\\$_\" }",
-        "}"
+    "pre_install": "if (!(Test-Path \"$persist_dir\\$dnscrypt-proxy.toml\")) { Copy-Item \"$dir\\example-dnscrypt-proxy.toml\" \"$dir\\dnscrypt-proxy.toml\" }",
     "bin": "dnscrypt-proxy.exe",
     "persist": [
         "config",

--- a/bucket/dnscrypt-proxy.json
+++ b/bucket/dnscrypt-proxy.json
@@ -3,7 +3,11 @@
     "description": "A flexible DNS proxy, with support for encrypted DNS protocols",
     "homepage": "https://dnscrypt.info",
     "license": "ISC",
-    "notes": "\"fallback_resolvers\" was renamed to \"bootstrap_resolvers\" for clarity. Please update your configuration file accordingly.",
+    "notes": [
+        "1. \"fallback_resolvers\" was renamed to \"bootstrap_resolvers\" for clarity. Please update your configuration file accordingly.",
+        "2. Some of the configuration files are changed, for details: https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.45",
+        "3. For compatibility reasons, please move all configuration files exclude \"dnscrypt-proxy.toml\" into \"config\" folder and update your config."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.1.0/dnscrypt-proxy-win64-2.1.0.zip",
@@ -17,18 +21,15 @@
         }
     },
     "pre_install": [
-        "'blacklist.txt', 'cloaking-rules.txt', 'dnscrypt-proxy.toml', 'forwarding-rules.txt', 'whitelist.txt' | ForEach-Object {",
+        "'dnscrypt-proxy.toml' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { Copy-Item \"$dir\\example-$_\" \"$dir\\$_\" }",
         "}"
     ],
     "bin": "dnscrypt-proxy.exe",
     "persist": [
-        "blacklist.txt",
-        "cloaking-rules.txt",
+        "config",
         "dnscrypt-proxy.toml",
-        "forwarding-rules.txt",
-        "localhost.pem",
-        "whitelist.txt"
+        "localhost.pem"
     ],
     "checkver": {
         "github": "https://github.com/DNSCrypt/dnscrypt-proxy"

--- a/bucket/dnscrypt-proxy.json
+++ b/bucket/dnscrypt-proxy.json
@@ -24,7 +24,6 @@
         "'dnscrypt-proxy.toml' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { Copy-Item \"$dir\\example-$_\" \"$dir\\$_\" }",
         "}"
-    ],
     "bin": "dnscrypt-proxy.exe",
     "persist": [
         "config",

--- a/bucket/dnscrypt-proxy.json
+++ b/bucket/dnscrypt-proxy.json
@@ -1,17 +1,18 @@
 {
-    "version": "2.0.45",
+    "version": "2.1.0",
     "description": "A flexible DNS proxy, with support for encrypted DNS protocols",
     "homepage": "https://dnscrypt.info",
     "license": "ISC",
+    "notes": "\"fallback_resolvers\" was renamed to \"bootstrap_resolvers\" for clarity. Please update your configuration file accordingly.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.0.45/dnscrypt-proxy-win64-2.0.45.zip",
-            "hash": "d8cfc18e7892fe6977a78131750ae65a59aef602d0030f03f789881b2b31818c",
+            "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.1.0/dnscrypt-proxy-win64-2.1.0.zip",
+            "hash": "196DCB3DA3152DEF54F9BE89276A2B9063026F59FA6993D1850D66FD83858DF0",
             "extract_dir": "win64"
         },
         "32bit": {
-            "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.0.45/dnscrypt-proxy-win32-2.0.45.zip",
-            "hash": "001cdab7a426b71641afd58dab5b1451dc2554354b1630233c3a33b116d9542f",
+            "url": "https://github.com/DNSCrypt/dnscrypt-proxy/releases/download/2.1.0/dnscrypt-proxy-win32-2.1.0.zip",
+            "hash": "64B9AB36F5037FF44DE0FA16A261E00192A419583DC2C3AEBE28B809D8908D23",
             "extract_dir": "win32"
         }
     },


### PR DESCRIPTION
Because of https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.45, persisting a config folder instead of files should be a better choice to improve compatibility. And this allows to user create their own custom configuration files besides the default ones by just putting them into the `config` folder.