### PR TITLE
Remove dupfinder binary

### DIFF
--- a/bucket/resharper-clt.json
+++ b/bucket/resharper-clt.json
@@ -10,7 +10,6 @@
     "hash": "753afb9475709959d0132a57cf4d0eb486fe66961844738cd9f6f810431fa74c",
     "bin": [
         "cleanupcode.exe",
-        "dupfinder.exe",
         "inspectcode.exe"
     ],
     "checkver": {


### PR DESCRIPTION
As announced [here](https://blog.jetbrains.com/dotnet/2021/08/12/sunsetting-dupfinder-command-line-tool/), `dupfinder` is not part of the latest tools anymore.