### PR TITLE
Escape single quotes and spaces in the path of neofetch in "pre_install" property

### DIFF
--- a/bucket/neofetch.json
+++ b/bucket/neofetch.json
@@ -13,7 +13,7 @@
     "hash": "3dc33493e54029fb1528251552093a9f9a2894fcf94f9c3a6f809136a42348c7",
     "pre_install": [
         "if(installed 'git-with-openssh') { $git = 'git-with-openssh' } else { $git = 'git' }",
-        "Write-Output \"`$GitDir = (Get-Item `$(scoop which $git) -ErrorAction:Stop).Directory.Parent; if (`$GitDir.FullName -imatch 'mingw') { `$GitDir = `$GitDir.Parent }; & `$(Join-Path (Join-Path `$GitDir.FullName 'bin') 'bash.exe') `$('\"' + (Join-Path `$PSScriptRoot 'neofetch') + '\"') @args\" | Out-File \"$dir\\neofetch.ps1\" -Encoding utf8"
+        "Write-Output \"`$GitDir = (Get-Item (scoop which $git) -ErrorAction:Stop).Directory.Parent; if (`$GitDir.FullName -imatch 'mingw') { `$GitDir = `$GitDir.Parent }; & (Join-Path (Join-Path `$GitDir.FullName 'bin') 'bash.exe') `\"`$(Join-Path `$PSScriptRoot 'neofetch')`\" @args\" | Out-File \"$dir\\neofetch.ps1\" -Encoding utf8"
     ],
     "bin": "neofetch.ps1",
     "checkver": "github",

--- a/bucket/neofetch.json
+++ b/bucket/neofetch.json
@@ -13,7 +13,7 @@
     "hash": "3dc33493e54029fb1528251552093a9f9a2894fcf94f9c3a6f809136a42348c7",
     "pre_install": [
         "if(installed 'git-with-openssh') { $git = 'git-with-openssh' } else { $git = 'git' }",
-        "Write-Output \"`$GitDir = (Get-Item `$(scoop which $git) -ErrorAction:Stop).Directory.Parent; if (`$GitDir.FullName -imatch 'mingw') { `$GitDir = `$GitDir.Parent }; & `$(Join-Path (Join-Path `$GitDir.FullName 'bin') 'bash.exe') `$(Join-Path `$PSScriptRoot 'neofetch') @args\" | Out-File \"$dir\\neofetch.ps1\" -Encoding utf8"
+        "Write-Output \"`$GitDir = (Get-Item `$(scoop which $git) -ErrorAction:Stop).Directory.Parent; if (`$GitDir.FullName -imatch 'mingw') { `$GitDir = `$GitDir.Parent }; & `$(Join-Path (Join-Path `$GitDir.FullName 'bin') 'bash.exe') `$('\"' + (Join-Path `$PSScriptRoot 'neofetch') + '\"') @args\" | Out-File \"$dir\\neofetch.ps1\" -Encoding utf8"
     ],
     "bin": "neofetch.ps1",
     "checkver": "github",


### PR DESCRIPTION
Many windows usernames contain spaces or single quotes/apostrophe. I accidentally have an apostrophe (') in my username. As a result neofetch fails to run as mentioned in detail [here](https://github.com/dylanaraps/neofetch/issues/2002#issue-1084846469)

I discovered that the fix to this issue is to surround the path of the neofetch script being passed as an argument to bash.exe in double-quotes. This would escape spaces and single quotes in username. Windows does not allow double quotes or backslashes in usernames, so there is no need to consider those.

This is the updated working script: https://pastebin.com/J0zTeNAw
I tried to escape my double quotes in the json file with backslashes, please check if it corresponds to my intent.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes [#2002 in dylanaraps/neofetch](https://github.com/dylanaraps/neofetch/issues/2002#issue-1084846469)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
