### PR TITLE
railway: Add version 0.2.45

### DIFF
--- a/bucket/railway.json
+++ b/bucket/railway.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.45",
+    "description": "The command line interface for Railway. Use it to connect your code to Railways infrastructure.",
+    "homepage": "https://github.com/railwayapp/cli",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/railwayapp/cli/releases/download/v0.2.45/railway_0.2.45_windows_amd64.tar.gz",
+            "hash": "92776ed8715d9e9ed2662982febdb87ec9bec0354e0b90d0f04680091fdd1e87"
+        },
+        "32bit": {
+            "url": "https://github.com/railwayapp/cli/releases/download/v0.2.45/railway_0.2.45_windows_386.tar.gz",
+            "hash": "7910e18ae8158e6a60dae83435fb27640c917355790d541ad81f9999307b33d9"
+        }
+    },
+    "bin": "railway.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway_$version_windows_amd64.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway_$version_windows_386.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/railway_$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
CLI client for https://railway.app, allowing to develop, push and run code on their instructure.

Repo: https://github.com/railwayapp/cli
Docs: https://docs.railway.app/develop/cli