### PR TITLE
Update scrcpy to v1.20

### DIFF
--- a/bucket/scrcpy.json
+++ b/bucket/scrcpy.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.19",
+    "version": "1.20",
     "description": "Display and control your Android device",
     "homepage": "https://github.com/Genymobile/scrcpy",
     "license": "Apache-2.0",
     "depends": "adb",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.19/scrcpy-win64-v1.19.zip",
-            "hash": "383d6483f25ac0092d4bb9fef6c967351ecd50fc248e0c82932db97d6d32f11b"
+            "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.20/scrcpy-win64-v1.20.zip",
+            "hash": "548532b616288bcaeceff6881ad5e6f0928e5ae2b48c380385f03627401cfdba"
         },
         "32bit": {
-            "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.19/scrcpy-win32-v1.19.zip",
-            "hash": "50a21f07ef9705e7867d96666fb638a4cde2b9cbd4922a9268f269d217a4cd5d"
+            "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.20/scrcpy-win32-v1.20.zip",
+            "hash": "d3b72604ef024cbab06445effcf052438332a2cbf353465702666eefc13cf2b1"
         }
     },
     "pre_install": "if (Test-Path \"$dir\\adb.exe\") { Remove-Item \"$dir\\adb.exe\" }",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #2988

But unsure why the excavator run didn't pick up the update, any ideas?

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
