### PR TITLE
b2: Add version 3.2.0

### DIFF
--- a/bucket/b2.json
+++ b/bucket/b2.json
@@ -1,0 +1,15 @@
+{
+    "version": "3.2.0",
+    "description": "The command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage",
+    "homepage": "https://www.backblaze.com/b2/docs/quick_command_line.html",
+    "license": "MIT",
+    "url": "https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.2.0/b2-windows.exe#/b2.exe",
+    "hash": "8797CFB67447CE020EB70C793449B024B7C7155D0619D331954A2128527FB142",
+    "bin": "b2.exe",
+    "checkver": {
+        "github": "https://github.com/Backblaze/B2_Command_Line_Tool"
+    },
+    "autoupdate": {
+         "url": "https://github.com/cli/cli/releases/download/v$version/b2-windows.exe#/b2.exe"
+    }
+}

--- a/bucket/b2.json
+++ b/bucket/b2.json
@@ -1,6 +1,6 @@
 {
     "version": "3.2.0",
-    "description": "The command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage",
+    "description": "Command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage",
     "homepage": "https://www.backblaze.com/b2/docs/quick_command_line.html",
     "license": "MIT",
     "architecture": {

--- a/bucket/b2.json
+++ b/bucket/b2.json
@@ -16,7 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cli/cli/releases/download/v$version/b2-windows.exe#/b2.exe"
+                "url": "https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v$version/b2-windows.exe#/b2.exe"
             }
         }
     }

--- a/bucket/b2.json
+++ b/bucket/b2.json
@@ -3,13 +3,21 @@
     "description": "The command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage",
     "homepage": "https://www.backblaze.com/b2/docs/quick_command_line.html",
     "license": "MIT",
-    "url": "https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.2.0/b2-windows.exe#/b2.exe",
-    "hash": "8797CFB67447CE020EB70C793449B024B7C7155D0619D331954A2128527FB142",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.2.0/b2-windows.exe#/b2.exe",
+            "hash": "8797CFB67447CE020EB70C793449B024B7C7155D0619D331954A2128527FB142",
+        }
+    },
     "bin": "b2.exe",
     "checkver": {
         "github": "https://github.com/Backblaze/B2_Command_Line_Tool"
     },
     "autoupdate": {
-         "url": "https://github.com/cli/cli/releases/download/v$version/b2-windows.exe#/b2.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cli/cli/releases/download/v$version/b2-windows.exe#/b2.exe"
+            }
+        }
     }
 }

--- a/bucket/b2.json
+++ b/bucket/b2.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Backblaze/B2_Command_Line_Tool/releases/download/v3.2.0/b2-windows.exe#/b2.exe",
-            "hash": "8797CFB67447CE020EB70C793449B024B7C7155D0619D331954A2128527FB142",
+            "hash": "8797CFB67447CE020EB70C793449B024B7C7155D0619D331954A2128527FB142"
         }
     },
     "bin": "b2.exe",


### PR DESCRIPTION
This adds the Backblaze B2 CLI (`b2`) which can be found here:
https://www.backblaze.com/b2/docs/quick_command_line.html

It is licensed as MIT:
https://github.com/Backblaze/B2_Command_Line_Tool/blob/master/LICENSE

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
