### PR TITLE
freepascal: Add version 3.2.2 #845

### DIFF
--- a/bucket/freepascal.json
+++ b/bucket/freepascal.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://www.freepascal.org",
+    "version": "3.2.2",
+    "description": "Professional Pascal compiler.",
+    "license": {
+        "identifier": "GPL-2.0-or-later | FPC-modified-LGPL-2.0-or-later",
+        "url": "http://wiki.lazarus.freepascal.org/licensing"
+    },
+    "url": "https://downloads.sourceforge.net/project/freepascal/Win32/3.2.2/fpc-3.2.2.i386-win32.exe",
+    "hash": "sha1:c3fc24290da7349e4fba763eaadd2a5bec07bfa3",
+    "innosetup": true,
+    "bin": [
+        "bin\\i386-win32\\fp.exe",
+        "bin\\i386-win32\\fpc.exe"
+    ],
+    "shortcuts": [
+        [
+            "bin\\i386-win32\\fp.exe",
+            "Free Pascal IDE",
+            "",
+            "bin\\i386-win32\\fp32.ico"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/p/freepascal/news/?source=navbar",
+        "regex": "Free Pascal ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/freepascal/Win32/$version/fpc-$version.i386-win32.exe"
+    }
+}


### PR DESCRIPTION
- Closes #844 

Providing definition file that will allow scoop install `freepascal` compiler (FPC) 

Thanks to https://github.com/shytikov for contribution