### PR TITLE
pelook: Add version 1.73

### DIFF
--- a/bucket/pelook.json
+++ b/bucket/pelook.json
@@ -4,16 +4,16 @@
     "homepage": "http://bytepointer.com/tools/index.htm#pelook",
     "license": {
         "identifier": "Freeware",
-        "url": "http://bytepointer.com/tools/index.htm"
+        "url": "https://bytepointer.com/tools/index.htm"
     },
-    "url": "http://bytepointer.com/download.php?name=pelook.zip#/dl.zip",
+    "url": "https://bytepointer.com/download.php?name=pelook.zip#/dl.zip",
     "hash": "12baccfb7db419c7533bcf495392e1baf9740c8b3bc558e496201c3c1a046cd7",
     "bin": "pelook.exe",
     "checkver": {
-        "url": "http://bytepointer.com/tools/pelook_changelist.htm",
+        "url": "https://bytepointer.com/tools/pelook_changelist.htm",
         "regex": "\\d{4}-\\d{2}-\\d{2}\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://bytepointer.com/download.php?name=pelook.zip#/dl.zip"
+        "url": "https://bytepointer.com/download.php?name=pelook.zip#/dl.zip"
     }
 }

--- a/bucket/pelook.json
+++ b/bucket/pelook.json
@@ -14,7 +14,6 @@
         "regex": "\\d{4}-\\d{2}-\\d{2}\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://bytepointer.com/download.php?name=pelook.zip#/dl.zip",
-        "extract_dir": "MagicaVoxel-$version-win64"
+        "url": "http://bytepointer.com/download.php?name=pelook.zip#/dl.zip"
     }
 }

--- a/bucket/pelook.json
+++ b/bucket/pelook.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.73",
+    "description": "Information tool for Windows EXE, DLL, driver and OBJ files (PE/COFF images)",
+    "homepage": "http://bytepointer.com/tools/index.htm#pelook",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://bytepointer.com/tools/index.htm"
+    },
+    "url": "http://bytepointer.com/download.php?name=pelook.zip#/dl.zip",
+    "hash": "12baccfb7db419c7533bcf495392e1baf9740c8b3bc558e496201c3c1a046cd7",
+    "bin": "pelook.exe",
+    "checkver": {
+        "url": "http://bytepointer.com/tools/pelook_changelist.htm",
+        "regex": "\\d{4}-\\d{2}-\\d{2}\\s+([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://bytepointer.com/download.php?name=pelook.zip#/dl.zip",
+        "extract_dir": "MagicaVoxel-$version-win64"
+    }
+}


### PR DESCRIPTION
[pelook](http://bytepointer.com/tools/index.htm#pelook) is an information tool for 32 and 64 bit Windows EXE, DLL, driver and OBJ files (PE/COFF images). This tool is suitable for reverse engineers or anyone needing to delve into the internals of Windows PE files.

![](http://bytepointer.com/images/pelook_screenshot1_thumb.png)