### PR TITLE
Add a manifest for the Openshift OKD client CLI

### DIFF
--- a/bucket/openshift-okd-client.json
+++ b/bucket/openshift-okd-client.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://okd.io",
-    "license": "https://github.com/openshift/okd/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "description": "OKD is the community distribution of Kubernetes optimized for continuous application development and multi-tenant deployment. OKD adds developer and operations-centric tools on top of Kubernetes to enable rapid application development, easy deployment and scaling, and long-term lifecycle maintenance for small and large teams.",
     "version": "4.8.0-0.okd-2021-10-24-061736",
     "architecture": {


### PR DESCRIPTION
This is the latest in the 4.x series of Openshift OKD, while the openshift-origin-client manifest is the latest in the legacy 3.x series.