### PR TITLE
sbcl: Fix extract_dir

### DIFF
--- a/bucket/sbcl.json
+++ b/bucket/sbcl.json
@@ -11,7 +11,7 @@
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/sbcl/sbcl/2.1.9/sbcl-2.1.9-x86-64-windows-binary.msi",
             "hash": "sha1:46cc7a499cf5b597be7cd3aac52ad5a0482d2015",
-            "extract_dir": "PFiles\\Steel Bank Common Lisp\\2.1.9"
+            "extract_dir": "PFiles\\Steel Bank Common Lisp"
         }
     },
     "bin": "sbcl.exe",
@@ -26,7 +26,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://downloads.sourceforge.net/project/sbcl/sbcl/$version/sbcl-$version-x86-64-windows-binary.msi",
-                "extract_dir": "PFiles\\Steel Bank Common Lisp\\$version"
+                "extract_dir": "PFiles\\Steel Bank Common Lisp"
             }
         }
     }


### PR DESCRIPTION
I extracted versions 2.0.0 and 2.1.9 with lessmsi and compared the structure.
```
❯ tree
C:.
├───sbcl2.0.0
│   └───SourceDir
│       └───PFiles
│           └───Steel Bank Common Lisp
│               └───2.0.0
│                   └───contrib
└───sbcl2.1.9
    └───SourceDir
        └───PFiles
            └───Steel Bank Common Lisp
                └───contrib
```

fixes #2714 