### PR TITLE
binutils: Add version 2.37

### DIFF
--- a/bucket/binutils.json
+++ b/bucket/binutils.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.37",
+    "description": "GNU Binutils",
+    "homepage": "https://www.gnu.org/software/binutils/",
+    "license": "GPL-3.0-or-later",
+    "url": [
+        "https://downloads.sourceforge.net/project/ezwinports/binutils-2.37-w32-bin.zip",
+        "https://mirrors.gigenet.com/OSDN//mingw/72215/libgcc-9.2.0-3-mingw32-dll-1.tar.xz"
+    ],
+    "hash": [
+        "9d761a423a5c066911a9568102be481ac5638c58e8fc7385a3bb3425e6d7dbea",
+        "27f7a72e1aa5d0bb894f84aa62da0200b3a4a334e85457bb1961fc341290f833"
+    ],
+    "bin": [
+        "bin\\addr2line.exe",
+        "bin\\ar.exe",
+        "bin\\as.exe",
+        "bin\\c++filt.exe",
+        "bin\\dlltool.exe",
+        "bin\\dllwrap.exe",
+        "bin\\elfedit.exe",
+        "bin\\gprof.exe",
+        "bin\\ld.bfd.exe",
+        "bin\\ld.exe",
+        "bin\\nm.exe",
+        "bin\\objcopy.exe",
+        "bin\\objdump.exe",
+        "bin\\ranlib.exe",
+        "bin\\readelf.exe",
+        "bin\\size.exe",
+        "bin\\strings.exe",
+        "bin\\strip.exe",
+        "bin\\windmc.exe",
+        "bin\\windres.exe"
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/ezwinports/files",
+        "regex": "/files/binutils-([\\d.]+)-w32-bin.zip"
+    },
+    "autoupdate": {
+        "url": [
+            "https://downloads.sourceforge.net/project/ezwinports/binutils-$version-w32-bin.zip",
+            "https://mirrors.gigenet.com/OSDN//mingw/72215/libgcc-9.2.0-3-mingw32-dll-1.tar.xz"
+        ]
+    }
+}

--- a/bucket/gawk.json
+++ b/bucket/gawk.json
@@ -3,8 +3,14 @@
     "description": "Interprets a special-purpose programming language that makes it possible to handle simple data-reformatting jobs with just a few lines of code.",
     "homepage": "https://sourceforge.net/projects/ezwinports/",
     "license": "GPL-3.0-only",
-    "url": "https://downloads.sourceforge.net/project/ezwinports/gawk-5.1.1-w32-bin.zip",
-    "hash": "sha1:a52f5bfc03e861f740ce73b7cb294df71a25b22a",
+    "url": [
+        "https://downloads.sourceforge.net/project/ezwinports/gawk-5.1.1-w32-bin.zip",
+        "https://mirrors.gigenet.com/OSDN//mingw/72215/libgcc-9.2.0-3-mingw32-dll-1.tar.xz"
+    ],
+    "hash": [
+        "sha1:a52f5bfc03e861f740ce73b7cb294df71a25b22a",
+        "27f7a72e1aa5d0bb894f84aa62da0200b3a4a334e85457bb1961fc341290f833"
+    ],
     "bin": [
         "bin\\awk.exe",
         "bin\\gawk.exe",
@@ -15,6 +21,9 @@
         "regex": "gawk-([\\d.]+)-w32-bin.zip"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/ezwinports/gawk-$version-w32-bin.zip"
+        "url": [
+            "https://downloads.sourceforge.net/project/ezwinports/gawk-$version-w32-bin.zip",
+            "https://mirrors.gigenet.com/OSDN//mingw/72215/libgcc-9.2.0-3-mingw32-dll-1.tar.xz"
+        ]
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->

Note: Starting from 2021, packages from ezwinports require libgcc DLL, which has to be downloaded separately.

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
