### PR TITLE
pwsh: persist global profiles

### DIFF
--- a/bucket/pwsh.json
+++ b/bucket/pwsh.json
@@ -13,12 +13,24 @@
             "hash": "b44702f129514e638798d62a6f3eacb62ef8a628052f71f1ceed179ede3d4564"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\profile.ps1\")) {",
+        "    New-Item -ItemType File \"$persist_dir\\profile.ps1\" | Out-Null",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\Microsoft.PowerShell_profile.ps1\")) {",
+        "    New-Item -ItemType File \"$persist_dir\\Microsoft.PowerShell_profile.ps1\" | Out-Null",
+        "}"
+    ],
     "bin": "pwsh.exe",
     "shortcuts": [
         [
             "pwsh.exe",
             "PowerShell Core"
         ]
+    ],
+    "persist": [
+        "profile.ps1",
+        "Microsoft.PowerShell_profile.ps1"
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
PowerShell uses two installation wide profiles.

You can check them with:
`$PROFILE | Format-List * -Force`

And read about them here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.1#the-profile-files

```
AllUsersAllHosts:  $dir\Profile.ps1
AllUsersCurrentHost:   $dir\Microsoft.PowerShell_profile.ps1
... two user profiles ...
```

Those two files should be persisted.