### PR TITLE
gopher360: add manifest

### DIFF
--- a/bucket/gopher360.json
+++ b/bucket/gopher360.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.989",
+    "description": "App to turn a controller into a mouse and keyboard",
+    "homepage": "https://github.com/Tylemagne/Gopher360",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/Tylemagne/Gopher360/releases/download/v0.989/Gopher.exe#/gopher360.exe",
+    "hash": "13b45c1487d4920df5acc5e69ab4d827e69f086bdf0e666244038856e5ac8d4d",
+    "shortcuts": [
+        [
+            "gopher360.exe",
+            "Gopher360"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Tylemagne/Gopher360"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Tylemagne/Gopher360/releases/download/v$version/Gopher.exe#/gopher360.exe"
+    }
+}


### PR DESCRIPTION
It would've been nice to be able to persist config.ini, but that file is created upon first launch, and as far as I can understand, there is no way to persist files that don't exist before installation.