### PR TITLE
Manifests update 11 01 21

### DIFF
--- a/bucket/clink.json
+++ b/bucket/clink.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.40",
+    "version": "1.2.41",
     "description": "Powerful Bash-style command line editing for cmd.exe",
     "homepage": "https://chrisant996.github.io/clink/",
     "license": "GPL-3.0-only",
@@ -7,8 +7,8 @@
         "Run 'clink inject' to start clink on the current cmd",
         "Run 'clink autorun install' to auto start clink"
     ],
-    "url": "https://github.com/chrisant996/clink/releases/download/v1.2.40/clink.1.2.40.a4d3a0.zip",
-    "hash": "73b4b755f30b2881faf470f95a171609165652b984a761b3ac4e70e55b51e20f",
+    "url": "https://github.com/chrisant996/clink/releases/download/v1.2.41/clink.1.2.41.647c1b.zip",
+    "hash": "bab0ecb6a754d3b3411626d59f755e2cb47656c06e0b21f4558659591ba113a8",
     "bin": "clink.bat",
     "persist": "profile",
     "checkver": {

--- a/bucket/concourse-fly.json
+++ b/bucket/concourse-fly.json
@@ -1,12 +1,12 @@
 {
-    "version": "7.6.0",
+    "version": "7.4.2",
     "description": "Concourse CI/CD manager and controller",
     "homepage": "https://concourse-ci.org/fly.html",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/concourse/concourse/releases/download/v7.6.0/fly-7.6.0-windows-amd64.zip",
-            "hash": "sha1:ff17465907969c50730f64ca11baa846b8c9443b"
+            "url": "https://github.com/concourse/concourse/releases/download/v7.4.2/fly-7.4.2-windows-amd64.zip",
+            "hash": "sha1:ea9ab68fac2cac4aecd407a754abdf95c1f73be5"
         }
     },
     "bin": "fly.exe",

--- a/bucket/gawk.json
+++ b/bucket/gawk.json
@@ -1,10 +1,10 @@
 {
-    "version": "5.1.0",
+    "version": "5.1.1",
     "description": "Interprets a special-purpose programming language that makes it possible to handle simple data-reformatting jobs with just a few lines of code.",
     "homepage": "https://sourceforge.net/projects/ezwinports/",
     "license": "GPL-3.0-only",
-    "url": "https://downloads.sourceforge.net/project/ezwinports/gawk-5.1.0-w32-bin.zip",
-    "hash": "sha1:e2d5c2901deda9394dc3821766e46527d8363f1d",
+    "url": "https://downloads.sourceforge.net/project/ezwinports/gawk-5.1.1-w32-bin.zip",
+    "hash": "sha1:a52f5bfc03e861f740ce73b7cb294df71a25b22a",
     "bin": [
         "bin\\awk.exe",
         "bin\\gawk.exe",

--- a/bucket/just.json
+++ b/bucket/just.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "A command runner written in rust",
     "homepage": "https://just.systems",
     "license": "CC0-1.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/casey/just/releases/download/0.10.2/just-0.10.2-x86_64-pc-windows-msvc.zip",
-            "hash": "745c0bad2d771c7a471a561b03141f5fe0a4bcb1a9d2fe8026d8306ffb80ce35"
+            "url": "https://github.com/casey/just/releases/download/0.10.3/just-0.10.3-x86_64-pc-windows-msvc.zip",
+            "hash": "ffcf9b0a31666419cdedf059966463824347e57692ceac1e2470b48e94d0e494"
         }
     },
     "bin": "just.exe",

--- a/bucket/jx.json
+++ b/bucket/jx.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.2.210",
+    "version": "3.2.211",
     "description": "A command line tool for installing and using Jenkins X",
     "homepage": "https://github.com/jenkins-x/jx",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jenkins-x/jx/releases/download/v3.2.210/jx-windows-amd64.zip",
-            "hash": "794cc858d1b913254219b3da0bf833e3403ff813a71ea26fe85ccf3fe17358d9"
+            "url": "https://github.com/jenkins-x/jx/releases/download/v3.2.211/jx-windows-amd64.zip",
+            "hash": "09455cbbb4200ad2edbe751bc7eb99b2b1bd2124c522181856be6839bec7dd80"
         }
     },
     "pre_install": "Stop-Process -Name 'jx' -ErrorAction 'Ignore' -Verbose",

--- a/bucket/k3d.json
+++ b/bucket/k3d.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0.2",
+    "version": "5.0.3",
     "description": "Creates multi-node k3s cluster on a single machine using docker",
     "homepage": "https://github.com/rancher/k3d",
     "license": "MIT",
@@ -12,8 +12,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rancher/k3d/releases/download/v5.0.2/k3d-windows-amd64.exe#/k3d.exe",
-            "hash": "b4af92aaf6244d13c8bc3478ea8291a8948056b412dc2b73d68074d732452ec4"
+            "url": "https://github.com/rancher/k3d/releases/download/v5.0.3/k3d-windows-amd64.exe#/k3d.exe",
+            "hash": "9081316aade8288a810b6e730db1f9688cc08d6ba5b4bb1e73e70803587ba950"
         }
     },
     "bin": "k3d.exe",

--- a/bucket/lessmsi.json
+++ b/bucket/lessmsi.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.8.3",
+    "version": "1.9.0",
     "description": "Windows Installer (.msi) files content viewer and extractor.",
     "homepage": "https://lessmsi.activescott.com",
     "license": "MIT",
-    "url": "https://github.com/activescott/lessmsi/releases/download/v1.8.3/lessmsi-v1.8.3.zip",
-    "hash": "1cf8599068e1b137a7dee6cff89fa11fb2e43b71ea382ce8e6a8dba0b45868df",
+    "url": "https://github.com/activescott/lessmsi/releases/download/v1.9.0/lessmsi-v1.9.0.zip",
+    "hash": "12d923e3a7aa0d26aa44a2d70eede050d86614b3e0badbd829fbe9a742a58ab6",
     "bin": "lessmsi.exe",
     "shortcuts": [
         [

--- a/bucket/macchina.json
+++ b/bucket/macchina.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.0.1",
+    "version": "5.0.0",
     "description": "A system information fetcher, with an emphasis on performance and minimalism",
     "homepage": "https://github.com/Macchina-CLI/macchina",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Macchina-CLI/macchina/releases/download/v4.0.1/macchina-windows-x86_64.exe#/macchina.exe",
-            "hash": "db207756a6c314c390354e5f8c60ea4f49e587bc3cc6829ba162521c11dcaa4f"
+            "url": "https://github.com/Macchina-CLI/macchina/releases/download/v5.0.0/macchina-windows-x86_64.exe#/macchina.exe",
+            "hash": "830d5234b48c6741a98c6067e19ae915f15067e148a47b2f24b47d0fe5d930b9"
         }
     },
     "bin": "macchina.exe",

--- a/bucket/mdcat.json
+++ b/bucket/mdcat.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.23.2",
+    "version": "0.24.1",
     "description": "cat for markdown",
     "homepage": "https://github.com/lunaryorn/mdcat",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lunaryorn/mdcat/releases/download/mdcat-0.23.2/mdcat-0.23.2-x86_64-pc-windows-msvc.zip",
-            "hash": "sha512:6d2d341b891d6efb608404604248ae545a908ce7bd8abd2907450192312ba6ebb036088da46e380116a75fc8604e348e5049ff4a21717251b2d42f5942d2400f"
+            "url": "https://github.com/lunaryorn/mdcat/releases/download/mdcat-0.24.1/mdcat-0.24.1-x86_64-pc-windows-msvc.zip",
+            "hash": "sha512:1a9a28e3f758e954339b1ee4d3f1104936d4205866a1cafb729f24793583edd3b30892a2b8f30e77c03d28354aef9d43321eb0bd8bd8749661021b47864d25d5"
         }
     },
     "bin": "mdcat.exe",

--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.0-dev-525-ge921e98ce",
+    "version": "0.6.0-dev-544-g7ae86c1d4",
     "description": "Vim fork focused on extensibility and usability",
     "homepage": "https://neovim.io",
     "license": {

--- a/bucket/oh-my-posh3.json
+++ b/bucket/oh-my-posh3.json
@@ -1,13 +1,13 @@
 {
-    "version": "5.16.2",
+    "version": "5.16.4",
     "description": "A prompt theme engine for any shell",
     "homepage": "https://ohmyposh.dev",
     "license": "GPL-3.0-only",
     "notes": "Refer to 'https://ohmyposh.dev/docs/windows#replace-your-existing-prompt' for shell specific configurations.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v5.16.2/posh-windows-wsl-amd64.7z",
-            "hash": "bb2d0da4e9dd59166fcee0e630974e025e6dc495704f21f9084a856396e1bc61"
+            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v5.16.4/posh-windows-wsl-amd64.7z",
+            "hash": "04552604dc1f169cbfce39eead3b176c8b9bb696ca3d422bb1e82c0a0f460074"
         }
     },
     "bin": "bin\\oh-my-posh.exe",

--- a/bucket/pandoc.json
+++ b/bucket/pandoc.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.15",
+    "version": "2.16",
     "description": "Universal markup converter",
     "homepage": "https://pandoc.org",
     "license": "GPL-2.0-or-later",
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jgm/pandoc/releases/download/2.15/pandoc-2.15-windows-x86_64.zip",
-            "hash": "a106d810eaa736b03c6d30b7c3e5620e0937989d4482ce7f1351427ceccfce98"
+            "url": "https://github.com/jgm/pandoc/releases/download/2.16/pandoc-2.16-windows-x86_64.zip",
+            "hash": "e60217de897aa89d2d03ccb1734ea8874e839a11965cf389680bbe22404da9a1"
         }
     },
-    "extract_dir": "pandoc-2.15",
+    "extract_dir": "pandoc-2.16",
     "bin": "pandoc.exe",
     "checkver": {
         "github": "https://github.com/jgm/pandoc"

--- a/bucket/rink.json
+++ b/bucket/rink.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "A tool for unit conversions, calculations, and dimensionality analysis",
     "homepage": "https://github.com/tiffany352/rink-rs",
     "license": "MPL-2.0,GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tiffany352/rink-rs/releases/download/v0.6.1/Rink.CLI.Windows.zip",
-            "hash": "d54a71da9d6b5b0762dbeb2780b56b9ae68b6e9c2ced1e0e4fb477f3cc1e03e7"
+            "url": "https://github.com/tiffany352/rink-rs/releases/download/v0.6.2/Rink.CLI.Windows.zip",
+            "hash": "d937db037311d68f6a9264c1592d22ee6b65ebbc7b150d0e46224a551e0d3301"
         }
     },
     "bin": "rink.exe",

--- a/bucket/rust-analyzer.json
+++ b/bucket/rust-analyzer.json
@@ -1,12 +1,12 @@
 {
-    "version": "2021-10-25",
+    "version": "2021-11-01",
     "description": "An experimental Rust compiler front-end for IDEs",
     "homepage": "https://rust-analyzer.github.io/",
     "license": "Apache-2.0|MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rust-analyzer/rust-analyzer/releases/download/2021-10-25/rust-analyzer-x86_64-pc-windows-msvc.gz",
-            "hash": "ffbbc28f59cef772dd19c266cf8960c2eb872e47a36fe903f49b92f30d8fad2d"
+            "url": "https://github.com/rust-analyzer/rust-analyzer/releases/download/2021-11-01/rust-analyzer-x86_64-pc-windows-msvc.gz",
+            "hash": "12ce024ef3e22172b3b630f05f49b0b43eb25581ad4ad830c84329c92ffbb1c1"
         }
     },
     "pre_install": "Rename-Item \"$dir\\$($fname -replace '\\.gz$')\" 'rust-analyzer.exe'",

--- a/bucket/s3deploy.json
+++ b/bucket/s3deploy.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "Deploy static websites to Amazon S3 and CloudFront with Gzip and custom headers support (e.g. 'Cache-Control')",
     "homepage": "https://github.com/bep/s3deploy",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bep/s3deploy/releases/download/v2.5.0/s3deploy_2.5.0_windows-64bit.zip",
-            "hash": "749f2ead8763bcfca60fc7f2ce302f8a8b128dca530ec2a59acb0d0783e68e21"
+            "url": "https://github.com/bep/s3deploy/releases/download/v2.5.1/s3deploy_2.5.1_windows-64bit.zip",
+            "hash": "4273aa24e3ceb489eb0776a38a34867ee4e8b3bf92af295485342dbc44a9f0fd"
         }
     },
     "bin": "s3deploy.exe",

--- a/bucket/tflint.json
+++ b/bucket/tflint.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.33.0",
+    "version": "0.33.1",
     "description": "A Terraform linter focused on possible errors, best practices, etc.",
     "homepage": "https://github.com/terraform-linters/tflint",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/terraform-linters/tflint/releases/download/v0.33.0/tflint_windows_amd64.zip",
-            "hash": "46d0af62d0b8f51e5d7e81bdd0242b79bffd1ed5d60735bdbd767d2b50dc829b"
+            "url": "https://github.com/terraform-linters/tflint/releases/download/v0.33.1/tflint_windows_amd64.zip",
+            "hash": "4ed4ce569638480ea29a71386cb81a0865a918320d87ab1248327588f8e26743"
         },
         "32bit": {
-            "url": "https://github.com/terraform-linters/tflint/releases/download/v0.33.0/tflint_windows_386.zip",
-            "hash": "ee9f293767fa509476dec134b3309a24c60c7951e2a57d64d2fd86f2b1af18e2"
+            "url": "https://github.com/terraform-linters/tflint/releases/download/v0.33.1/tflint_windows_386.zip",
+            "hash": "2633246daffaca52d95688c903e94d93ac2fe772a8c4c5c2828d14a0f3a4a226"
         }
     },
     "bin": "tflint.exe",

--- a/bucket/vim-nightly.json
+++ b/bucket/vim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.2.3565",
+    "version": "8.2.3568",
     "description": "A highly configurable text editor for efficiently creating and changing any kind of text.",
     "homepage": "https://www.vim.org",
     "license": "Vim",
@@ -10,12 +10,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/vim/vim-win32-installer/releases/download/v8.2.3565/gvim_8.2.3565_x64.zip",
+                "https://github.com/vim/vim-win32-installer/releases/download/v8.2.3568/gvim_8.2.3568_x64.zip",
                 "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/vim/install-context.reg",
                 "https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/vim/uninstall-context.reg"
             ],
             "hash": [
-                "3f60ada7d00da1534aa5cb8fe88743e3af7c46a268a1ff7f5f99275e3f1cfcb4",
+                "d3f4902c0c39402248f0b54210b809dbaaf4bda0aab4bb1a2ab37ff3cc22c49b",
                 "16a29881837047d783e8556506c73bbb292bdfefe042d77564d3c166d92b9d98",
                 "49225d3470bf4b397d3cab865eddca6e47610be356f812588588c2661a11557e"
             ]

--- a/bucket/wasmtime.json
+++ b/bucket/wasmtime.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.30.0",
+    "version": "0.31.0",
     "description": "Standalone JIT-style runtime for WebAssembly, using Cranelift",
     "homepage": "https://wasmtime.dev",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-x86_64-windows.zip",
-            "hash": "85268ada8df5a10655fe3539c3d8ef120b6d06c2c00f166241381ce4c51e6a69",
-            "extract_dir": "wasmtime-v0.30.0-x86_64-windows"
+            "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-x86_64-windows.zip",
+            "hash": "48b410f6db9548f0c89ae370cd31a02e9a0119edc9d39af5f9798ab192bab566",
+            "extract_dir": "wasmtime-v0.31.0-x86_64-windows"
         }
     },
     "bin": "wasmtime.exe",

--- a/bucket/xmake.json
+++ b/bucket/xmake.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.5.8",
+    "version": "2.5.9",
     "description": "A cross-platform build utility based on Lua",
     "homepage": "https://xmake.io",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/xmake-io/xmake/releases/download/v2.5.8/xmake-v2.5.8.win64.zip",
-            "hash": "829c44b603062f5a8eeb02a89f42dbbf5913ef55c6d47d43a885e2b2344f38bc"
+            "url": "https://github.com/xmake-io/xmake/releases/download/v2.5.9/xmake-v2.5.9.win64.zip",
+            "hash": "64c033965d8d42a54a600a6e8ce62bb6c0531c2f0e01fc0b2b4c9c32046c89f9"
         },
         "32bit": {
-            "url": "https://github.com/xmake-io/xmake/releases/download/v2.5.8/xmake-v2.5.8.win32.zip",
-            "hash": "b8beb1557e4d80b2ea5ad28ae2fc5d4399897ba6129f0f27be24abf70c0d2269"
+            "url": "https://github.com/xmake-io/xmake/releases/download/v2.5.9/xmake-v2.5.9.win32.zip",
+            "hash": "84d062942eb5df54c50c762c55fc648c3d731be948aab03ae911ffbb4b00ea00"
         }
     },
     "extract_dir": "xmake",

--- a/bucket/yq.json
+++ b/bucket/yq.json
@@ -1,16 +1,16 @@
 {
-    "version": "4.13.5",
+    "version": "4.14.1",
     "description": "A portable command-line YAML processor",
     "homepage": "https://mikefarah.gitbook.io/yq/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_windows_amd64.exe#/yq.exe",
-            "hash": "e45ad07b3bdae4be77979a7080e62973658ea22156c7877b0f6e47c3b0f82723"
+            "url": "https://github.com/mikefarah/yq/releases/download/v4.14.1/yq_windows_amd64.exe#/yq.exe",
+            "hash": "be2028ffadd97339ec38ce139f7d07cfd8f0c5920836adde65106aa4e386a354"
         },
         "32bit": {
-            "url": "https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_windows_386.exe#/yq.exe",
-            "hash": "fc36681bf015b4e58f63c72b2cc9215ee5e683e45e62120b6b599f3e7d4fb99b"
+            "url": "https://github.com/mikefarah/yq/releases/download/v4.14.1/yq_windows_386.exe#/yq.exe",
+            "hash": "43b727f813262412fa3b2689427e81a2bb7577ca5e3760d24ec64a513dae79f3"
         }
     },
     "bin": "yq.exe",


### PR DESCRIPTION
**Update manifest for** 
* clink.json
* concourse-fly.json
* gawk.json
* just.json
* jx.json
* k3d.json
* lessmsi.json
* macchina.json
* mdcat.json
* neovim-nightly.json
* oh-my-posh3.json
* pandoc.json
* rink.json
* rust-analyzer.json
* s3deploy.json
* tflint.json
* vim-nightly.json
* wasmtime.json
* xmake.json
* yq.json

Tested (install / uninstall )

**Not updated :** 
* terraform-provider-ibm.json

Dependancy to version bucket. Not tested