### PR TITLE
ffmpeg: Remove .ps1 shims after installation

### DIFF
--- a/bucket/ffmpeg-nightly-shared-vulkan.json
+++ b/bucket/ffmpeg-nightly-shared-vulkan.json
@@ -10,6 +10,10 @@
             "extract_dir": "ffmpeg-N-101857-g0617e578a3-win64-gpl-shared-vulkan"
         }
     },
+    "post_install": [
+        "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
+        "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\""
+    ],
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",

--- a/bucket/ffmpeg-nightly-shared.json
+++ b/bucket/ffmpeg-nightly-shared.json
@@ -10,6 +10,10 @@
             "extract_dir": "ffmpeg-N-104667-gc90b3661fa-win64-gpl-shared"
         }
     },
+    "post_install": [
+        "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
+        "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\""
+    ],
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",

--- a/bucket/ffmpeg-nightly-vulkan.json
+++ b/bucket/ffmpeg-nightly-vulkan.json
@@ -10,6 +10,10 @@
             "extract_dir": "ffmpeg-N-101857-g0617e578a3-win64-gpl-vulkan"
         }
     },
+    "post_install": [
+        "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
+        "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\""
+    ],
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",

--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -10,6 +10,10 @@
             "extract_dir": "ffmpeg-N-104667-gc90b3661fa-win64-gpl"
         }
     },
+    "post_install": [
+        "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
+        "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\""
+    ],
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",

--- a/bucket/ffmpeg-shared.json
+++ b/bucket/ffmpeg-shared.json
@@ -10,6 +10,10 @@
             "extract_dir": "ffmpeg-n4.4.1-2-gcc33e73618-win64-gpl-shared-4.4"
         }
     },
+    "post_install": [
+        "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
+        "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\""
+    ],
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -10,6 +10,10 @@
             "extract_dir": "ffmpeg-n4.4.1-2-gcc33e73618-win64-gpl-4.4"
         }
     },
+    "post_install": [
+        "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
+        "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\""
+    ],
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",


### PR DESCRIPTION
close #2611 
close https://github.com/ScoopInstaller/Scoop/issues/4473

This is a workaround for the issue mentioned in https://github.com/ScoopInstaller/Main/issues/2611.
(ffmpeg has problem handling arguments containing `:` if `ffmpeg.ps1` is involved)

Also see upstream issue (closed by the maintainer of *ffmpeg*) : https://trac.ffmpeg.org/ticket/9398