### PR TITLE
ImageMagick@7.1.0-12: Fix hash

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -7,11 +7,11 @@
     "architecture": {
         "64bit": {
             "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-portable-Q16-x64.zip",
-            "hash": "897796139e00f1c694416a335239e622f08b6dd17a9c700d90aa1cbee2bf2fc8"
+            "hash": "2630cd01858f445312146eb09e8b5f925017e6ecae952ef31db15f876c7bea9c"
         },
         "32bit": {
             "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-portable-Q16-x86.zip",
-            "hash": "6ae37cb95b8e79cf905470a47fa747c8505ca801ffae5fcc74399072442f997f"
+            "hash": "de6d00e8046577db63291b776876e446b2553f5bb93b78fcb2e3a4ddbd20b872"
         }
     },
     "bin": [


### PR DESCRIPTION
Corrected both the sha256 hashes for both 64bit and 32bit binaries according to the digest from
https://download.imagemagick.org/ImageMagick/download/binaries/

fixes #2831