### PR TITLE
libvips: Add version 8.12.1

### DIFF
--- a/bucket/libvips.json
+++ b/bucket/libvips.json
@@ -23,10 +23,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w64-all-$version.zip"
+                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w64-all-$version.zip",
+                "extract_dir": "vips-dev-$majorVersion.$minorVersion"
             },
             "32bit": {
-                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w32-all-$version.zip"
+                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w32-all-$version.zip",
+                "extract_dir": "vips-dev-$majorVersion.$minorVersion"
             }
         }
     }

--- a/bucket/libvips.json
+++ b/bucket/libvips.json
@@ -1,10 +1,8 @@
 {
     "version": "8.12.1",
+    "description": "A demand-driven, horizontally threaded image processing library",
     "homepage": "https://www.libvips.org/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://github.com/libvips/build-win64-mxe#libvips-web-dependencies"
-    },
+    "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
             "hash": "49e6909c8e0c57f15677c16434946b45a288d078b4bc65a3e03616b0aed08881",
@@ -15,21 +13,25 @@
             "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.12.1/vips-dev-w32-all-8.12.1.zip"
         }
     },
-    "env_add_path": "bin",
     "extract_dir": "vips-dev-8.12",
+    "bin": [
+        "bin\\vips.exe",
+        "bin\\vipsedit.exe",
+        "bin\\vipsheader.exe",
+        "bin\\vipsthumbnail.exe"
+    ],
     "checkver": {
         "github": "https://github.com/libvips/build-win64-mxe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w64-all-$version.zip",
-                "extract_dir": "vips-dev-$majorVersion.$minorVersion"
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w64-all-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w32-all-$version.zip",
-                "extract_dir": "vips-dev-$majorVersion.$minorVersion"
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w32-all-$version.zip"
             }
-        }
+        },
+        "extract_dir": "vips-dev-$majorVersion.$minorVersion"
     }
 }

--- a/bucket/libvips.json
+++ b/bucket/libvips.json
@@ -7,9 +7,11 @@
     },
     "architecture": {
         "64bit": {
+            "hash": "49e6909c8e0c57f15677c16434946b45a288d078b4bc65a3e03616b0aed08881",
             "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.12.1/vips-dev-w64-all-8.12.1.zip"
         },
         "32bit": {
+            "hash": "f084cbd6b15e4f8afd28b7893f628fa8bd3fc9d601bfe0fddac4fdeddbe3233a",
             "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.12.1/vips-dev-w32-all-8.12.1.zip"
         }
     },

--- a/bucket/libvips.json
+++ b/bucket/libvips.json
@@ -1,0 +1,31 @@
+{
+    "version": "8.12.1",
+    "homepage": "https://www.libvips.org/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/libvips/build-win64-mxe#libvips-web-dependencies"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.12.1/vips-dev-w64-all-8.12.1.zip"
+        },
+        "32bit": {
+            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.12.1/vips-dev-w32-all-8.12.1.zip"
+        }
+    },
+    "env_add_path": "bin",
+    "extract_dir": "vips-dev-8.12",
+    "checkver": {
+        "github": "https://github.com/libvips/build-win64-mxe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w64-all-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w32-all-$version.zip"
+            }
+        }
+    }
+}

--- a/bucket/libvips.json
+++ b/bucket/libvips.json
@@ -23,11 +23,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w64-all-$version.zip",
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w64-all-$version.zip",
                 "extract_dir": "vips-dev-$majorVersion.$minorVersion"
             },
             "32bit": {
-                "url": "https://github.com/cmderdev/cmder/releases/download/v$version/vips-dev-w32-all-$version.zip",
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w32-all-$version.zip",
                 "extract_dir": "vips-dev-$majorVersion.$minorVersion"
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Closes #3030.

## Note

There is an arm64 build for libvips. Should we add it for Shovel and future Scoop?

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
