### PR TITLE
nvm hash conflict

### DIFF
--- a/bucket/nvm.json
+++ b/bucket/nvm.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "notes": "You'll need to restart powershell/cmd to have it reload Environment Variables so nvm will work correctly",
     "url": "https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip",
-    "hash": "md5:03fdea18df83704d0cc3efc1963b4705",
+    "hash": "md5:20c6eb074c1e1b906acc9e0a32b48f7e",
     "architecture": {
         "64bit": {
             "pre_install": [


### PR DESCRIPTION
Checking hash of nvm-noinstall.zip ... ERROR Hash check failed!
App:         main/nvm
URL:         https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip
First bytes: 50 4B 03 04 14 00 02 00
Expected:    03fdea18df83704d0cc3efc1963b4705
Actual:      20c6eb074c1e1b906acc9e0a32b48f7e