### PR TITLE
cloudflared: Update description, remove reference to Argo

### DIFF
--- a/bucket/cloudflared.json
+++ b/bucket/cloudflared.json
@@ -1,6 +1,6 @@
 {
     "version": "2021.10.3",
-    "description": "Command-line client to interact with Cloudflare's Argo Tunnel, Cloudflare Access, start up a DNS over HTTPS resolver and more.",
+    "description": "Command-line client to interact with Cloudflare Tunnel, Cloudflare Access, start up a DNS over HTTPS resolver and more.",
     "homepage": "https://github.com/cloudflare/cloudflared",
     "license": {
         "identifier": "Freeware",


### PR DESCRIPTION
After initially [announcing](https://blog.cloudflare.com/tunnel-for-everyone/) to rebrand from Argo Tunnel to Cloudflare Tunnel, it was eventually changed in their CLI source in https://github.com/cloudflare/cloudflared/commit/cbdf88ea285886bf32104fbdb367a81bffa25b72

Thus, this PR changes the `cloudflared` description to reflect that branding change.