### PR TITLE
binaryen: add version 101

### DIFF
--- a/bucket/binaryen.json
+++ b/bucket/binaryen.json
@@ -1,0 +1,37 @@
+{
+    "version": "101",
+    "description": "Compiler infrastructure and toolchain library for WebAssembly",
+    "homepage": "https://github.com/WebAssembly/binaryen",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-windows.tar.gz",
+            "hash": "ae1ed9a281f90fd42181e4363ad44bf75a86fe4e1728500a026cae122d3853c1"
+        }
+    },
+    "extract_dir": "binaryen-version_101",
+    "bin": [
+        "bin\\wasm2js.exe",
+        "bin\\wasm-as.exe",
+        "bin\\wasm-ctor-eval.exe",
+        "bin\\wasm-dis.exe",
+        "bin\\wasm-emscripten-finalize.exe",
+        "bin\\wasm-metadce.exe",
+        "bin\\wasm-opt.exe",
+        "bin\\wasm-reduce.exe",
+        "bin\\wasm-shell.exe",
+        "bin\\wasm-split.exe"
+    ],
+    "checkver": {
+        "url": "https://github.com/WebAssembly/binaryen/releases",
+        "regex": "binaryen-version_([\\d.]+)-x86_64-windows\\.tar\\.gz"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/WebAssembly/binaryen/releases/download/version_$version/binaryen-version_$version-x86_64-windows.tar.gz"
+            }
+        },
+        "extract_dir": "binaryen-version_$version"
+    }
+}


### PR DESCRIPTION
This is a toolkit often used when developing for WebAssembly.

I've used version 101 (and not version 102, which is the latest version) because the latest version doesn't have any binaries. For details, see: https://github.com/WebAssembly/binaryen/issues/4148