### PR TITLE
hyperfine: Fix error "Cannot create shim"

### DIFF
--- a/bucket/hyperfine.json
+++ b/bucket/hyperfine.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine-v1.12.0-x86_64-pc-windows-msvc.zip",
-            "hash": "ae92a684d0f72c209eab8fe320cfea877383605a7ed18d72e3096b938c28be4b"
+            "hash": "ae92a684d0f72c209eab8fe320cfea877383605a7ed18d72e3096b938c28be4b",
+            "extract_dir": "hyperfine-v1.12.0-x86_64-pc-windows-msvc"
         }
     },
     "bin": "hyperfine.exe",
@@ -16,6 +17,7 @@
             "64bit": {
                 "url": "https://github.com/sharkdp/hyperfine/releases/download/v$version/hyperfine-v$version-x86_64-pc-windows-msvc.zip"
             }
-        }
+        },
+        "extract_dir": "hyperfine-v$version-x86_64-pc-windows-msvc"
     }
 }


### PR DESCRIPTION
Add `extract_dir` 

Fix #2776 
