### PR TITLE
haskell: update to 9.0.1

### DIFF
--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.10.7",
+    "version": "9.0.1",
     "description": "An advanced, purely functional programming language.",
     "homepage": "https://www.haskell.org",
     "license": "BSD-3-Clause",
@@ -12,9 +12,9 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.10.7-release/ghc-8.10.7-x86_64-unknown-mingw32.tar.xz",
-            "hash": "b6515b0ea3f7a6e34d92e7fcd0c1fef50d6030fe8f46883000185289a4b8ea9a",
-            "extract_dir": "ghc-8.10.7"
+            "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-9.0.1-release/ghc-9.0.1-x86_64-unknown-mingw32.tar.xz",
+            "hash": "4f4ab118df01cbc7e7c510096deca0cb25025339a97730de0466416296202493",
+            "extract_dir": "ghc-9.0.1-x86_64-unknown-mingw32"
         }
     },
     "bin": [
@@ -25,19 +25,19 @@
         "bin\\hp2ps.exe",
         "bin\\hpc.exe",
         "bin\\hsc2hs.exe",
-        "bin\\runghc.exe",
-        "bin\\runhaskell.exe"
+        "bin\\runghc.exe"
     ],
     "env_add_path": "lib\\bin",
     "checkver": {
-        "github": "https://github.com/commercialhaskell/ghc",
-        "regex": "/releases/tag/ghc-([\\d\\.]+)-release"
+        "url": "https://api.github.com/repos/commercialhaskell/ghc/tags",
+        "jsonpath": "$.name",
+        "regex": "ghc-([\\d\\.]+)-release"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-$version-release/ghc-$version-x86_64-unknown-mingw32.tar.xz",
-                "extract_dir": "ghc-$version"
+                "extract_dir": "ghc-$version-x86_64-unknown-mingw32"
             }
         }
     }


### PR DESCRIPTION
Based on @glatavento's [commit](https://github.com/ScoopInstaller/Main/pull/1792)

Differences common to both from existing on Main:-
1. Can autoupdate to 8.10.7
2. Update env_add_path
3. Remove WinGHCi which is no longer shipped
4. Switch to GitHub for checkver

Differences between current @glatavento's commit
1. Switch to GitHub for downloading the binaries themselves
2. No longer is the pre_install script required (handled with extract_dir)
3. Update to 9.0.1
4. Use GitHub API for checkver to always ensure 9.0.1 is received
5. Remove runhaskell which is absent in 9.0.1 from shims

I hope @glatavento can update their commit based on this or we can merge this.