### PR TITLE
neovim-nightly: Remove 32bit and add au.hash

### DIFF
--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.0-dev-575-g2ef9d2a66",
+    "version": "0.6.0-dev-581-g8f984dc1f",
     "description": "Vim fork focused on extensibility and usability",
     "homepage": "https://neovim.io",
     "license": {
@@ -12,11 +12,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip",
-            "hash": "6f86e7e684893da5c3351a1c1e3ec05891bffc52f59d5b7abf7ff8d89b0cc316"
-        },
-        "32bit": {
-            "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win32.zip",
-            "hash": "9a20dda23b0ccf571dc197c34bf18d57286ee9874808355d449dc3bcedf1f73a"
+            "hash": "57177d9b983fcadf54d79317c74df3de4c9a27caf8b9dc710c9b987d6748c76b"
         }
     },
     "extract_dir": "Neovim",
@@ -38,10 +34,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win32.zip"
+                "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip",
+                "hash": {
+                    "url": "$url.sha256sum"
+                }
             }
         }
     }

--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -31,7 +31,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/neovim/neovim"
+        "github": "https://github.com/neovim/neovim",
+        "regex": "NVIM v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -41,6 +42,9 @@
             "32bit": {
                 "url": "https://github.com/neovim/neovim/releases/download/v$version/nvim-win32.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256sum"
         }
     }
 }


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/commit/7bd6f12b3edd5c42956034b2f1c8a9ea14b9bcdc

- Fix https://github.com/ScoopInstaller/Main/issues/2948
- Fix https://github.com/ScoopInstaller/Main/issues/2955