### PR TITLE
macchina: Add version 1.1.6

### DIFF
--- a/bucket/macchina.json
+++ b/bucket/macchina.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.1.6",
+    "description": "A system information fetcher, with an emphasis on performance and minimalism.",
+    "homepage": "https://github.com/Macchina-CLI/macchina",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Macchina-CLI/macchina/releases/download/v1.1.6/macchina-windows.exe#/macchina.exe",
+            "hash": "b1f382ef873a75423c14530157899dac63876c20e6d252bc59358869b1d5029c"
+        }
+    },
+    "bin": "macchina.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Macchina-CLI/macchina/releases/download/v$version/macchina-windows.exe#/macchina.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
A blazing fast system information pretty-printer. Like neofetch, but written in Rust!