### PR TITLE
msys2: Add shortcut for clang32 environment

### DIFF
--- a/bucket/msys2.json
+++ b/bucket/msys2.json
@@ -35,6 +35,11 @@
         ],
         [
             "msys2_shell.cmd",
+            "clang32",
+            "-clang32 -defterm -here -full-path -no-start"
+        ],
+        [
+            "msys2_shell.cmd",
             "clang64",
             "-clang64 -defterm -here -full-path -no-start"
         ],
@@ -56,6 +61,10 @@
         [
             "mingw64.exe",
             "MinGW64"
+        ],
+        [
+            "clang32.exe",
+            "Clang32"
         ],
         [
             "clang64.exe",


### PR DESCRIPTION
msys2 adds a shortcut to open a clang32 environment.

Closes #3048