### PR TITLE
rust: Update to version 1.56.1

### DIFF
--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.56.0",
+    "version": "1.56.1",
     "description": "A language empowering everyone to build reliable and efficient software. (GNU toolchain)",
     "homepage": "https://www.rust-lang.org",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.56.0-x86_64-pc-windows-gnu.msi",
-            "hash": "699fe30b7f46a8e12f7e0067f5127168aa237154322dd962ce8172644868094b"
+            "url": "https://static.rust-lang.org/dist/rust-1.56.1-x86_64-pc-windows-gnu.msi",
+            "hash": "C7E8B912E2AC2C84E36AD22D86DC61B5C46D8675A0527EDB8E35C46C299D59DE"
         },
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.56.0-i686-pc-windows-gnu.msi",
-            "hash": "aeff433b01d47d09bd942630fc9f811e94a1302b8a2a225f5892434a23f2ebac"
+            "url": "https://static.rust-lang.org/dist/rust-1.56.1-i686-pc-windows-gnu.msi",
+            "hash": "41285B335C96FF64765653C8199403C3FDE9B7626C4AF40E3A334AEE59B69476"
         }
     },
     "extract_dir": "Rust",


### PR DESCRIPTION
- Update 1.56.0 -> 1.56.1
[https://github.com/rust-lang/rust/releases/tag/1.56.1](https://github.com/rust-lang/rust/releases/tag/1.56.1)
[https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html](https://github.com/rust-lang/rust/releases/tag/1.56.1)