### PR TITLE
Add docker-compose as a docker cli plugin

### DIFF
--- a/bucket/docker-compose.json
+++ b/bucket/docker-compose.json
@@ -10,6 +10,10 @@
         }
     },
     "bin": "docker-compose.exe",
+    "post_install": "echo 'Installing docker-compose as docker-cli plugin...'; New-Item -ItemType Directory -Force \"$Env:USERPROFILE/.docker/cli-plugins\" | Out-Null; Copy-Item \"$original_dir/docker-compose.exe\" \"$Env:USERPROFILE/.docker/cli-plugins/docker-compose.exe\"",
+    "uninstaller": {
+        "script": "Remove-Item -Force \"$Env:USERPROFILE/.docker/cli-plugins/docker-compose.exe\""
+    },
     "checkver": {
         "github": "https://github.com/docker/compose"
     },


### PR DESCRIPTION
This change would install the docker compose command as proposed in docker documentation for linux install of new compose command: https://docs.docker.com/compose/cli-command/#install-on-linux