### PR TITLE
unrar: Correct version

### DIFF
--- a/bucket/unrar.json
+++ b/bucket/unrar.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.10",
+    "version": "6.02",
     "description": "Decompress RAR files.",
     "homepage": "https://www.rarlab.com/",
     "license": {
@@ -9,7 +9,7 @@
     "url": "https://www.rarlab.com/rar/unrarw32.exe#/dl.7z",
     "hash": "63dac3b0e3faa90f85e234e0608ce7db94dd6a43b12793c71895b3ee35ff7755",
     "bin": "UnRAR.exe",
-    "checkver": "RAR ([\\d.]+)",
+    "checkver": "RAR ([\\d.]+) [^ab]",
     "autoupdate": {
         "url": "https://www.rarlab.com/rar/unrarw32.exe#/dl.7z"
     }


### PR DESCRIPTION
`unrar` is in 6.02, the last stable version of RAR.

6.10 is the beta version.