### PR TITLE
Add diffsitter 0.6.7

### DIFF
--- a/bucket/diffsitter.json
+++ b/bucket/diffsitter.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.6.7",
+    "description": "A tree-sitter based AST difftool to get meaningful semantic diffs",
+    "homepage": "https://github.com/afnanenayet/diffsitter",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/afnanenayet/diffsitter/releases/download/v0.6.7/diffsitter-x86_64-pc-windows-msvc.zip",
+            "hash": "dd47a751a9c9c73f47d056717f548071c32906b0f43ddcf927edd5848ccb162e"
+        }
+    },
+    "bin": "diffsitter.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/afnanenayet/diffsitter/releases/download/v$version/diffsitter-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
`diffsitter` creates semantically meaningful diffs that ignore formatting differences like spacing. It does so by computing a diff on the AST (abstract syntax tree) of a file rather than computing the diff on the text contents of the file.