### PR TITLE
mosh-client: Add version 1.3.2

### DIFF
--- a/bucket/mosh-client.json
+++ b/bucket/mosh-client.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.3.2",
+    "description": "Windows native port of Mobile Shell (mosh) client.",
+    "homepage": "https://github.com/jumptrading/mosh-windows-wrappers",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://raw.githubusercontent.com/felixse/FluentTerminal/master/Dependencies/MoshExecutables/x64/mosh-client.exe",
+                "https://raw.githubusercontent.com/felixse/FluentTerminal/master/Dependencies/MoshExecutables/x64/mosh.exe"
+            ],
+            "hash": [
+                "5a8d84ff205c6a0711e53b961f909484a892f42648807e52d46d4fa93c05e286",
+                "851fac844da32d341a240a85f85a01b89e3279578fad84ea3b7935333767bd27"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "https://raw.githubusercontent.com/felixse/FluentTerminal/master/Dependencies/MoshExecutables/x86/mosh-client.exe",
+                "https://raw.githubusercontent.com/felixse/FluentTerminal/master/Dependencies/MoshExecutables/x86/mosh.exe"
+            ],
+            "hash": [
+                "2b8123f0ddbce9b0cc0fae89d40ab3c2c3c59546f4f1e341941f2b8743d69c18",
+                "852ffd3803613636105a47572a8d883661c8360aa9d2b778a3f1cd163f1e71f1"
+            ]
+        }
+    },
+    "bin": "mosh.exe"
+}

--- a/bucket/mosh-client.json
+++ b/bucket/mosh-client.json
@@ -2,6 +2,7 @@
     "version": "1.3.2",
     "description": "Windows native port of Mobile Shell (mosh) client.",
     "homepage": "https://github.com/jumptrading/mosh-windows-wrappers",
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

No autoupdate because:
- mosh hasn't had a release in 5 years - https://github.com/mobile-shell/mosh/releases
- the repository of the Windows port is archived

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
