### PR TITLE
openssh: Update to version 8.8p1-1

### DIFF
--- a/bucket/openssh.json
+++ b/bucket/openssh.json
@@ -1,5 +1,5 @@
 {
-    "version": "8.2p1-1",
+    "version": "8.3p1-1",
     "description": "A suite of secure networking utilities based on the Secure Shell protocol.",
     "homepage": "https://www.openssh.com/",
     "license": "ISC",
@@ -13,12 +13,14 @@
                 "http://repo.msys2.org/msys/x86_64/libcrypt-2.1-2-x86_64.pkg.tar.xz",
                 "http://repo.msys2.org/msys/x86_64/libdb-5.3.28-3-x86_64.pkg.tar.zst",
                 "http://repo.msys2.org/msys/x86_64/libedit-20191231_3.1-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libopenssl-1.1.1.e-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libsqlite-3.30.0-1-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/libopenssl-1.1.1.g-3-x86_64.pkg.tar.zst",
+                "http://repo.msys2.org/msys/x86_64/libreadline-8.0.004-1-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/libsqlite-3.33.0-2-x86_64.pkg.tar.zst",
                 "http://repo.msys2.org/msys/x86_64/msys2-runtime-3.2.0-8-x86_64.pkg.tar.zst",
                 "http://repo.msys2.org/msys/x86_64/ncurses-6.2-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/openssh-8.2p1-1-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/openssh-8.3p1-1-x86_64.pkg.tar.zst",
                 "http://repo.msys2.org/msys/x86_64/openssl-1.1.1.k-1-x86_64.pkg.tar.zst",
+                "http://repo.msys2.org/msys/x86_64/tcl-8.6.10-1-x86_64.pkg.tar.xz",
                 "http://repo.msys2.org/msys/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz"
             ],
             "hash": [
@@ -29,12 +31,14 @@
                 "333b5089ea0d27c167e7bcf786bf0ceb2192d76c18f338379d771adda18bda3e",
                 "00caef39902d34112fe9f9e5f9aad063cbde3922c212558ce4cec5f8c33534ee",
                 "236bedb6a8a90c0ecb70c1bc9c90ccd347f2f1ae96df11aa9af8e6878a606fe3",
-                "e142b12df8b5f1765a1a0739a5a304d18f810523ac5d36dc66bb92ff00d67d1b",
-                "45dcd0b4ac5444cfa8a7b9b98908b398710b65277e639666135746d7ffe0bfbb",
+                "1c33bc8b42ca94cce1c6aae148a9253c516406907d26ef0b12fcde78059e3164",
+                "1175428c8f668f987c84c0345c6f8e511e1bc741ba3a7d60886b7ee2e392f784",
+                "b797641807b725d1a194884f7e718c6faa2b4272a4fb03a6b05ed5fcd97d6d2a",
                 "bc452a4db3ea81ba812b1b153e2486d4abd63d64f4d376b7b7f2133efadd11a5",
                 "0943eb05da94d3ab8efac1a923bfcd515a9ba7251186e29401f06f155ce4d2ba",
+                "adc6e09db844d3b5b0846804cd397796f8a5c9a472829bc54cb6e6c9e607f7b4",
                 "bc633859967a1a3f99f97e79daae6a9b520bf2cdc7e7c14e7647f1e86adee289",
-                "4f34fdff9fd67affd4de0c6becf112976df8e77ead0937d86db38cd50839ac3f",
+                "28b3c8e528c6b6c935dbd8f008fd3858ea0e89609f3f5a383fee04aae2e0a918",
                 "4af63558e39e7a4941292132b2985cb2650e78168ab21157a082613215e4839a"
             ]
         }

--- a/bucket/openssh.json
+++ b/bucket/openssh.json
@@ -1,43 +1,43 @@
 {
-    "version": "8.3p1-1",
+    "version": "8.8p1-1",
     "description": "A suite of secure networking utilities based on the Secure Shell protocol.",
     "homepage": "https://www.openssh.com/",
     "license": "ISC",
     "architecture": {
         "64bit": {
             "url": [
-                "http://repo.msys2.org/msys/x86_64/bash-4.4.023-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/gcc-libs-9.3.0-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/heimdal-7.7.0-2-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/heimdal-libs-7.7.0-2-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/libcrypt-2.1-2-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libdb-5.3.28-3-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/libedit-20191231_3.1-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libopenssl-1.1.1.g-3-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/libreadline-8.0.004-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/libsqlite-3.33.0-2-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/msys2-runtime-3.2.0-8-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/ncurses-6.2-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/openssh-8.3p1-1-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/openssl-1.1.1.k-1-x86_64.pkg.tar.zst",
-                "http://repo.msys2.org/msys/x86_64/tcl-8.6.10-1-x86_64.pkg.tar.xz",
-                "http://repo.msys2.org/msys/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz"
+                "https://mirror.msys2.org/msys/x86_64/bash-5.1.008-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/gcc-libs-10.2.0-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/heimdal-7.7.0-2-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/heimdal-libs-7.7.0-2-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/libcrypt-2.1-3-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/libdb-5.3.28-3-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/libedit-20210910_3.1-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/libopenssl-1.1.1.l-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/libreadline-8.1.001-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/libsqlite-3.36.0-2-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.2.0-15-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/ncurses-6.2-1-x86_64.pkg.tar.xz",
+                "https://mirror.msys2.org/msys/x86_64/openssh-8.8p1-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/openssl-1.1.1.l-1-x86_64.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/tcl-8.6.10-1-x86_64.pkg.tar.xz",
+                "https://mirror.msys2.org/msys/x86_64/zlib-1.2.11-1-x86_64.pkg.tar.xz"
             ],
             "hash": [
-                "ed17af38e37e0790b467b9887b98bdfb4c711279d067a34b440cdb583ebc12ea",
-                "79a74bb1ef1d7f4eb12f7437ac24371ec9e41a3d96b653a2ec7f09d1e7aa9c63",
+                "1111c47c37116bf461d2ab7d0e7a6fb0ee3b4a6bea362309c58a2e0ea5f198ff",
+                "1fe019c7872820617060e1972e9b0f6878eca846937aa460178ffd54bc52d9bb",
                 "e64fcf00ddd4158ac56dc3b282698d616bedeece3466376bc03ff61f09a0c044",
                 "eda2132707ef438db009613c011b47217cb00ee4d4a28ad4f6cb10ad1845f74e",
-                "333b5089ea0d27c167e7bcf786bf0ceb2192d76c18f338379d771adda18bda3e",
+                "2ed4842520063192fc09ebc50d150e53b1f2224485833fa89582789ee462d8ac",
                 "00caef39902d34112fe9f9e5f9aad063cbde3922c212558ce4cec5f8c33534ee",
-                "236bedb6a8a90c0ecb70c1bc9c90ccd347f2f1ae96df11aa9af8e6878a606fe3",
-                "1c33bc8b42ca94cce1c6aae148a9253c516406907d26ef0b12fcde78059e3164",
-                "1175428c8f668f987c84c0345c6f8e511e1bc741ba3a7d60886b7ee2e392f784",
-                "b797641807b725d1a194884f7e718c6faa2b4272a4fb03a6b05ed5fcd97d6d2a",
-                "bc452a4db3ea81ba812b1b153e2486d4abd63d64f4d376b7b7f2133efadd11a5",
+                "3e78ff30d730fe382c31221807ba91fcec999331e22247da2fa62d8e43d4b4f1",
+                "6657a7a2bef09df5368c08fe088c21402e9cb5e41a3cfe903c469f8b1d220aee",
+                "b56c205e311990f19a8e159b2db7de7f875f6858b84f2c67535449418eb38970",
+                "4fa8b5fc5046f918a9ab1f93f38ed561f93f89dce71e66977dc7674f96ec0b56",
+                "d1152c99f761f0a5198ad63896fd0e97f4828b97e922c46aea9357e6990ed9af",
                 "0943eb05da94d3ab8efac1a923bfcd515a9ba7251186e29401f06f155ce4d2ba",
-                "adc6e09db844d3b5b0846804cd397796f8a5c9a472829bc54cb6e6c9e607f7b4",
-                "bc633859967a1a3f99f97e79daae6a9b520bf2cdc7e7c14e7647f1e86adee289",
+                "be56d258b00051e3bec88f2c5829cee807b56921265ee68bc8dd47c5214e08fd",
+                "da3fff40aab97f4811684d83bdc53154713f584000c6b8d10229c345f1cec7da",
                 "28b3c8e528c6b6c935dbd8f008fd3858ea0e89609f3f5a383fee04aae2e0a918",
                 "4af63558e39e7a4941292132b2985cb2650e78168ab21157a082613215e4839a"
             ]
@@ -53,7 +53,7 @@
     "bin": [
         [
             "usr\\bin\\sh.exe",
-            "findssl.sh",
+            "findssl",
             "$dir/usr/bin/findssl.sh"
         ],
         "usr\\bin\\scp.exe",
@@ -68,6 +68,10 @@
         ],
         "usr\\bin\\ssh-keygen.exe",
         "usr\\bin\\ssh-keyscan.exe",
-        "usr\\bin\\sshd.exe"
+        "usr\\bin\\sshd.exe",
+        "usr\\lib\\ssh\\sftp-server.exe",
+        "usr\\lib\\ssh\\ssh-keysign.exe",
+        "usr\\lib\\ssh\\ssh-pkcs11-helper.exe",
+        "usr\\lib\\ssh\\ssh-sk-helper.exe"
     ]
 }


### PR DESCRIPTION
new PR for openSSH update to version 8.3p1-1 as requested by pratikpc

Relates to #1494

