### PR TITLE
fix 7zip install-error

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -35,7 +35,7 @@
     },
     "pre_install": [
         "$7zip_root = \"$dir\".Replace('\\', '\\\\')",
-        "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
+        "'install-context_x64.reg', 'uninstall-context_x64.reg' | ForEach-Object {",
         "    $content = Get-Content \"$dir\\$_\"",
         "    $content = $content.Replace('$7zip_root', $7zip_root)",
         "    if ($global) {",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->


Relates to #3022 
Maybe someone's mistake is caused by thisproblem

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->


- before and after fix

  ```
  ╰─ scoop install 7zip
  Installing '7zip' (21.06) [64bit] [main]
  WARN  By installing you accept following licenses: Freeware, LGPL-2.0-only, BSD-3-Clause (https://www.7-zip.org/license.txt)
  Loading 7z2106-x64.msi from cache.
  Loading install-context_x64.reg from cache.
  Loading uninstall-context_x64.reg from cache.
  Checking hash of 7z2106-x64.msi ... ok.
  Checking hash of install-context_x64.reg ... ok.
  Checking hash of uninstall-context_x64.reg ... ok.
  Extracting 7z2106-x64.msi ... done.
  Running pre-install script...
  Get-Content:
  Line |
     3 |      $content = Get-Content "$dir\$_"
       |                 ~~~~~~~~~~~~~~~~~~~~~
       | Cannot find path 'D:\Game\Scoop\apps\7zip\21.06\install-context.reg' because it does not exist.
  ERROR You cannot call a method on a null-valued expression.
  ERROR This application failed to install: 7zip
  ```

  ```
  ╰─ scoop install 7zip                                                                         ─╯ 
  Installing '7zip' (21.06) [64bit] [main]
  WARN  By installing you accept following licenses: Freeware, LGPL-2.0-only, BSD-3-Clause (https://www.7-zip.org/license.txt)
  Loading 7z2106-x64.msi from cache.
  Loading install-context_x64.reg from cache.
  Loading uninstall-context_x64.reg from cache.
  Checking hash of 7z2106-x64.msi ... ok.
  Checking hash of install-context_x64.reg ... ok.
  Checking hash of uninstall-context_x64.reg ... ok.
  Extracting 7z2106-x64.msi ... done.
  Running pre-install script...
  Linking D:\Game\Scoop\apps\7zip\current => D:\Game\Scoop\apps\7zip\21.06
  Creating shim for '7z'.
  Creating shortcut for 7-Zip (7zFM.exe)
  Persisting Codecs
  Persisting Formats
  '7zip' (21.06) was installed successfully!
  ```
