### PR TITLE
fix: switch checkver to github for cloc

### DIFF
--- a/bucket/cloc.json
+++ b/bucket/cloc.json
@@ -8,6 +8,6 @@
     "bin": "cloc.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/AlDanial/cloc/releases/download/$matchPrefix$version/cloc-$version.exe#/cloc.exe"
+        "url": "https://github.com/AlDanial/cloc/releases/download/v$version/cloc-$version.exe#/cloc.exe"
     }
 }


### PR DESCRIPTION
Better than using URL