### PR TITLE
azure-cli: Fix AzureCLIPath environment variable

### DIFF
--- a/bucket/azure-cli.json
+++ b/bucket/azure-cli.json
@@ -15,7 +15,7 @@
         "url": "https://azurecliprod.azureedge.net/msi/azure-cli-$version.msi"
     },
     "env_set": {
-        "AzureCLIPath": "$dir",
-        "AZURE_CLI_PATH": "$dir"
+        "AzureCLIPath": "$dir\\wbin",
+        "AZURE_CLI_PATH": "$dir\\wbin"
     }
 }


### PR DESCRIPTION
The 2 AzureCLIPath environment variables introduced for azure-cli in https://github.com/ScoopInstaller/Main/pull/1469 are not set to the actual az cli path. 
az is installed in the \wbin sub folder, as seen in the bin property. 

This for example resulted in tools using the go-autorest library not working when the az cli is installed using scoop. 
https://github.com/Azure/go-autorest/blob/c7f947c0610de1bc279f76e6d453353f95cd1bfa/autorest/azure/cli/token.go#L128
 