### PR TITLE
fd@8.3.0: Fix missing fd.exe

### DIFF
--- a/bucket/fd.json
+++ b/bucket/fd.json
@@ -6,11 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/sharkdp/fd/releases/download/v8.3.0/fd-v8.3.0-x86_64-pc-windows-msvc.zip",
-            "hash": "bec94e02cd383dd2323770ecef57de34fb550f416b39fc8b75831274f585ef35"
+            "hash": "bec94e02cd383dd2323770ecef57de34fb550f416b39fc8b75831274f585ef35",
+            "extract_dir": "fd-v8.3.0-x86_64-pc-windows-msvc"
         },
         "32bit": {
             "url": "https://github.com/sharkdp/fd/releases/download/v8.3.0/fd-v8.3.0-i686-pc-windows-msvc.zip",
-            "hash": "7cbe5fd79c9507602462d681da1994c1ea53f26f8cc36cf4581142ee6aa240cb"
+            "hash": "7cbe5fd79c9507602462d681da1994c1ea53f26f8cc36cf4581142ee6aa240cb",
+            "extract_dir": "fd-v8.3.0-i686-pc-windows-msvc"
         }
     },
     "bin": "fd.exe",
@@ -18,10 +20,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sharkdp/fd/releases/download/v$version/fd-v$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/sharkdp/fd/releases/download/v$version/fd-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "fd-v$version-x86_64-pc-windows-msvc"
             },
             "32bit": {
-                "url": "https://github.com/sharkdp/fd/releases/download/v$version/fd-v$version-i686-pc-windows-msvc.zip"
+                "url": "https://github.com/sharkdp/fd/releases/download/v$version/fd-v$version-i686-pc-windows-msvc.zip",
+                "extract_dir": "fd-v$version-i686-pc-windows-msvc"
             }
         }
     }


### PR DESCRIPTION
In the latest release of fd, the binary was moved into a subdirectory `fd-v$version-x86_64-pc-windows-msvc`, this PR adds `extract_dir` to fix that. This is basically the same as #2773.

Closes https://github.com/ScoopInstaller/Scoop/issues/4542