### PR TITLE
OpenSSL: license is now Apache-2.0

### DIFF
--- a/bucket/openssl-mingw.json
+++ b/bucket/openssl-mingw.json
@@ -2,7 +2,7 @@
     "version": "3.0.0",
     "description": "A robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.",
     "homepage": "https://curl.haxx.se/windows/",
-    "license": "OpenSSL",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://curl.haxx.se/windows/dl-7.80.0/openssl-3.0.0-win64-mingw.tar.xz",

--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -3,7 +3,7 @@
     "description": "TLS/SSL toolkit",
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
     "license": {
-        "identifier": "OpenSSL|Freeware",
+        "identifier": "Apache-2.0",
         "url": "https://www.openssl.org/source/license-openssl-ssleay.txt"
     },
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Since v3.0.0 OpenSSL is published under Apache License 2.0

Announcement:
https://www.openssl.org/blog/blog/2021/09/07/OpenSSL3.Final/

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

<!-- or -->
Relates to #516

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
