### PR TITLE
ImageMagick - includes DLLs for programming APIs

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -21,7 +21,6 @@
         "compare.exe",
         "composite.exe",
         "conjure.exe",
-        "convert.exe",
         [
             "convert.exe",
             "imconvert"
@@ -42,7 +41,7 @@
     "post_install": [
         "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old"
     ],
-    "notes": "The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - if you need it, run 'scoop install ffmpeg' for the latest version",
+    "notes": "- The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - if you need it, run 'scoop install ffmpeg' for the latest version.\n- 'convert.exe' has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command.\n",
     "checkver": {
         "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -3,9 +3,6 @@
     "description": "Create, edit, compose, and convert 200+ of bitmap images formats.",
     "homepage": "https://imagemagick.org/",
     "license": "ImageMagick",
-    "suggest": {
-        "ffmpeg": "ffmpeg"
-    },
     "architecture": {
         "64bit": {
             "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x64-dll.exe",
@@ -26,7 +23,7 @@
         "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old",
         "Rename-Item $dir\\convert.exe $dir\\imconvert.exe"
     ],
-    "notes": "- The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - if you need it, run 'scoop install ffmpeg' for the latest version.\n- 'convert.exe' has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command.\n",
+    "notes": "- The bundled ffmpeg has been renamed to 'ffmpeg.exe.old' to prevent conflict with a standalone ffmpeg installation - if you need it for ImageMagick tools, rename it back to 'ffmpeg.exe'.\n- 'convert.exe' has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command.",
     "checkver": {
         "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -3,7 +3,9 @@
     "description": "Create, edit, compose, and convert 200+ of bitmap images formats.",
     "homepage": "https://imagemagick.org/",
     "license": "ImageMagick",
-    "depends": "ffmpeg",
+    "suggest": {
+        "ffmpeg": "ffmpeg"
+    },
     "architecture": {
         "64bit": {
             "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x64-dll.exe",
@@ -40,7 +42,7 @@
     "post_install": [
         "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old"
     ],
-    "notes": "The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - scoop will install the latest ffmpeg instead.",
+    "notes": "The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - if you need it, run 'scoop install ffmpeg' for the latest version",
     "checkver": {
         "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -17,29 +17,14 @@
         }
     },
     "innosetup": true,
-    "bin": [
-        "compare.exe",
-        "composite.exe",
-        "conjure.exe",
-        [
-            "convert.exe",
-            "imconvert"
-        ],
-        "dcraw.exe",
-        "identify.exe",
-        "IMDisplay.exe",
-        "magick.exe",
-        "mogrify.exe",
-        "montage.exe",
-        "stream.exe"
-    ],
     "env_set": {
         "MAGICK_HOME": "$dir",
         "MAGICK_CODER_MODULE_PATH": "$dir\\modules\\coders"
     },
     "env_add_path": ".",
     "post_install": [
-        "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old"
+        "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old",
+        "Rename-Item $dir\\convert.exe $dir\\imconvert.exe"
     ],
     "notes": "- The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - if you need it, run 'scoop install ffmpeg' for the latest version.\n- 'convert.exe' has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command.\n",
     "checkver": {

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -14,28 +14,16 @@
         }
     },
     "innosetup": true,
-    "bin": [
-        "compare.exe",
-        "composite.exe",
-        "conjure.exe",
-        "dcraw.exe",
-        "identify.exe",
-        "IMDisplay.exe",
-        "magick.exe",
-        "mogrify.exe",
-        "montage.exe",
-        "stream.exe"
-    ],
     "env_set": {
         "MAGICK_HOME": "$dir",
         "MAGICK_CODER_MODULE_PATH": "$dir\\modules\\coders"
     },
     "env_add_path": ".",
-    "post_install": [
-        "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old",
-        "Rename-Item $dir\\convert.exe $dir\\imconvert.exe"
+    "post_install": "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old",
+    "notes": [
+        "- The bundled ffmpeg has been renamed to 'ffmpeg.exe.old' to prevent conflict with a standalone ffmpeg installation - if you need it for ImageMagick tools, rename it back to 'ffmpeg.exe'.",
+        "- 'convert.exe' is deprecated in v7 (it also conflicts with the builtin Windows 'convert' utility). Use 'magick convert ...' instead."
     ],
-    "notes": "- The bundled ffmpeg has been renamed to 'ffmpeg.exe.old' to prevent conflict with a standalone ffmpeg installation - if you need it for ImageMagick tools, rename it back to 'ffmpeg.exe'.\n- 'convert.exe' is deprecated in v7 and has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command. Use 'magick convert ...' instead.",
     "checkver": {
         "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -5,11 +5,11 @@
     "license": "ImageMagick",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x64-dll.exe",
+            "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x64-dll.exe",
             "hash": "c4607f68794f9e8e5ed73b1c0a295aae8e612c4b63b163e65c5f2669068b78d0"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x86-dll.exe",
+            "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x86-dll.exe",
             "hash": "477bf261a8ad6d3034e0b6f58ce7abdeb9a2c6186c9caef34e64fe9e24eafa42"
         }
     },
@@ -31,10 +31,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x64-dll.exe"
+                "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x64-dll.exe"
             },
             "32bit": {
-                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x86-dll.exe"
+                "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x86-dll.exe"
             }
         },
         "hash": {

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -6,14 +6,15 @@
     "depends": "ffmpeg",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-portable-Q16-x64.zip",
-            "hash": "946f3ff4a3a25621820cedf020796c897a987830bf0e471ec97611f25bd24215"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x64-dll.exe",
+            "hash": "c4607f68794f9e8e5ed73b1c0a295aae8e612c4b63b163e65c5f2669068b78d0"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-portable-Q16-x86.zip",
-            "hash": "d336cd19c6acb7fa5cddfd476a1f814631e3343e1fbd31310b1954bde85aa129"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.1.0-13-Q16-HDRI-x86-dll.exe",
+            "hash": "477bf261a8ad6d3034e0b6f58ce7abdeb9a2c6186c9caef34e64fe9e24eafa42"
         }
     },
+    "innosetup": true,
     "bin": [
         "compare.exe",
         "composite.exe",
@@ -31,14 +32,23 @@
         "montage.exe",
         "stream.exe"
     ],
+    "env_set": {
+        "MAGICK_HOME": "$dir",
+        "MAGICK_CODER_MODULE_PATH": "$dir\\modules\\coders"
+    },
+    "env_add_path": ".",
+    "post_install": [
+        "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old"
+    ],
+    "notes": "The bundled ffmpeg is outdated and has been renamed to ffmpeg.exe.old - scoop will install the latest ffmpeg instead.",
     "checkver": "The current release is ImageMagick <a.*?>([\\d.p-]+)</a>",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$matchHead-portable-Q16-x64.zip"
+                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x64-dll.exe"
             },
             "32bit": {
-                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$matchHead-portable-Q16-x86.zip"
+                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x86-dll.exe"
             }
         },
         "hash": {

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -14,6 +14,18 @@
         }
     },
     "innosetup": true,
+    "bin": [
+        "compare.exe",
+        "composite.exe",
+        "conjure.exe",
+        "dcraw.exe",
+        "identify.exe",
+        "IMDisplay.exe",
+        "magick.exe",
+        "mogrify.exe",
+        "montage.exe",
+        "stream.exe"
+    ],
     "env_set": {
         "MAGICK_HOME": "$dir",
         "MAGICK_CODER_MODULE_PATH": "$dir\\modules\\coders"
@@ -23,7 +35,7 @@
         "Rename-Item $dir\\ffmpeg.exe $dir\\ffmpeg.exe.old",
         "Rename-Item $dir\\convert.exe $dir\\imconvert.exe"
     ],
-    "notes": "- The bundled ffmpeg has been renamed to 'ffmpeg.exe.old' to prevent conflict with a standalone ffmpeg installation - if you need it for ImageMagick tools, rename it back to 'ffmpeg.exe'.\n- 'convert.exe' has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command.",
+    "notes": "- The bundled ffmpeg has been renamed to 'ffmpeg.exe.old' to prevent conflict with a standalone ffmpeg installation - if you need it for ImageMagick tools, rename it back to 'ffmpeg.exe'.\n- 'convert.exe' is deprecated in v7 and has been renamed to 'imconvert.exe' so that it does not conflict with the built-in command. Use 'magick convert ...' instead.",
     "checkver": {
         "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"


### PR DESCRIPTION
The manifest now downloads the full installer and unpacks it rather than the portable version. It also adds the environment variables and the installation folder to the path. This allows other programs such as Python Wand to find the programs and libraries for their own use. If further environment variables are missing, they can be added from this list: https://imagemagick.org/script/resources.php#environment. The bundled ffmpeg was unused in the portable version but as the manifest now adds the installation directory to the path, the outdated ffmpeg is renamed so that users can continue using the up-to-date ffmpeg downloaded by scoop.