### PR TITLE
chore: Add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 14
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+    - blocked
+    - bug
+    - discussion
+    - enhancement
+    - help-wanted
+    - package-request
+    - pinned
+    - security
+    - upstream
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This PR adds the configuration for [Stale Bot](https://github.com/apps/stale), but someone with organisation/repo settings access would need to enable it once this has been merged. The intention here is to keep the open issues focused issues that have been triaged and to remove issues which are no longer relevant. I've gone for a 7 day stale and a further 7 days to close as this project is expected to have a high churn, but I don't have a strong opinion here. We could/should add some other labels for issues that shouldn't ever go stale.

@rasa @issaclin32 @rashil2000 @Valinor @pratikpc (recent maintainers) what are your thoughts on this in principal and on the actual details?

@rasa is turning on the bot something you'd be able to do if this is agreed on?