### PR TITLE
Correct autoupdate-fix for #2844

### DIFF
--- a/bucket/vim-nightly.json
+++ b/bucket/vim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.2.3564",
+    "version": "8.2.3565",
     "description": "A highly configurable text editor for efficiently creating and changing any kind of text.",
     "homepage": "https://www.vim.org",
     "license": "Vim",
@@ -10,12 +10,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/vim/vim-win32-installer/releases/download/v8.2.3564/gvim_8.2.3564_x64.zip",
+                "https://github.com/vim/vim-win32-installer/releases/download/v8.2.3565/gvim_8.2.3565_x64.zip",
                 "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/vim/install-context.reg",
                 "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/vim/uninstall-context.reg"
             ],
             "hash": [
-                "18c9906824e76f16f6adaf54becd29293d27aacc471203287cfe039d3a0dc0de",
+                "3f60ada7d00da1534aa5cb8fe88743e3af7c46a268a1ff7f5f99275e3f1cfcb4",
                 "16a29881837047d783e8556506c73bbb292bdfefe042d77564d3c166d92b9d98",
                 "49225d3470bf4b397d3cab865eddca6e47610be356f812588588c2661a11557e"
             ]

--- a/bucket/vim-nightly.json
+++ b/bucket/vim-nightly.json
@@ -19,18 +19,6 @@
                 "16a29881837047d783e8556506c73bbb292bdfefe042d77564d3c166d92b9d98",
                 "49225d3470bf4b397d3cab865eddca6e47610be356f812588588c2661a11557e"
             ]
-        },
-        "32bit": {
-            "url": [
-                "https://github.com/vim/vim-win32-installer/releases/download/v8.2.3564/gvim_8.2.3564_x86.zip",
-                "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/vim/install-context.reg",
-                "https://raw.githubusercontent.com/ScoopInstaller/Main/master/master/scripts/vim/uninstall-context.reg"
-            ],
-            "hash": [
-                "d32a48f6a3222522b1db0db8f2dd118ba3bc7bfc15c04c90b1cc4c31d3e7346b",
-                "16a29881837047d783e8556506c73bbb292bdfefe042d77564d3c166d92b9d98",
-                "49225d3470bf4b397d3cab865eddca6e47610be356f812588588c2661a11557e"
-            ]
         }
     },
     "extract_dir": "vim\\vim82",
@@ -132,9 +120,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x86.zip"
             }
         },
         "extract_dir": "vim\\vim$majorVersion$minorVersion"

--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.1.19.1138",
+    "version": "2.1.19.1142",
     "description": "A Simple ACME Client",
     "homepage": "https://www.win-acme.com",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/win-acme/win-acme/releases/download/v2.1.19.1138/win-acme.v2.1.19.1138.x64.trimmed.zip",
-            "hash": "7dd85cac6ce5eefb52114ac2e6d041ababfcdb8534c521c1537039d15c10ff31"
+            "url": "https://github.com/win-acme/win-acme/releases/download/v2.1.19.1142/win-acme.v2.1.19.1142.x64.trimmed.zip",
+            "hash": "9b25c9ffa8ed4ae6034661d5e53e6b19a465fc94cc6d948c5a329edaf6037d43"
         },
         "32bit": {
-            "url": "https://github.com/win-acme/win-acme/releases/download/v2.1.19.1138/win-acme.v2.1.19.1138.x86.trimmed.zip",
-            "hash": "9b61bf8167649f62b982fdfcf9f6506fa152a8f43600f2ae5d875ca4df1dc00b"
+            "url": "https://github.com/win-acme/win-acme/releases/download/v2.1.19.1142/win-acme.v2.1.19.1142.x86.trimmed.zip",
+            "hash": "0bb2079636427bfe365db783e8b642fa1577dc243c68248e1244ed9888d60149"
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\settings.json\")) { Copy-Item \"$dir\\settings_default.json\" \"$dir\\settings.json\" }",

--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -23,10 +23,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/win-acme/win-acme/releases/download/v$matchHead/win-acme.v$version.x64.trimmed.zip"
+                "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x64.trimmed.zip"
             },
             "32bit": {
-                "url": "https://github.com/win-acme/win-acme/releases/download/v$matchHead/win-acme.v$version.x86.trimmed.zip"
+                "url": "https://github.com/win-acme/win-acme/releases/download/v$version/win-acme.v$version.x86.trimmed.zip"
             }
         }
     }


### PR DESCRIPTION
Fix #2844

- vim-nightly : no more win32
- win-acme : path change