### PR TITLE
OpenSSL: Update to 3.0.1

### DIFF
--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "TLS/SSL toolkit",
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://slproweb.com/download/Win64OpenSSL-3_0_0.exe",
-            "hash": "646901553d54a84ba36e46d9e1f558dd980d88b6b13554c3c6915c2552b63fc3"
+            "url": "https://slproweb.com/download/Win64OpenSSL-3_0_1.exe",
+            "hash": "d2eea91c5d7bc33a9ea69c6a1d82cef6113d08760601b9986c12e6828904dfcc"
         },
         "32bit": {
-            "url": "https://slproweb.com/download/Win32OpenSSL-3_0_0.exe",
-            "hash": "e03205aa6ecad055c7b471d44f36b16fe712b7db2372d1bc32e9087909d7004a"
+            "url": "https://slproweb.com/download/Win32OpenSSL-3_0_1.exe",
+            "hash": "2d39885a7c6d607bf05327e53e86f3a3e159ad4650bc06b6dbe0719aa7eb235b"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The older version (3.0.0) no longer exists in the slproweb site
( https://slproweb.com/download/Win64OpenSSL-3_0_0.exe )

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->


<!-- or -->


<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
