### PR TITLE
Persist rclone.conf in application directory for portability

### DIFF
--- a/bucket/rclone.json
+++ b/bucket/rclone.json
@@ -15,7 +15,7 @@
             "extract_dir": "rclone-v1.56.2-windows-386"
         }
     },
-    "pre_install": "New-Item -ItemType File \"$persist_dir\\rclone.conf\" -ErrorAction SilentlyContinue",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\rclone.conf\")) { New-Item -ItemType File \"$persist_dir\\rclone.conf\" | Out-Null }",
     "uninstaller": {
         "script": "Copy-Item \"$dir\\rclone.conf\" \"$persist_dir\\\" -Force"
     },

--- a/bucket/rclone.json
+++ b/bucket/rclone.json
@@ -15,7 +15,12 @@
             "extract_dir": "rclone-v1.56.2-windows-386"
         }
     },
+    "pre_install": "New-Item -ItemType File \"$persist_dir\\rclone.conf\" -ErrorAction SilentlyContinue",
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\rclone.conf\" \"$persist_dir\\\" -Force"
+    },
     "bin": "rclone.exe",
+    "persist": "rclone.conf",
     "checkver": {
         "github": "https://github.com/rclone/rclone"
     },

--- a/bucket/rclone.json
+++ b/bucket/rclone.json
@@ -15,10 +15,7 @@
             "extract_dir": "rclone-v1.56.2-windows-386"
         }
     },
-    "pre_install": "if (!(Test-Path \"$persist_dir\\rclone.conf\")) { New-Item -ItemType File \"$persist_dir\\rclone.conf\" | Out-Null }",
-    "uninstaller": {
-        "script": "Copy-Item \"$dir\\rclone.conf\" \"$persist_dir\\\" -Force"
-    },
+    "pre_install": "if (!(Test-Path \"$persist_dir\\rclone.conf\")) { New-Item -ItemType File \"$dir\\rclone.conf\" | Out-Null }",
     "bin": "rclone.exe",
     "persist": "rclone.conf",
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #1634.

Also, I notice many manifests that utilizes the similar tech often omit the `-ItemType File` part, which results in creating an empty directory instead of file. So I decide to put it to guarantee a file, regardless of PowerShell's default.

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
