### PR TITLE
Manifests update

### DIFF
--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "A post-modern modal text editor",
     "homepage": "https://helix-editor.com",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/helix-editor/helix/releases/download/v0.4.1/helix-v0.4.1-x86_64-windows.zip",
-            "hash": "e9ff91d6212abf5daaf31bdf201ef138dc62c2d0628b4b0fe768e8ecb64611d7",
-            "extract_dir": "helix-v0.4.1-x86_64-windows"
+            "url": "https://github.com/helix-editor/helix/releases/download/v0.5.0/helix-v0.5.0-x86_64-windows.zip",
+            "hash": "c3cc06fa601bc91f10de9eb337d10775c964135f8e6ac672251c8e0161c21bde",
+            "extract_dir": "helix-v0.5.0-x86_64-windows"
         }
     },
     "bin": "hx.exe",

--- a/bucket/k3d.json
+++ b/bucket/k3d.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "Creates multi-node k3s cluster on a single machine using docker",
     "homepage": "https://github.com/rancher/k3d",
     "license": "MIT",
@@ -12,8 +12,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rancher/k3d/releases/download/v5.0.1/k3d-windows-amd64.exe#/k3d.exe",
-            "hash": "e69948b063603f5c939544840d00b7370d241d2321e38fef2ce67948068f0586"
+            "url": "https://github.com/rancher/k3d/releases/download/v5.0.2/k3d-windows-amd64.exe#/k3d.exe",
+            "hash": "b4af92aaf6244d13c8bc3478ea8291a8948056b412dc2b73d68074d732452ec4"
         }
     },
     "bin": "k3d.exe",

--- a/bucket/kubefwd.json
+++ b/bucket/kubefwd.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.21.0",
+    "version": "1.22.0",
     "description": "Bulk port forwarding Kubernetes services for local development",
     "homepage": "https://github.com/txn2/kubefwd",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/txn2/kubefwd/releases/download/1.21.0/kubefwd_Windows_x86_64.zip",
-            "hash": "098ab72078629e4282b62a4980ca7639d4efc6f4abf9357dc1f4b568b66d01c8"
+            "url": "https://github.com/txn2/kubefwd/releases/download/1.22.0/kubefwd_Windows_x86_64.zip",
+            "hash": "f01bc7909dc30b584c7ed59b5814c24a24beb80a71a56a01e49b9fd094f8a114"
         },
         "32bit": {
-            "url": "https://github.com/txn2/kubefwd/releases/download/1.21.0/kubefwd_Windows_i386.zip",
-            "hash": "ed765acb1462cd164f1ad4fc0fd126c9e87aabc8727aa36378eccf1624f3af2d"
+            "url": "https://github.com/txn2/kubefwd/releases/download/1.22.0/kubefwd_Windows_i386.zip",
+            "hash": "f6f394dfbe339a7ec7c53d5a5b3a047494b75ab7e11fdef2ad4bb25fa3b6a7ab"
         }
     },
     "bin": "kubefwd.exe",

--- a/bucket/lean-cli.json
+++ b/bucket/lean-cli.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.28.0",
+    "version": "0.28.1",
     "description": "LeanEngine Command Line Tool",
     "homepage": "https://leancloud.cn/docs/leanengine_cli.html",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/leancloud/lean-cli/releases/download/v0.28.0/lean-windows-x64.exe#/lean.exe",
-            "hash": "ce15081e8c46a8dc68c278bd10c42c5e2a9c2f0a8120bf36000de9314e3debab"
+            "url": "https://github.com/leancloud/lean-cli/releases/download/v0.28.1/lean-windows-x64.exe#/lean.exe",
+            "hash": "7f7a649c98c2025e88bd35fa6eb898d074fbb2fcf2ae305d532829dae9fd8aac"
         },
         "32bit": {
-            "url": "https://github.com/leancloud/lean-cli/releases/download/v0.28.0/lean-windows-x86.exe#/lean.exe",
-            "hash": "3fa18711d7e4b58f6c1b3cd903ae306130abeea69011e676f7988ae759f2f15d"
+            "url": "https://github.com/leancloud/lean-cli/releases/download/v0.28.1/lean-windows-x86.exe#/lean.exe",
+            "hash": "d6af39166f1093cac70017c606b6c15a0b0308dbaf9cd2b158938553bfa9e1e2"
         }
     },
     "bin": "lean.exe",

--- a/bucket/lychee.json
+++ b/bucket/lychee.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.7.1",
+    "version": "0.8.0",
     "description": "A command-line link checker",
     "homepage": "https://github.com/lycheeverse/lychee",
     "license": "Apache-2.0|MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lycheeverse/lychee/releases/download/v0.7.1/lychee-v0.7.1-windows-x86_64.exe#/lychee.exe",
-            "hash": "1c122fc0e13516e490d20de106dc8494ef3952883cb525bedcf69eed8f38cc75"
+            "url": "https://github.com/lycheeverse/lychee/releases/download/v0.8.0/lychee-v0.8.0-windows-x86_64.exe#/lychee.exe",
+            "hash": "2dd4ca34fb3ffe1012c2e09653657c0ba4b62876c002f4331237d2be8aaa103f"
         }
     },
     "bin": "lychee.exe",

--- a/bucket/micronaut.json
+++ b/bucket/micronaut.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.1",
+    "version": "3.1.3",
     "description": "Micronaut - A modern, JVM-based (Java, Groovy, Kotlin), full-stack framework for building modular and testable microservice and serverless applications",
     "homepage": "https://micronaut.io",
     "license": "Apache-2.0",
@@ -9,9 +9,9 @@
             "java/openjdk"
         ]
     },
-    "url": "https://github.com/micronaut-projects/micronaut-starter/releases/download/v3.1.1/micronaut-cli-3.1.1.zip",
-    "hash": "b01dbaf8e15daa7b676679ea84b4a4eb8b3e9438a46cb6b51791a301eca21668",
-    "extract_dir": "micronaut-cli-3.1.1",
+    "url": "https://github.com/micronaut-projects/micronaut-starter/releases/download/v3.1.3/micronaut-cli-3.1.3.zip",
+    "hash": "3261f3d2d15529d551dfe8bcbb4b3476b09a783ace75e5b81da2ef8da3672218",
+    "extract_dir": "micronaut-cli-3.1.3",
     "bin": "bin\\mn.bat",
     "env_set": {
         "MICRONAUT_HOME": "$dir"

--- a/bucket/minio.json
+++ b/bucket/minio.json
@@ -1,5 +1,5 @@
 {
-    "version": "2021-10-23T03-28-24Z",
+    "version": "2021-10-27T16-29-42Z",
     "description": "A high performance, distributed object storage server, designed for large-scale data infrastructure. (server)",
     "homepage": "https://min.io",
     "license": "Apache-2.0",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2021-10-23T03-28-24Z#/minio.exe",
-            "hash": "b368b98bfdecac33f5a0e0d329fa32a901db4afe4f403201b70b8a0dc1fed809"
+            "url": "https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2021-10-27T16-29-42Z#/minio.exe",
+            "hash": "c39acb0abd7dc07dbb0291513c80c7c18aa9f15316f4c6d6c607e3687a8457ff"
         }
     },
     "bin": "minio.exe",

--- a/bucket/mob.json
+++ b/bucket/mob.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.12.0",
+    "version": "2.0.0",
     "description": "Smooth git handover with mob",
     "homepage": "https://mob.sh",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/remotemobprogramming/mob/releases/download/v1.12.0/mob_v1.12.0_windows_amd64.tar.gz",
-            "hash": "md5:19115d799667022a87be9eccd410876e"
+            "url": "https://github.com/remotemobprogramming/mob/releases/download/v2.0.0/mob_v2.0.0_windows_amd64.tar.gz",
+            "hash": "md5:4f8eae479dc2146664a29d003fc7082f"
         }
     },
     "bin": "mob.exe",

--- a/bucket/mutagen.json
+++ b/bucket/mutagen.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.11.8",
+    "version": "0.12.0",
     "description": "Fast, cross-platform, continuous, multidirectional file synchronization for remote development",
     "homepage": "https://mutagen.io/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mutagen-io/mutagen/releases/download/v0.11.8/mutagen_windows_amd64_v0.11.8.zip",
-            "hash": "ca3058794ec9d1fc9a3e190eea91e8efaca74d5206a96e937c23177c8262f6f7"
+            "url": "https://github.com/mutagen-io/mutagen/releases/download/v0.12.0/mutagen_windows_amd64_v0.12.0.zip",
+            "hash": "9a9b1e73213d7afc563256d8c1fc9e2223345b3a2602bcd4acad0d995ff4df74"
         },
         "32bit": {
-            "url": "https://github.com/mutagen-io/mutagen/releases/download/v0.11.8/mutagen_windows_386_v0.11.8.zip",
-            "hash": "368d6ce0622ff6736219d93e1bbfbef753a2ccc5164bcd49adac3e24a890357d"
+            "url": "https://github.com/mutagen-io/mutagen/releases/download/v0.12.0/mutagen_windows_386_v0.12.0.zip",
+            "hash": "50cdd713c79617145f0965ee0c14c35a75ce68988d5c54f32ffe9e3ecda206a5"
         }
     },
     "bin": "mutagen.exe",

--- a/bucket/naiveproxy.json
+++ b/bucket/naiveproxy.json
@@ -1,18 +1,18 @@
 {
-    "version": "95.0.4638.54-1",
+    "version": "95.0.4638.54-3",
     "description": "A proxy using Chrome's network stack to camouflage traffic with strong censorship resistence and low detectablility.",
     "homepage": "https://github.com/klzgrad/naiveproxy",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v95.0.4638.54-1/naiveproxy-v95.0.4638.54-1-win-x64.zip",
-            "hash": "752af03d27ccaa8ad85a1e498f8f0c812b179063f9079776d153a3ef2e309ea0",
-            "extract_dir": "naiveproxy-v95.0.4638.54-1-win-x64"
+            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v95.0.4638.54-3/naiveproxy-v95.0.4638.54-3-win-x64.zip",
+            "hash": "3c23ffca7ae83f411d353abe73d8fcb78dafb3f43b48c264d13a648193c012ba",
+            "extract_dir": "naiveproxy-v95.0.4638.54-3-win-x64"
         },
         "32bit": {
-            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v95.0.4638.54-1/naiveproxy-v95.0.4638.54-1-win-x86.zip",
-            "hash": "5fdf1e06cbada97636e891247b7301ab85cad03d99657ea0856dafdc98bb60e8",
-            "extract_dir": "naiveproxy-v95.0.4638.54-1-win-x86"
+            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v95.0.4638.54-3/naiveproxy-v95.0.4638.54-3-win-x86.zip",
+            "hash": "2ca0b79aa22c1a3e656fc422a3b0d99d77daa23373ab7d08d38f2e4164e08139",
+            "extract_dir": "naiveproxy-v95.0.4638.54-3-win-x86"
         }
     },
     "bin": "naive.exe",

--- a/bucket/oh-my-posh3.json
+++ b/bucket/oh-my-posh3.json
@@ -1,13 +1,13 @@
 {
-    "version": "5.14.1",
+    "version": "5.16.2",
     "description": "A prompt theme engine for any shell",
     "homepage": "https://ohmyposh.dev",
     "license": "GPL-3.0-only",
     "notes": "Refer to 'https://ohmyposh.dev/docs/windows#replace-your-existing-prompt' for shell specific configurations.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v5.14.1/posh-windows-wsl-amd64.7z",
-            "hash": "bc0bb6992ba5c3c09d3df623a2143a80d0dade156be99fe23fe40cc48ab797df"
+            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v5.16.2/posh-windows-wsl-amd64.7z",
+            "hash": "bb2d0da4e9dd59166fcee0e630974e025e6dc495704f21f9084a856396e1bc61"
         }
     },
     "bin": "bin\\oh-my-posh.exe",

--- a/bucket/opa.json
+++ b/bucket/opa.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.33.1",
+    "version": "0.34.0",
     "description": "Policy-based control for cloud native environments",
     "homepage": "https://www.openpolicyagent.org",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_windows_amd64.exe#/opa.exe",
-            "hash": "dbb6fedd4db398ff90973396e4ef4a47a06d50cfec0bc6708171db4e3eed22b7"
+            "url": "https://github.com/open-policy-agent/opa/releases/download/v0.34.0/opa_windows_amd64.exe#/opa.exe",
+            "hash": "ccf1b38a269c7229016967cf178f22a3b21b4ed5f81dd37f0dcc6d7c283c12f6"
         }
     },
     "bin": "opa.exe",

--- a/bucket/s3deploy.json
+++ b/bucket/s3deploy.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. 'Cache-Control')",
     "homepage": "https://github.com/bep/s3deploy",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bep/s3deploy/releases/download/v2.4.0/s3deploy_2.4.0_windows-64bit.zip",
-            "hash": "0ea3a4fd46535fa001ddad0e78a557ba627e0b3f24243fa8f9c57324f092afa5"
+            "url": "https://github.com/bep/s3deploy/releases/download/v2.5.0/s3deploy_2.5.0_windows-64bit.zip",
+            "hash": "749f2ead8763bcfca60fc7f2ce302f8a8b128dca530ec2a59acb0d0783e68e21"
         }
     },
     "bin": "s3deploy.exe",

--- a/bucket/scaleway-cli.json
+++ b/bucket/scaleway-cli.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.3.1",
+    "version": "2.4.0",
     "description": "Manage BareMetal Servers from Command Line (as easily as with Docker).",
     "homepage": "https://github.com/scaleway/scaleway-cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.3.1/scw-2.3.1-windows-x86_64.exe#/scw.exe",
-            "hash": "3aa8f1251c5bc137225af83bbad2d86df19fcda262b4724d84ffac2e712448e9"
+            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.4.0/scw-2.4.0-windows-x86_64.exe#/scw.exe",
+            "hash": "b3d20738c8d266e7b37611a7a12f7ea26073dbef6bb7c34499a590862b25c443"
         },
         "32bit": {
-            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.3.1/scw-2.3.1-windows-386.exe#/scw.exe",
-            "hash": "85f69b8139dd632b8182536ea400bc2afc8fc7c0bdc6e67c88754853fe88b69b"
+            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.4.0/scw-2.4.0-windows-386.exe#/scw.exe",
+            "hash": "fb3042a12619302e20e9c97803182d0c90a9f12dbcbc3b6b91f73ec828bc7476"
         }
     },
     "bin": "scw.exe",

--- a/bucket/telegraf.json
+++ b/bucket/telegraf.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.20.2",
+    "version": "1.20.3",
     "description": "The plugin-driven server agent for collecting & reporting metrics.",
     "homepage": "https://www.influxdata.com/time-series-platform/telegraf/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://dl.influxdata.com/telegraf/releases/telegraf-1.20.2_windows_amd64.zip",
-            "hash": "25eb477ce68b990a359b568fee08137e085010926fbd64d1a36b6e61eaaad979"
+            "url": "https://dl.influxdata.com/telegraf/releases/telegraf-1.20.3_windows_amd64.zip",
+            "hash": "b33aa6dfdd3fd15942bcbfed36dad84812786d878c7b76fa3c931b3351b83580"
         },
         "32bit": {
-            "url": "https://dl.influxdata.com/telegraf/releases/telegraf-1.20.2_windows_i386.zip",
-            "hash": "e86c75ef5584f05135c220154e8ed8a097e29fc4e8ce1683fa21e5e7f787d846"
+            "url": "https://dl.influxdata.com/telegraf/releases/telegraf-1.20.3_windows_i386.zip",
+            "hash": "6ca4894106ffd3697ded13074f180a50d194084044e942fe2c5b520261939c01"
         }
     },
-    "extract_dir": "telegraf-1.20.2",
+    "extract_dir": "telegraf-1.20.3",
     "bin": "telegraf.exe",
     "persist": "telegraf.conf",
     "env_set": {

--- a/bucket/terragrunt.json
+++ b/bucket/terragrunt.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.35.4",
+    "version": "0.35.5",
     "description": "Thin wrapper for Terraform that provides extra tools for keeping Terraform configurations DRY, working with multiple Terraform modules, and managing remote state.",
     "homepage": "https://github.com/gruntwork-io/terragrunt",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/gruntwork-io/terragrunt/releases/download/v0.35.4/terragrunt_windows_amd64.exe#/terragrunt.exe",
-            "hash": "b3032791bd06553f46ade95aba74dd0d1ac1d5c21c424559f36b66369fb07c1b"
+            "url": "https://github.com/gruntwork-io/terragrunt/releases/download/v0.35.5/terragrunt_windows_amd64.exe#/terragrunt.exe",
+            "hash": "0177f6c5b3b56e5b3c4e7d637f0e0c0a12c9145e5da90b1858d9fb4af7d92678"
         },
         "32bit": {
-            "url": "https://github.com/gruntwork-io/terragrunt/releases/download/v0.35.4/terragrunt_windows_386.exe#/terragrunt.exe",
-            "hash": "e4ac5b914bca27d5f7602d163c828d9c4cc9f9063a35e1da6a1e355f9becbc5b"
+            "url": "https://github.com/gruntwork-io/terragrunt/releases/download/v0.35.5/terragrunt_windows_386.exe#/terragrunt.exe",
+            "hash": "091990faae3a1f9533a3b4ef7000b0b65a9705ffd65eb02be525f50887a75e45"
         }
     },
     "bin": "terragrunt.exe",

--- a/bucket/topgrade.json
+++ b/bucket/topgrade.json
@@ -1,12 +1,12 @@
 {
-    "version": "8.0.0",
+    "version": "8.0.3",
     "description": "Upgrade everything, keep your system up to date by detecting which tools you use and run their appropriate package managers.",
     "homepage": "https://github.com/r-darwish/topgrade",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/r-darwish/topgrade/releases/download/v8.0.0/topgrade-v8.0.0-x86_64-pc-windows-msvc.zip",
-            "hash": "7beb1e58be4c6faee37978cd61879e961afa7b256bcc9ecb4272ac4cee146fc7"
+            "url": "https://github.com/r-darwish/topgrade/releases/download/v8.0.3/topgrade-v8.0.3-x86_64-pc-windows-msvc.zip",
+            "hash": "1797e4b8910be554aad7b926aeffae1a256d696dd179f501f2cf628ffda6d57e"
         }
     },
     "bin": "topgrade.exe",

--- a/bucket/zeebe.json
+++ b/bucket/zeebe.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.0",
+    "version": "1.2.2",
     "description": "Distributed Workflow Engine for Microservices Orchestration",
     "homepage": "https://camunda.com/products/cloud/workflow-engine/",
     "license": {
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/camunda-cloud/zeebe/releases/download/1.2.0/camunda-cloud-zeebe-1.2.0.zip",
-            "hash": "sha1:5bda6a443bfa1a629e2dba7806b1c6cf2ed1631c"
+            "url": "https://github.com/camunda-cloud/zeebe/releases/download/1.2.2/camunda-cloud-zeebe-1.2.2.zip",
+            "hash": "sha1:6ddadc03274c267a8d69e937cc381995a27733dd"
         }
     },
-    "extract_dir": "camunda-cloud-zeebe-1.2.0",
+    "extract_dir": "camunda-cloud-zeebe-1.2.2",
     "bin": [
         [
             "bin\\broker.bat",


### PR DESCRIPTION
Update version and hash for :
- helix
- k3d
- kubefwd
- lean-cli
- lychee
- micronaut
- minio
- mob
- mutagen
- naiveproxy
- oh-my-posh3
- opa
- s3deploy
- scaleway-cli
- telegraf
- terragrunt
- topgrade
- zeebe