### PR TITLE
Fix installation path for executable files

### DIFF
--- a/bucket/hyperfine.json
+++ b/bucket/hyperfine.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-pc-windows-msvc.zip",
-            "hash": "ae92a684d0f72c209eab8fe320cfea877383605a7ed18d72e3096b938c28be4b"
+            "hash": "ae92a684d0f72c209eab8fe320cfea877383605a7ed18d72e3096b938c28be4b",
+            "extract_dir": "hyperfine-v1.12.0-x86_64-pc-windows-msvc"
         }
     },
     "bin": "hyperfine.exe",


### PR DESCRIPTION
In Version 1.12.0 the binary assets for hyperfine are not in the top level directory of the zip release file -
in contrast to what was the case the former versions.
Therefore, regular install does not find the executable and thus cannot create the shim. 
Proposed change mitigates the issue by adjusting extraction path.