### PR TITLE
oh-my-posh3: Update to version 6.11.2 and fix url

### DIFF
--- a/bucket/oh-my-posh3.json
+++ b/bucket/oh-my-posh3.json
@@ -1,13 +1,13 @@
 {
-    "version": "5.16.4",
+    "version": "6.11.2",
     "description": "A prompt theme engine for any shell",
     "homepage": "https://ohmyposh.dev",
     "license": "GPL-3.0-only",
     "notes": "Refer to 'https://ohmyposh.dev/docs/windows#replace-your-existing-prompt' for shell specific configurations.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v5.16.4/posh-windows-wsl-amd64.7z",
-            "hash": "04552604dc1f169cbfce39eead3b176c8b9bb696ca3d422bb1e82c0a0f460074"
+            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v6.11.2/posh-windows-amd64.7z",
+            "hash": "d5fa44686e2663d4c5cacd4e3b96dd2151dd3a58795fcaa5705a752f12376ee6"
         }
     },
     "bin": "bin\\oh-my-posh.exe",
@@ -18,7 +18,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v$version/posh-windows-wsl-amd64.7z"
+                "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v$version/posh-windows-amd64.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
* Update to version 6.11.2

* Change url, because the filename on oh-my-posh release page has changed from `posh-windows-wsl-amd64.7z` to `posh-windows-amd64.7z` since [v6.9.0 release](https://github.com/JanDeDobbeleer/oh-my-posh/releases/tag/v6.9.0)