### PR TITLE
mage: add version 1.11.0

### DIFF
--- a/bucket/mage.json
+++ b/bucket/mage.json
@@ -16,7 +16,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/magefile/mage/releases/download/v$version/mage_$version_Windows-64bit.zip"
+                "url": "https://github.com/magefile/mage/releases/download/v$version/mage_$version_Windows-64bit.zip",
+                "hash": {
+                    "url": "$baseurl/mage_$version_checksums.txt"
+                }
             }
         }
     }


### PR DESCRIPTION
A make/rake-like build tool using Go.

Homepage: https://magefile.org/
GitHub: https://github.com/magefile/mage


Similar to:
* [Cake](https://github.com/ScoopInstaller/Main/blob/master/bucket/cake.json) (for C#)
* [FAKE](https://github.com/ScoopInstaller/Main/blob/master/bucket/fake.json) (for F#)
* [Rake](https://github.com/ruby/rake) (for Ruby)

Doesn't have any runtime dependencies, available only for 64-bit.