### PR TITLE
ffmpeg@4.4.1: Switch to mirrors

### DIFF
--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -1,13 +1,13 @@
 {
-    "version": "4.4.1-2",
+    "version": "4.4.1",
     "description": "A complete, cross-platform solution to record, convert and stream audio and video.",
     "homepage": "https://ffmpeg.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2021-12-21-12-18/ffmpeg-n4.4.1-2-gcc33e73618-win64-gpl-4.4.zip",
-            "hash": "3a795611e3d01ab4d23b4ffb465538bb53a8959238cfab2ee479280b3143a2e6",
-            "extract_dir": "ffmpeg-n4.4.1-2-gcc33e73618-win64-gpl-4.4"
+            "url": "https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-4.4.1-full_build.7z",
+            "hash": "016cac40110c1016f9e4a981a08b6c51b50c11cb1cbb794903e7d1ea879b6f9d",
+            "extract_dir": "ffmpeg-4.4.1-full_build"
         }
     },
     "post_install": [
@@ -20,15 +20,16 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "github": "https://github.com/BtbN/FFmpeg-Builds",
-        "regex": "/autobuild-(?<time>[\\d-]+)/ffmpeg-n(?<version>[\\d.]+)-(?<commit>\\d+)-g(?<hash>[a-z\\d]+)-win64-gpl-[\\d.]+\\.zip",
-        "replace": "${version}-${commit}"
+        "url": "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z.ver"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-$matchTime/ffmpeg-n$version-g$matchHash-win64-gpl-$majorVersion.$minorVersion.zip",
-                "extract_dir": "ffmpeg-n$version-g$matchHash-win64-gpl-$majorVersion.$minorVersion"
+                "url": "https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-$version-full_build.7z",
+                "hash": {
+                    "url": "https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-$version-full_build.7z.sha256"
+                },
+                "extract_dir": "ffmpeg-$version-full_build"
             }
         }
     }

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -20,7 +20,8 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "url": "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z.ver"
+        "url": "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z.ver",
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3113 
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Let me know if you want GitHub download URL instead

```
PS C:\Users\LazyGeniusMan\scoop-bucket> scoop install ffmpeg
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
WARN  To disable this warning, run 'scoop config aria2-warning-enabled false'.
Installing 'ffmpeg' (4.4.1) [64bit]
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 3e2dd1|OK  |   107KiB/s|C:/Users/LazyGeniusMan/scoop/cache/ffmpeg#4.4.1#https_www.gyan.dev_ffmpeg_builds_packages_ffmpeg-4.4.1-full_build.7z
Download: Status Legend:
Download: (OK):download completed.
Checking hash of ffmpeg-4.4.1-full_build.7z ... ok.
Extracting ffmpeg-4.4.1-full_build.7z ... done.
Linking ~\scoop\apps\ffmpeg\current => ~\scoop\apps\ffmpeg\4.4.1
Creating shim for 'ffmpeg'.
Creating shim for 'ffplay'.
Creating shim for 'ffprobe'.
Running post-install script...
'ffmpeg' (4.4.1) was installed successfully!
PS C:\Users\LazyGeniusMan\scoop-bucket> ffmpeg
ffmpeg version 4.4.1-full_build-www.gyan.dev Copyright (c) 2000-2021 the FFmpeg developers
  built with gcc 11.2.0 (Rev1, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libdav1d --enable-libzvbi --enable-librav1e --enable-libsvtav1 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-ffnvcodec --enable-nvdec --enable-nvenc --enable-d3d11va --enable-dxva2 --enable-libmfx --enable-libglslang --enable-vulkan --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libilbc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'
```