### PR TITLE
git: Add note for setting GCM Core

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -3,6 +3,7 @@
     "description": "Distributed version control system",
     "homepage": "https://gitforwindows.org",
     "license": "GPL-2.0-only",
+    "notes": "Set Git Credential Manager Core by running: \"git config --global credential.helper manager-core\"",
     "architecture": {
         "64bit": {
             "url": "https://github.com/git-for-windows/git/releases/download/v2.33.1.windows.1/PortableGit-2.33.1-64-bit.7z.exe#/dl.7z",


### PR DESCRIPTION
The default setting for `credential.helper` is `helper-selector` in the Git Portable version. We don't set it to `manager-core` automatically, as it would possibly overwrite an existing user config. 
Thus, this PR adds a note about how to set the `credential.helper` to `manager-core` when installing Git.

Resolves #2894