### PR TITLE
Fix missing hyperfine.exe

### DIFF
--- a/bucket/hyperfine.json
+++ b/bucket/hyperfine.json
@@ -8,6 +8,11 @@
             "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-pc-windows-msvc.zip",
             "hash": "ae92a684d0f72c209eab8fe320cfea877383605a7ed18d72e3096b938c28be4b",
             "extract_dir": "hyperfine-v1.12.0-x86_64-pc-windows-msvc"
+        },
+        "32bit": {
+            "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-i686-pc-windows-msvc.zip",
+            "hash": "a941b663bf37130483da27ea60e0099089e265a12727256be8380af1bd7abaeb",
+            "extract_dir": "hyperfine-v1.12.0-i686-pc-windows-msvc"
         }
     },
     "bin": "hyperfine.exe",
@@ -17,6 +22,10 @@
             "64bit": {
                 "url": "https://github.com/sharkdp/hyperfine/releases/download/v$version/hyperfine-v$version-x86_64-pc-windows-msvc.zip",
                 "extract_dir": "hyperfine-v$version-x86_64-pc-windows-msvc"
+            },
+            "32bit": {
+                "url": "https://github.com/sharkdp/hyperfine/releases/download/v$version/hyperfine-v$version-i686-pc-windows-msvc.zip",
+                "extract_dir": "hyperfine-v$version-i686-pc-windows-msvc"
             }
         }
     }


### PR DESCRIPTION
In the latest release of [hyperfine](https://github.com/sharkdp/hyperfine/releases), the binary was moved into a subdirectory `hyperfine-v$version-x86_64-pc-windows-msvc`, this PR adds `extract_dir` to fix that.