### PR TITLE
hurl: Add hurlfmt.exe

### DIFF
--- a/bucket/hurl.json
+++ b/bucket/hurl.json
@@ -9,7 +9,10 @@
             "hash": "78255bb838095a1015679f92189074c1162edd51b5edc1dda7b863ba7304c4b5"
         }
     },
-    "bin": "hurl.exe",
+    "bin": [
+        "hurl.exe",
+        "hurlfmt.exe"
+    ],
     "checkver": {
         "github": "https://github.com/Orange-OpenSource/hurl"
     },


### PR DESCRIPTION
> The current 1.3.1 zip package does not include the hurlfmt.exe binary, we have corrected this for the next 1.4.0 release, then it will be necessary to make a scoop configuration allowing to use both hurl.exe and hurlfmt.exe for the next delivery.

Related: 
- https://github.com/Orange-OpenSource/hurl/issues/282
- https://github.com/Orange-OpenSource/hurl/issues/289