### PR TITLE
qemu 6.2.0-rc2: fix hash

### DIFF
--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-20211125.exe#/dl.7z",
-            "hash": "44b5857f48d26c28bb90073358ba5de28ab7dee9811dca954b3c20dcc7148475"
+            "hash": "c4ab32703d3fb4ce79ecd90b23f41f01ab0602969fad9951544b9ffbf5fb530c"
         },
         "32bit": {
             "url": "https://qemu.weilnetz.de/w32/qemu-w32-setup-20211125.exe#/dl.7z",


### PR DESCRIPTION
Got this error when updating `qemu`
```
App:         main/qemu
URL:         https://qemu.weilnetz.de/w64/qemu-w64-setup-20211125.exe#/dl.7z
First bytes: 4D 5A 90 00 03 00 00 00
Expected:    44b5857f48d26c28bb90073358ba5de28ab7dee9811dca954b3c20dcc7148475
Actual:      c4ab32703d3fb4ce79ecd90b23f41f01ab0602969fad9951544b9ffbf5fb530c

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/ScoopInstaller/Main/issues/new?title=qemu%406.2.0-rc2%3a+hash+check+failed
```

changing hash should fix it