### PR TITLE
ffmpeg@4.4-154: Fix url

### DIFF
--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -5,8 +5,8 @@
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2021-09-22-12-21/ffmpeg-n4.4-154-g79c114e1b2-win64-gpl-4.4.zip",
-            "hash": "508deed909cb853752223f1ea747b6c4814d3e77b5c0cfa92d7c6d5bab7da57e",
+            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2021-10-06-12-21/ffmpeg-n4.4-154-g79c114e1b2-win64-gpl-4.4.zip",
+            "hash": "0f7ec58e1f92e9c9b66dc6d15e609a9e0ea6ac7e35653657d7478b6d285bd0f9",
             "extract_dir": "ffmpeg-n4.4-154-g79c114e1b2-win64-gpl-4.4"
         }
     },


### PR DESCRIPTION
Fix #2734

https://github.com/BtbN/FFmpeg-Builds/ deleted the build on `2021-09-22`. This fixes the problem.