### PR TITLE
latex: Update to version 21.8

### DIFF
--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -1,6 +1,6 @@
 {
-    "version": "21.6",
-    "description": "MikTeX is an up-to-date implementation of TeX/LaTeX and related programs.",
+    "version": "21.8",
+    "description": "MikTeX, an up-to-date implementation of TeX/LaTeX and related programs.",
     "homepage": "https://miktex.org",
     "license": {
         "identifier": "LPPL1.3c,GPL-3.0-or-later,Public Domain,...",
@@ -8,29 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x64/basic-miktex-21.6-x64.exe",
-            "hash": "299f2eb278409c672ba38941388c9d9e70182b7b1ba61319bc7128bbb9051a6d",
+            "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x64/basic-miktex-21.8-x64.exe",
+            "hash": "0dfeba2bfcf8492c22661710e0d2c4fa7fb0ebd34f9830048cec03f8fbc9efad",
             "bin": [
                 [
                     "texmfs\\install\\miktex\\bin\\x64\\miktex-console.exe",
-                    "miktex",
-                    "--hide --mkmaps"
-                ]
-            ],
-            "shortcuts": [
-                [
-                    "texmfs\\install\\miktex\\bin\\x64\\miktex-console.exe",
-                    "MiKTeX Console"
-                ]
-            ],
-            "env_add_path": "texmfs\\install\\miktex\\bin\\x64"
-        },
-        "32bit": {
-            "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-21.6.exe",
-            "hash": "0cf009bd2c1ba25f47c99c14bea4c4ef351a41144274c9a40dc5aeb20c14b938",
-            "bin": [
-                [
-                    "texmfs\\install\\miktex\\bin\\miktex-console.exe",
                     "miktex",
                     "--hide --mkmaps"
                 ]
@@ -38,10 +20,10 @@
             "shortcuts": [
                 [
                     "MiKTeX Console",
-                    "texmfs\\install\\miktex\\bin\\miktex-console.exe"
+                    "texmfs\\install\\miktex\\bin\\x64\\miktex-console.exe"
                 ]
             ],
-            "env_add_path": "texmfs\\install\\miktex\\bin"
+            "env_add_path": "texmfs\\install\\miktex\\bin\\x64"
         }
     },
     "installer": {
@@ -54,20 +36,17 @@
     "persist": "texmfs\\config",
     "checkver": {
         "url": "https://miktex.org/download",
-        "regex": "basic-miktex-([\\d.]+)\\.exe"
+        "regex": "basic-miktex-([\\d.]+)-x64\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x64/basic-miktex-$version-x64.exe"
-            },
-            "32bit": {
-                "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/basic-miktex-$version.exe"
             }
         },
         "hash": {
             "url": "https://miktex.org/download",
-            "regex": "(?sm)$basename</td>.*?$sha256"
+            "regex": "(?sm)$basename</div>.*?$sha256"
         }
     }
 }


### PR DESCRIPTION
closes #2783

- Fixes the shortcut error mentioned in #2783
- **MikTeX** does not provide 32-bit binaries anymore, causing `autoupdate` to fail. This fixes the problem