### PR TITLE
get-iplayer: Add version 3.27.1

### DIFF
--- a/bucket/get-iplayer.json
+++ b/bucket/get-iplayer.json
@@ -3,10 +3,6 @@
     "description": "Utility for downloading TV and radio programmes from BBC iPlayer and BBC Sounds",
     "homepage": "https://github.com/get-iplayer/get_iplayer",
     "license": "GPL-3.0-only",
-    "notes": [
-        "Default Download directories (for TV and radio) are set to",
-        "'$dir\\tv' and '$dir\\radio'"
-    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/get-iplayer/get_iplayer_win32/releases/download/3.27.1/get_iplayer-3.27.1-windows-x64-setup.exe",
@@ -23,7 +19,12 @@
         "    Set-Content \"$dir\\scoop_$_\" \"@echo off`r`n%~dp0$_ --profile-dir `\"$dir\\profile`\" %*\" -Encoding Ascii | Out-Null",
         "}"
     ],
-    "post_install": "Invoke-ExternalCommand \"$dir\\scoop_get_iplayer.cmd\" -ArgumentList @('--prefs-add', '--output-tv', \"$dir\\tv\", '--output-radio', \"$dir\\radio\") | Out-Null",
+    "post_install": [
+        "if (!(Test-Path \"$persist_dir\\options\")) {",
+        "    Invoke-ExternalCommand \"$dir\\scoop_get_iplayer.cmd\" -ArgumentList @('--prefs-add', '--output-tv', \"$dir\\tv\", '--output-radio', \"$dir\\radio\") | Out-Null",
+        "    warn 'Default Download directories (for TV and radio) are set to \"$dir\\tv\" and \"$dir\\radio\"'",
+        "}"
+    ],
     "bin": [
         [
             "scoop_get_iplayer.cmd",

--- a/bucket/get-iplayer.json
+++ b/bucket/get-iplayer.json
@@ -20,7 +20,7 @@
         "}"
     ],
     "post_install": [
-        "if (!(Test-Path \"$persist_dir\\options\")) {",
+        "if (!(Test-Path \"$persist_dir\\profile\\options\")) {",
         "    Invoke-ExternalCommand \"$dir\\scoop_get_iplayer.cmd\" -ArgumentList @('--prefs-add', '--output-tv', \"$dir\\tv\", '--output-radio', \"$dir\\radio\") | Out-Null",
         "    warn 'Default Download directories (for TV and radio) are set to \"$dir\\tv\" and \"$dir\\radio\"'",
         "}"

--- a/bucket/get-iplayer.json
+++ b/bucket/get-iplayer.json
@@ -1,0 +1,82 @@
+{
+    "version": "3.27.1",
+    "description": "Utility for downloading TV and radio programmes from BBC iPlayer and BBC Sounds",
+    "homepage": "https://github.com/get-iplayer/get_iplayer",
+    "license": "GPL-3.0-only",
+    "notes": [
+        "Default Download directories (for TV and radio) are set to",
+        "'$dir\\tv' and '$dir\\radio'"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/get-iplayer/get_iplayer_win32/releases/download/3.27.1/get_iplayer-3.27.1-windows-x64-setup.exe",
+            "hash": "6dcadf0553401fe3f5594bedc5629360266921bf295d70140861cbffa10cccef"
+        },
+        "32bit": {
+            "url": "https://github.com/get-iplayer/get_iplayer_win32/releases/download/3.27.1/get_iplayer-3.27.1-windows-x86-setup.exe",
+            "hash": "574115e41bb7dcc97ba36372acf40ef3df6f2ba3988304c27bef05abbce0865e"
+        }
+    },
+    "innosetup": true,
+    "pre_install": [
+        "'get_iplayer.cmd', 'get_iplayer_pvr.cmd', 'get_iplayer_web_pvr.cmd' | ForEach-Object {",
+        "    Set-Content \"$dir\\scoop_$_\" \"@echo off`r`n%~dp0$_ --profile-dir `\"$dir\\profile`\" %*\" -Encoding Ascii | Out-Null",
+        "}"
+    ],
+    "post_install": "Invoke-ExternalCommand \"$dir\\scoop_get_iplayer.cmd\" -ArgumentList @('--prefs-add', '--output-tv', \"$dir\\tv\", '--output-radio', \"$dir\\radio\") | Out-Null",
+    "bin": [
+        [
+            "scoop_get_iplayer.cmd",
+            "get_iplayer"
+        ],
+        [
+            "scoop_get_iplayer_pvr.cmd",
+            "get_iplayer_pvr"
+        ],
+        [
+            "scoop_get_iplayer_web_pvr.cmd",
+            "get_iplayer_web_pvr"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "scoop_get_iplayer.cmd",
+            "get_iplayer",
+            "--search dontshowanymatches && cd %HOMEDRIVE%%HOMEPATH% && cmd.exe /k get_iplayer.cmd --help",
+            "get_iplayer.ico"
+        ],
+        [
+            "scoop_get_iplayer_pvr.cmd",
+            "Run PVR Scheduler",
+            "",
+            "get_iplayer_pvr.ico"
+        ],
+        [
+            "scoop_get_iplayer_web_pvr.cmd",
+            "Web PVR Manager",
+            "",
+            "get_iplayer_pvr.ico"
+        ]
+    ],
+    "persist": [
+        "profile",
+        "tv",
+        "radio"
+    ],
+    "checkver": {
+        "github": "https://github.com/get-iplayer/get_iplayer_win32"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/get-iplayer/get_iplayer_win32/releases/download/$version/get_iplayer-$version-windows-x64-setup.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/get-iplayer/get_iplayer_win32/releases/download/$version/get_iplayer-$version-windows-x86-setup.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Supersedes https://github.com/ScoopInstaller/Extras/pull/3812

This adds [get_iplayer](https://github.com/get-iplayer/get_iplayer/), a tool for downloading TV and radio programmes from BBC iPlayer and BBC Sounds.

NOTES:
* The package has `shortcut` because the installer of **get_iplayer** creates shortcuts too.
* The "profile directory" [can only be specified at runtime](https://github.com/get-iplayer/get_iplayer/wiki/prefs). Therefore I use alternative batch files (`scoop_get_iplayer.cmd`, etc.) to do that.
* I tested the app by `get_iplayer --pid=m0011rxw --type=radio`
* See [previous PR](https://github.com/ScoopInstaller/Extras/pull/3812) for more discussions/details.