### PR TITLE
yedit: Add version 1.60

### DIFF
--- a/bucket/yedit.json
+++ b/bucket/yedit.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.60",
+    "description": "A modern version of the legacy EDIT.COM text editor, from the author of Yori.",
+    "homepage": "http://www.malsmith.net/yori/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "http://www.malsmith.net/download/?obj=yori/1.60/yori-typical-amd64.cab#/dl.7z",
+            "hash": "f9eaaacf9affc8285b79819d977697e73198f82a8d344428ac436d5a5c5e257b"
+        },
+        "32bit": {
+            "url": "http://www.malsmith.net/download/?obj=yori/1.60/yori-typical-win32.cab#/dl.7z",
+            "hash": "e72fa905b3f75eaccb4bf67a891cddfa1e2f5a6ff1398f5e435d2aeffac4bbb8"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\*\" -Recurse -Exclude yedit.exe",
+    "bin": "yedit.exe",
+    "checkver": {
+        "github": "https://github.com/malxau/yori"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://www.malsmith.net/download/?obj=yori/$version/yori-typical-amd64.cab#/dl.7z"
+            },
+            "32bit": {
+                "url": "http://www.malsmith.net/download/?obj=yori/$version/yori-typical-win32.cab#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[edit](https://en.wikipedia.org/wiki/MS-DOS_Editor) was a 16bit terminal text editor that was included in all versions of Windows (except 64bit SKUs). Think of it as a DOS equivalent for nano. 

Modern Windows does not come with a terminal text editor, but the author of [Yori](http://www.malsmith.net/yori) (an awesome CMD replacement shell, manifest [here](https://github.com/ScoopInstaller/Main/blob/master/bucket/yori.json)) decided to port it to 64bit, and here we are. 

More details can be found in this blog post - [Yedit – The missing edit.com replacement for modern Windows](https://virtuallyfun.com/wordpress/2021/03/03/yedit-the-missing-edit-com-replacement-for-modern-windows/).