### PR TITLE
gcc: Use WinLibs build and update to 11.2.0

### DIFF
--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -1,123 +1,37 @@
 {
-    "version": "9.3.0-2",
-    "description": "GNU Compiler Collection (Mingw-w64 port from MSYS2 project)",
-    "homepage": "http://mingw-w64.org/doku.php",
-    "license": "GPL-3.0-or-later,ZPL-2.1,...",
+    "version": "11.2.0-9.0.0-r3",
+    "description": "GNU Compiler Collection (WinLibs build)",
+    "homepage": "https://winlibs.com",
+    "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": [
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-binutils-2.34-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-crt-git-8.0.0.5815.9517d302-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-expat-2.2.9-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-fortran-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libgfortran-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gcc-libs-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gettext-0.19.8.1-8-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-gmp-6.2.0-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-headers-git-8.0.0.5815.9517d302-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-isl-0.22.1-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libiconv-1.16-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-libwinpthread-git-8.0.0.5814.9dbf4cc1-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-make-4.3-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-mpc-1.1.0-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-mpfr-4.0.2-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-pkg-config-0.29.2-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-windows-default-manifest-6.4-3-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-winpthreads-git-8.0.0.5814.9dbf4cc1-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-zlib-1.2.11-7-any.pkg.tar.xz"
-            ],
-            "hash": [
-                "c2c23fc704639f0e30a6aa094130f12028fd722d5961ef29df503f241d0bd93e",
-                "b2c79727807bf1c13881dbc5cc49617105e317cfff8a4e946d420163048fccb5",
-                "04ee9cc360b1aefb3729fec475001e1d35d94979a7dea1e604ac56015216df99",
-                "29ccb0030d1dae9fd194bb5bc76ba7330a7478b0afe1b2c0c19419a59c0980ef",
-                "228f8cb9ef89806fd96aba00d814d1f038e7ef84e5926730b427d79b5f225b73",
-                "c88596218c06622ee22df85bbd2f5b7e6fb99ea86f946d5f98f9c24b97f92dd0",
-                "596749645071942369ce93266f7622d64d53daf1cd509ca3b86782add9ef714a",
-                "0349bd137cd15ec2e3e882b1b8152ffc4bc5369999b0aa1999c6b087c34148bc",
-                "5cb1a3b31c95cfb0c9dafa93b2898479ac660e5ac931be54f7dddc8e726f98d0",
-                "cbe0b0a1af6c46ff2bf3f4cc8f96e73c862a2b11781bd21d6e10cbb4fba587da",
-                "202d28c4d0eeb38837afa39c157c3c1c046ae313641e1a348e1ff60787d447da",
-                "b37b013727b16a90095deb90cecdc073c5bb8dde26886448e2cbf357b29c1271",
-                "35d49b330e55c347644e4c0a8d8ce0886ae6b005c0ab1b0bb28bbcf563754704",
-                "7863472b0763a1a6ca70bdcc6e98df3b2016b221c9da5fe264b28d1c6e1c236c",
-                "d7c59f4e347a86e1cf1c539277fd3e43096846642b1cdf764cae1a8a4e783374",
-                "322712f92173473913b3199988301c3b32639289a4410ba31e732e54bacf3143",
-                "f69c6a4f83164db254178821009e69877855a5dfbfc6b7c5a796cb79964ddaf0",
-                "6c0ea4adcef503dc8174e9d4d70a10aee8295d620db4494f78fa512df0589dcf",
-                "9c8a641161971830f65503b45b0307a691fb13736815f7fdc30988dee07feb01",
-                "1decf05b8ae6ab10ddc9035929014837c18dd76da825329023da835aec53cec2"
-            ],
-            "pre_install": [
-                "Move-Item \"$dir\\mingw64\\*\" \"$dir\"",
-                "Remove-Item \"$dir\\mingw64\", \"$dir\\.*\""
-            ],
-            "post_install": [
-                "ensure \"$dir\\bin\\bak\" | Out-Null",
-                "Move-Item \"$dir\\bin\\python*.exe\" \"$dir\\bin\\bak\""
-            ]
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-11.2.0-mingw-w64-9.0.0-r3.7z",
+            "hash": "sha512:ce199913b462532905c8844978cabf1c961e2bd9b04b0f858e6ecf351974c3c1b6b67b8c8ee96437ca2ae25474b16023352f3ddfbdf1dda88407f7f0f4f747b0",
+            "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": [
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-binutils-2.34-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-crt-git-8.0.0.5815.9517d302-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-expat-2.2.9-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-fortran-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-libgfortran-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gcc-libs-9.3.0-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gettext-0.19.8.1-8-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-gmp-6.2.0-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-headers-git-8.0.0.5815.9517d302-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-isl-0.22.1-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libiconv-1.16-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-libwinpthread-git-8.0.0.5814.9dbf4cc1-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-make-4.3-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-mpc-1.1.0-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-mpfr-4.0.2-2-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-pkg-config-0.29.2-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-windows-default-manifest-6.4-3-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-winpthreads-git-8.0.0.5814.9dbf4cc1-1-any.pkg.tar.xz",
-                "http://repo.msys2.org/mingw/i686/mingw-w64-i686-zlib-1.2.11-7-any.pkg.tar.xz"
-            ],
-            "hash": [
-                "234396201fb4078ef8463497c04151c7826f0313dcb4b40c9b82aea3a282e819",
-                "15809600cdd409e83b75e9a937c6c32c5b81b236f394f1880800785cf7fa08ca",
-                "37dfa72246fd2478b991c93b5cce930b872420d6785fe7605458b472472134d8",
-                "2b0cb084cec8dcd63f893901007be3f70e3584e44a9f4f9dbb381905a4105d5e",
-                "3751e3f3878e979b9b49346ad3105499d6ca2da737db6bfb35663ac72c514f3d",
-                "66ee1a681d31b581c0450d57b06aa8e4f2ee6ce5a63db53041884f0b498d7f25",
-                "01b5f6e44b10be52a926b651a75d5d8137dafc27550915c24818023039ab1985",
-                "c1b3f4ea1a5c71b944bd0a71d2c2f6a36c38a5762a2b193bc4facf75c33d9c7a",
-                "3bf4783aed8e705fe9be132feced44d7097180d825367bc2b46fe45c39d2b701",
-                "d0b9419f8a1d858d99feaa7447a0ad28e48328a978ce8269ece612abc08dae8b",
-                "7e6f75306aec44e3351aa1ae0adb9eed892d99dd552d564a903e9200474a0599",
-                "bbd79d5059f116e8f4b8dd26ca661f384eee1082b265389dbfa364d316eea334",
-                "df7d70010f7e1443ede50887430352ddf15787cf6d8cb39bec2f4f36a3d5e5c5",
-                "49a9bd81fe265fd969618f9ffee9926a92193cc86d409cb1988f35a4dad3fe79",
-                "599a0276820e3d342d1c494c4506aaf79fbbbc2843bbec7aae5f22a1b71da284",
-                "7ba5ed9c5e535fdc619138278fff0567dad39b9251d5dc5c4d708ab6f345146e",
-                "39e07e61d739ba8f066605a109a19db397be6f7ddd81e5172f49ed253fdbe49f",
-                "56323bc39c7de0ff727915c09c4aaa25b8396efc0d7eda0006d5951bb6a6b983",
-                "554d832117312bdbfbb3840046916670625fa1383d16b25e76941285ff5bc933",
-                "addf6c52134027407640f1cbdf4efc5b64430f3a286cb4e4c4f5dbb44ce55a42"
-            ],
-            "pre_install": [
-                "Move-Item \"$dir\\mingw32\\*\" \"$dir\"",
-                "Remove-Item \"$dir\\mingw32\", \"$dir\\.*\""
-            ],
-            "post_install": [
-                "ensure \"$dir\\bin\\bak\" | Out-Null",
-                "Move-Item \"$dir\\bin\\python*.exe\" \"$dir\\bin\\bak\""
-            ]
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-msvcrt-r3/winlibs-i686-posix-dwarf-gcc-11.2.0-mingw-w64-9.0.0-r3.7z",
+            "hash": "sha512:c56bdcb93948adb0aa6b6b321d49ef6cee3a7e3f63610ce114c594671b3ebfdfc3c0db4bb802ea0f3de4724d2428b1d0f91624dd7d8026e993c40e6033aae570",
+            "extract_dir": "mingw32"
         }
     },
-    "bin": [
-        [
-            "bin\\mingw32-make.exe",
-            "make"
-        ]
-    ],
-    "env_add_path": "bin"
+    "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
+    "env_add_path": "bin",
+    "checkver": {
+        "regex": "GCC ([\\d.]+).*?LLVM.*?([\\d.]+).*?MinGW\\-w64 ([\\d.]+).*?MSVCRT.*?release ([\\d.]+).*?LATEST",
+        "replace": "${1}-${3}-r${4}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-x86_64-posix-seh-gcc-$match1-mingw-w64-$match3-r$match4.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-i686-posix-dwarf-gcc-$match1-mingw-w64-$match3-r$match4.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512"
+        }
+    }
 }


### PR DESCRIPTION
Change to [WInLibs](https://winlibs.com/) build and update to 11.2.0

Fix #1752 and close #1761