### PR TITLE
busybox-lean: Add version 4487-gd239d2d52

### DIFF
--- a/bucket/busybox-lean.json
+++ b/bucket/busybox-lean.json
@@ -1,0 +1,35 @@
+{
+    "version": "4487-gd239d2d52",
+    "description": "BusyBox is a single binary that contains many common Unix tools",
+    "homepage": "https://frippery.org/busybox",
+    "license": "GPL-2.0-only",
+    "notes": "To automatically create shims for all unix commands, install 'busybox' instead.",
+    "architecture": {
+        "64bit": {
+            "url": "https://frippery.org/files/busybox/busybox-w64-FRP-4487-gd239d2d52.exe#/busybox.exe",
+            "hash": "23d1bf00d07cf090abf1360eea2233195aeb5a99fcd35bf3ad1e833c76c00c6b"
+        },
+        "32bit": {
+            "url": "https://frippery.org/files/busybox/busybox-w32-FRP-4487-gd239d2d52.exe#/busybox.exe",
+            "hash": "35e2b0db6d57a045188b9afc617aae52a6c8e2aa0205256c049f3537a48f879b"
+        }
+    },
+    "bin": "busybox.exe",
+    "checkver": {
+        "url": "https://frippery.org/busybox/",
+        "regex": ">busybox-w32-FRP-([\\w-]+)\\."
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://frippery.org/files/busybox/busybox-w64-FRP-$version.exe#/busybox.exe"
+            },
+            "32bit": {
+                "url": "https://frippery.org/files/busybox/busybox-w32-FRP-$version.exe#/busybox.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUM"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

A manifest for busybox already exists here. However, that manifest creates over 150 aliases! Many of which conflict with Windows internal tools - `sort`, `date`, `whoami`, `echo`, `find`, `mkdir`, `rmdir`, `tar`, `uptime`, `time` etc.

Many users will find this annoying, because these shims will never actually get called (in both cmd and powershell, internal commands have the highest priority).

I have created this 'lean' manifest which does not create these shims. This will also be helpful in small containers/images (like Actions). I have added a note for the existing busybox manifest too.

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
