### PR TITLE
prowiz: Add version 1.70

### DIFF
--- a/bucket/prowiz.json
+++ b/bucket/prowiz.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.70",
+    "description": "Amiga music ripper",
+    "homepage": "http://asle.free.fr/prowiz/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "http://asle.free.fr/prowiz/prowiz-64bit.7z",
+            "hash": "fae4e3c1501f41ab264e7dfcdb98267fb548b9c4d6b8f49438fbdd7192524d5a",
+            "bin": [
+                [
+                    "Prowiz64bit.exe",
+                    "prowiz"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "regex": "Prowiz mingwin64bit binary v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://asle.free.fr/prowiz/prowiz-64bit.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supercedes https://github.com/ScoopInstaller/Extras/pull/6220

[ProWiz](http://asle.free.fr/prowiz/) is an Amiga music ripper.

*NOTES:
* I removed 32-bit support because the latest version for 64-bit and 32-bit are different. Also the url (`http://asle.free.fr/prowiz/prowiz-64bit.7z`) is not related to the version number. Which makes it impossible to track, unless we have a seperate package for 32-bit. 