### PR TITLE
fossa: Add version 2.17.2

### DIFF
--- a/bucket/fossa.json
+++ b/bucket/fossa.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.17.0",
-    "description": "Fast, portable and reliable dependency analysis for any codebase. Supports license & vulnerability scanning for large monoliths. Language-agnostic; integrates with 20+ build systems.",
+    "version": "2.17.2",
+    "description": "Dependency analysis tool. Supports license & vulnerability scanning. Language-agnostic; integrates with 20+ build systems.",
     "homepage": "https://github.com/fossas/spectrometer",
-    "checkver": "github",
     "license": "MPL-2.0",
     "bin": "fossa.exe",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fossas/spectrometer/releases/download/v2.17.0/fossa_2.17.0_windows_amd64.zip",
-            "hash": "1aa758ad80b8aa30862bcd18ed529e8cd63e292932824f499fcdcac8ec2f6d8c"
+            "url": "https://github.com/fossas/spectrometer/releases/download/v2.17.2/fossa_2.17.2_windows_amd64.zip",
+            "hash": "2464af1a7953748c14a1549b56f7e82ac2aeaef94cf69d3197f696ea260747cc"
         }
     },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
See https://github.com/fossas/spectrometer

Build hashes not added as they're not yet being published.