### PR TITLE
yasm: switch checkver and downloads to GitHub instead

### DIFF
--- a/bucket/yasm.json
+++ b/bucket/yasm.json
@@ -6,25 +6,24 @@
     "architecture": {
         "64bit": {
             "hash": "d160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f",
-            "url": "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe#/yasm.exe"
+            "url": "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0-win64.exe#/yasm.exe"
         },
         "32bit": {
             "hash": "db8ef9348ae858354cee4cc2f99e0f36de8a47a121de4cfeea5a16d45dd5ac1b",
-            "url": "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win32.exe#/yasm.exe"
+            "url": "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0-win32.exe#/yasm.exe"
         }
     },
     "bin": "yasm.exe",
     "checkver": {
-        "url": "http://yasm.tortall.net/Download.html",
-        "regex": "Latest Release: ([\\d.]+)"
+        "github": "https://github.com/yasm/yasm"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.tortall.net/projects/yasm/releases/yasm-$version-win64.exe#/yasm.exe"
+                "url": "https://github.com/yasm/yasm/releases/download/v$version/yasm-$version-win64.exe#/yasm.exe"
             },
             "32bit": {
-                "url": "http://www.tortall.net/projects/yasm/releases/yasm-$version-win32.exe#/yasm.exe"
+                "url": "https://github.com/yasm/yasm/releases/download/v$version/yasm-$version-win32.exe#/yasm.exe"
             }
         }
     }


### PR DESCRIPTION
GitHub checkvers would usually be easy to maintain and we would not have version update problems in case the website changes for example
Easier for maintenance