### PR TITLE
coursier: Persist cache and bin

### DIFF
--- a/bucket/coursier.json
+++ b/bucket/coursier.json
@@ -8,13 +8,13 @@
     "bin": "coursier.jar",
     "env_set": {
         "COURSIER_CACHE": "$dir\\cache",
-		"COURSIER_BIN_DIR": "$dir\\bin"
+        "COURSIER_BIN_DIR": "$dir\\bin"
     },
-	"env_add_path": "bin",
-	"persist": [
-		"cache",
-		"bin"
-	],
+    "env_add_path": "bin",
+    "persist": [
+        "cache",
+        "bin"
+    ],
     "checkver": {
         "url": "https://github.com/coursier/coursier/releases",
         "regex": "tag/v([\\w\\.-]+)"

--- a/bucket/coursier.json
+++ b/bucket/coursier.json
@@ -7,8 +7,14 @@
     "hash": "4c554d97e7b17493735aed86db98753d253fd9ca095d9ff82a117153d61b78c3",
     "bin": "coursier.jar",
     "env_set": {
-        "COURSIER_HOME": "${env:LOCALAPPDATA}\\Coursier"
+        "COURSIER_CACHE": "$dir\\cache",
+		"COURSIER_BIN_DIR": "$dir\\bin"
     },
+	"env_add_path": "bin",
+	"persist": [
+		"cache",
+		"bin"
+	],
     "checkver": {
         "url": "https://github.com/coursier/coursier/releases",
         "regex": "tag/v([\\w\\.-]+)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Coursier always create dummy `null` directory in %USERPROFILE%, I don't know why...

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
