### PR TITLE
gcc: Update to version 10.3.0-5

### DIFF
--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -25,7 +25,8 @@
                 "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-pkg-config-0.29.2-3-any.pkg.tar.zst",
                 "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-windows-default-manifest-6.4-3-any.pkg.tar.xz",
                 "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-winpthreads-git-9.0.0.6309.cb32954b9-1-any.pkg.tar.zst",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-9-any.pkg.tar.zst"
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-9-any.pkg.tar.zst",
+                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zstd-1.5.0-1-any.pkg.tar.zst"
             ],
             "hash": [
                 "a0f21f472db0ba265b06e47507c2191cedefe2303a94a54dec0b0d50e2130c85",
@@ -47,7 +48,8 @@
                 "867c946174c2a2db9f7836edf68aa317c8453b1417ff7851d994f99015e7a9a5",
                 "6c0ea4adcef503dc8174e9d4d70a10aee8295d620db4494f78fa512df0589dcf",
                 "3146b4931766a99ff4fdbf38d2a2ca5c441d1b2410755f3aa99b4ee503a4b72b",
-                "9da9ebafaef832dba2f442ad44d9ae8759784b86478dcbe326500195f8ea6339"
+                "9da9ebafaef832dba2f442ad44d9ae8759784b86478dcbe326500195f8ea6339",
+                "7fa44523a0e4a168a11941680e2207df2cbc01ccf72bde0f562579a434f6ba3f"
             ],
             "pre_install": [
                 "Move-Item \"$dir\\mingw64\\*\" \"$dir\"",
@@ -79,7 +81,8 @@
                 "http://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-3-any.pkg.tar.zst",
                 "http://repo.msys2.org/mingw/i686/mingw-w64-i686-windows-default-manifest-6.4-3-any.pkg.tar.xz",
                 "http://repo.msys2.org/mingw/i686/mingw-w64-i686-winpthreads-git-9.0.0.6309.cb32954b9-1-any.pkg.tar.zst",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-9-any.pkg.tar.zst"
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-9-any.pkg.tar.zst",
+                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zstd-1.5.0-1-any.pkg.tar.zst"
             ],
             "hash": [
                 "bb6d01bb18c613047e5fd4063f85afda96a9479422bceef3f242f7533fcce1a4",
@@ -101,7 +104,8 @@
                 "c564ce30f11f6e80bee34daa22ca22fbe001f2aa50aa661b0bcac8177557cbd7",
                 "56323bc39c7de0ff727915c09c4aaa25b8396efc0d7eda0006d5951bb6a6b983",
                 "482194124073200d2df05a776dd02fd2c70856fed31efd41305aa896dfa2c3f5",
-                "8d594fc14497d41a66415bfdd200d7d1d56a6ecd3fe81b9190bec0c4841a5eff"
+                "8d594fc14497d41a66415bfdd200d7d1d56a6ecd3fe81b9190bec0c4841a5eff",
+                "416e78a8e66b71d1e8aa76f90d1702b44c7fe49d4026eac789660ece4ca58504"
             ],
             "pre_install": [
                 "Move-Item \"$dir\\mingw32\\*\" \"$dir\"",


### PR DESCRIPTION
## Warning! 🚨 
This update needs `zstd` decompression support.

Since most of the non-_.zst_ files are gone on MSYS2's official repository for version `9.3.0-2`, you can judge and evaluate if it's preferable to cancel this PR or merge it and being restricted to use alternative fork, which supports `zstd`.

<!--
## Temporary workaound ⚡ 
Anyone who absolutely needs to have a working installation and reliable/trusted SHA256 checksums of the official MSYS2 repository now can install `shovel` (https://github.com/Ash258/Scoop-Core#installation) and add my [bucket](https://github.com/silverkorn/scoop-bucket) containing the update from this PR.
```
shovel bucket add silverkorn https://github.com/silverkorn/scoop-bucket.git
shovel update
shovel install silverkorn/gcc
```

---

Some references about this update:
https://github.com/lukesampson/scoop/issues/3990
https://github.com/lukesampson/scoop/issues/4250
https://github.com/lukesampson/scoop/issues/4332
https://github.com/lukesampson/scoop/pull/4268
https://github.com/ScoopInstaller/Main/pull/1761
https://github.com/ScoopInstaller/Main/pull/1774
https://github.com/ScoopInstaller/Main/pull/1933
https://github.com/Ash258/Scoop-Core/pull/97
-->