### PR TITLE
helix: Update to version 0.5.0

### DIFF
--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "A post-modern modal text editor",
     "homepage": "https://helix-editor.com",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/helix-editor/helix/releases/download/v0.4.1/helix-v0.4.1-x86_64-windows.zip",
-            "hash": "e9ff91d6212abf5daaf31bdf201ef138dc62c2d0628b4b0fe768e8ecb64611d7",
-            "extract_dir": "helix-v0.4.1-x86_64-windows"
+            "url": "https://github.com/helix-editor/helix/releases/download/v0.5.0/helix-v0.5.0-x86_64-windows.zip",
+            "hash": "c3cc06fa601bc91f10de9eb337d10775c964135f8e6ac672251c8e0161c21bde",
+            "extract_dir": "helix-v0.5.0-x86_64-windows"
         }
     },
     "bin": "hx.exe",


### PR DESCRIPTION
[Helix v0.5.0](https://github.com/helix-editor/helix/releases/tag/v0.5.0) was recently released so I thought the update should be reflected here. 