### PR TITLE
Add clink utils

### DIFF
--- a/bucket/clink-completions.json
+++ b/bucket/clink-completions.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.3.7",
+    "description": "Completions for various commands through Clink",
+    "homepage": "https://github.com/vladimir-kotikov/clink-completions",
+    "license": "MIT",
+    "suggest": {
+        "Clink": "clink"
+    },
+    "url": "https://github.com/vladimir-kotikov/clink-completions/archive/0.3.7.zip",
+    "hash": "2136a9b868fe05af7fb07a3b8a3c878b551bf6601321c91a6390376b47c1fad6",
+    "extract_dir": "clink-completions-0.3.7",
+    "installer": {
+        "script": [
+            "if (Get-Command clink -ErrorAction SilentlyContinue) {",
+            "   clink installscripts $dir",
+            "} else {",
+            "   \"Clink installation not found. Please manually install these scripts.\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (Get-Command clink -ErrorAction SilentlyContinue) {",
+            "   clink uninstallscripts $dir",
+            "}"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/vladimir-kotikov/clink-completions/archive/$version.zip",
+        "extract_dir": "clink-completions-$version"
+    }
+}

--- a/bucket/clink-completions.json
+++ b/bucket/clink-completions.json
@@ -12,16 +12,16 @@
     "installer": {
         "script": [
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink installscripts $dir",
+            "   clink installscripts \"$dir\"",
             "} else {",
-            "   \"Clink installation not found. Please manually install these scripts.\"",
+            "   warn 'Clink installation not found. Please manually install these scripts.'",
             "}"
         ]
     },
     "uninstaller": {
         "script": [
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink uninstallscripts $dir",
+            "   clink uninstallscripts \"$dir\"",
             "}"
         ]
     },

--- a/bucket/clink-flex-prompt.json
+++ b/bucket/clink-flex-prompt.json
@@ -11,20 +11,20 @@
     "installer": {
         "script": [
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink installscripts $dir",
+            "   clink installscripts \"$dir\"",
             "} elseif ($Env:CMDER_ROOT) {",
-            "   & $Env:CMDER_ROOT\\vendor\\clink\\clink.bat installscripts $dir",
+            "   & \"$Env:CMDER_ROOT\\vendor\\clink\\clink.bat\" installscripts \"$dir\"",
             "} else {",
-            "   \"Clink or Cmder installation not found. Please manually install these scripts.\"",
+            "   warn 'Clink or Cmder installation not found. Please manually install these scripts.'",
             "}"
         ]
     },
     "uninstaller": {
         "script": [
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink uninstallscripts $dir",
+            "   clink uninstallscripts \"$dir\"",
             "} elseif ($Env:CMDER_ROOT) {",
-            "   & $Env:CMDER_ROOT\\vendor\\clink\\clink.bat uninstallscripts $dir",
+            "   & \"$Env:CMDER_ROOT\\vendor\\clink\\clink.bat\" uninstallscripts \"$dir\"",
             "}"
         ]
     },

--- a/bucket/clink-flex-prompt.json
+++ b/bucket/clink-flex-prompt.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.5",
+    "description": "Flexible customizable prompt for Clink",
+    "homepage": "https://github.com/chrisant996/clink-flex-prompt",
+    "license": "MIT",
+    "suggest": {
+        "Clink": "clink"
+    },
+    "url": "https://github.com/chrisant996/clink-flex-prompt/releases/download/v0.5/clink-flex-prompt-0.5.zip",
+    "hash": "16e0e8a58d9f12acb9e29deafd258f033adb9d7ecaa81f9ea43a952827b298c6",
+    "installer": {
+        "script": [
+            "if (Get-Command clink -ErrorAction SilentlyContinue) {",
+            "   clink installscripts $dir",
+            "} elseif ($Env:CMDER_ROOT) {",
+            "   & $Env:CMDER_ROOT\\vendor\\clink\\clink.bat installscripts $dir",
+            "} else {",
+            "   \"Clink or Cmder installation not found. Please manually install these scripts.\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "if (Get-Command clink -ErrorAction SilentlyContinue) {",
+            "   clink uninstallscripts $dir",
+            "} elseif ($Env:CMDER_ROOT) {",
+            "   & $Env:CMDER_ROOT\\vendor\\clink\\clink.bat uninstallscripts $dir",
+            "}"
+        ]
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/chrisant996/clink-flex-prompt/releases/download/v$version/clink-flex-prompt-$version.zip"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

**Clink**

[Clink](https://chrisant996.github.io/clink/) is an extension framework which incorporates GNU Readline style editing in cmd.exe. It is currently internally used by the popular terminal package [Cmder](https://cmder.net/). The manifest for Clink is already present in Main - https://github.com/ScoopInstaller/Main/blob/master/bucket/clink.json

**Clink Completions**

This provides programmatic completions for various external programs leveraging the Clink framework. This is also used internally by Cmder.

**Clink Flex Prompt**

This is a Clink port of the popular Zsh prompt tool [Powerlevel10k](https://github.com/romkatv/powerlevel10k). This project is quite new, but since it is made by the author of Clink itself, I consider it trusted.

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
