### PR TITLE
prs: Add extras/vcredist2015 suggest

### DIFF
--- a/bucket/prs.json
+++ b/bucket/prs.json
@@ -8,6 +8,9 @@
         "gpg",
         "fzf"
     ],
+    "suggest": {
+        "vcredist": "extras/vcredist2015"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/timvisee/prs/releases/download/v0.3.2/prs-v0.3.2-windows.exe#/prs.exe",


### PR DESCRIPTION
Add a suggestion for `extras/vcredist2015`, required but apparently unavailable on fresh systems.