### PR TITLE
openssl-mingw: Updated openssl.cnf location

### DIFF
--- a/bucket/openssl-mingw.json
+++ b/bucket/openssl-mingw.json
@@ -18,7 +18,7 @@
     "bin": "openssl.exe",
     "env_add_path": ".",
     "env_set": {
-        "OPENSSL_CONF": "$dir\\openssl.cnf"
+        "OPENSSL_CONF": "$dir\\ssl\\openssl.cnf"
     },
     "checkver": "dl-(?<curl>[\\d._]+)/openssl-([\\da-z._]+)-win64-mingw",
     "autoupdate": {


### PR DESCRIPTION
Update `OPENSSL_CONF` env. variable, location of `openssl.cnf` was moved to the `ssl/` folder.