### PR TITLE
ncspot: Update to version 0.9.3

### DIFF
--- a/bucket/ncspot.json
+++ b/bucket/ncspot.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.9.0",
+    "version": "0.9.3",
     "description": "ncurses Spotify client written in Rust",
     "homepage": "https://github.com/hrkfdn/ncspot",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hrkfdn/ncspot/releases/download/v0.9.0/ncspot-v0.9.0-windows.zip",
-            "hash": "227ba1abac65c4b0029e24c8b491e87757b0377e3cad6b2dc983483de66c0bf6"
+            "url": "https://github.com/hrkfdn/ncspot/releases/download/v0.9.3/ncspot-v0.9.3-windows-x86_64.zip",
+            "hash": "d2a9c587decba9e37418577fb3ffc61cd230821ad792b20090eae4592849194f"
         }
     },
     "bin": "ncspot.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/hrkfdn/ncspot/releases/download/v$version/ncspot-v$version-windows.zip"
+                "url": "https://github.com/hrkfdn/ncspot/releases/download/v$version/ncspot-v$version-windows-x86_64.zip"
             }
         },
         "hash": {

--- a/bucket/ncspot.json
+++ b/bucket/ncspot.json
@@ -18,7 +18,7 @@
             }
         },
         "hash": {
-            "url": "$urlNoExt.sha256"
+            "url": "$baseurl/ncspot-v$version-windows-x86_64.sha256"
         }
     }
 }


### PR DESCRIPTION
Update from `0.9.0` to `0.9.3`. Add `x86_64` to urls.