### PR TITLE
erlang: fix installation error

### DIFF
--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "http://erlang.org/download/otp_win64_24.1.2.exe#/dl.7z",
+            "url": "https://erlang.org/download/otp_win64_24.1.2.exe#/dl.7z",
             "hash": "045ead7fa4aafa41a791f08e87da5acb816891f404fd518adb926209b7750ef3"
         },
         "32bit": {
-            "url": "http://erlang.org/download/otp_win32_24.1.2.exe#/dl.7z",
+            "url": "https://erlang.org/download/otp_win32_24.1.2.exe#/dl.7z",
             "hash": "7488c187d47c79ffc2d8fd5e79992dbbb02d290cc6edf88ce13b85a3003fe7fe"
         }
     },
@@ -43,10 +43,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://erlang.org/download/otp_win64_$version.exe#/dl.7z"
+                "url": "https://erlang.org/download/otp_win64_$version.exe#/dl.7z"
             },
             "32bit": {
-                "url": "http://erlang.org/download/otp_win32_$version.exe#/dl.7z"
+                "url": "https://erlang.org/download/otp_win32_$version.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Currently, when installing erlang, scoop will return error because
of url return HTTP status 503. This happens because of erlang switch
the url to use https instead of http.