### PR TITLE
memcached@1.6.12: Fix extract_dir, Disable autoupdate

### DIFF
--- a/bucket/memcached.json
+++ b/bucket/memcached.json
@@ -1,5 +1,5 @@
 {
-    "##": "Check https://www.apachelounge.com/viewtopic.php?t=7919 for details about this pre-compiled binary package of memcached.",
+    "##": "Check https://www.apachelounge.com/viewtopic.php?t=7919 for details about this pre-compiled binary package of memcached. memcached is built with both libevent 2.1 and 2.0 because libevent 2.1 is not compatible with Win7.",
     "version": "1.6.12",
     "description": "Distributed memory object caching system",
     "homepage": "https://memcached.org",
@@ -9,26 +9,15 @@
     "hash": "b7eb101d270fa2b49ec25ea3b3e86d69fdc41a272911210d4ee8f1d7ae2a055d",
     "architecture": {
         "64bit": {
-            "extract_dir": "memcached-1.6.12\\cygwin\\x64"
+            "extract_dir": "memcached-1.6.12\\libevent-2.1\\x64"
         },
         "32bit": {
-            "extract_dir": "memcached-1.6.12\\cygwin\\x86"
+            "extract_dir": "memcached-1.6.12\\libevent-2.1\\x86"
         }
     },
     "bin": "memcached.exe",
     "checkver": {
         "url": "https://raw.githubusercontent.com/nono303/memcached/master/README.md",
         "regex": "version\\s+\\[([\\d.]+)\\]"
-    },
-    "autoupdate": {
-        "url": "https://github.com/nono303/memcached/archive/$version.zip",
-        "architecture": {
-            "64bit": {
-                "extract_dir": "memcached-$version\\cygwin\\x64"
-            },
-            "32bit": {
-                "extract_dir": "memcached-$version\\cygwin\\x86"
-            }
-        }
     }
 }


### PR DESCRIPTION
close #2513

*memcached* is built with both `libevent 2.0` and `2.1`, because Windows 7 is not supported by `libevent 2.1`.
This causes error in *extract_dir*.

I think it is okay to take the one bulit with `libevent 2.1`, since Windows 7 has been discontinued for over a year.

