### PR TITLE
update pandoc manifest

### DIFF
--- a/bucket/pandoc.json
+++ b/bucket/pandoc.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.16",
+    "version": "2.16.2",
     "description": "Universal markup converter",
     "homepage": "https://pandoc.org",
     "license": "GPL-2.0-or-later",
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jgm/pandoc/releases/download/2.16/pandoc-2.16-windows-x86_64.zip",
-            "hash": "e60217de897aa89d2d03ccb1734ea8874e839a11965cf389680bbe22404da9a1"
+            "url": "https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-windows-x86_64.zip",
+            "hash": "a01bfd0fb702c4fc3de2e829fac2c6964afdb2bc285f57dce4ec00945069eff7"
         }
     },
-    "extract_dir": "pandoc-2.16",
+    "extract_dir": "pandoc-2.16.2",
     "bin": "pandoc.exe",
     "checkver": {
         "github": "https://github.com/jgm/pandoc"


### PR DESCRIPTION
This is juts an update for the Pandoc manifest so that 2.16.2 is used. 

Current 2.16 is already two versions behind. 

Thanks