### PR TITLE
scala: update to version 3.1.0

### DIFF
--- a/bucket/scala.json
+++ b/bucket/scala.json
@@ -1,30 +1,30 @@
 {
-    "version": "2.13.7",
+    "version": "3.1.0",
     "description": "A modern multi-paradigm programming language designed to express common programming patterns in a concise, elegant, and type-safe way.",
     "homepage": "https://www.scala-lang.org/",
     "license": "BSD-3-Clause",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://downloads.typesafe.com/scala/2.13.7/scala-2.13.7.zip",
-    "hash": "a52cd39d0c13748b36a389b87ffbf5c4b6bc098af9ea745cf3c874867fd91976",
-    "extract_dir": "scala-2.13.7",
+    "url": "https://github.com/lampepfl/dotty/releases/download/3.1.0/scala3-3.1.0.zip",
+    "hash": "2e8e19784779870c0b6e74c6ec530a6a191b470c1c56a20f207977232c88995b",
+    "extract_dir": "scala3-3.1.0",
     "bin": [
-        "bin\\fsc.bat",
         "bin\\scala.bat",
         "bin\\scalac.bat",
-        "bin\\scaladoc.bat",
-        "bin\\scalap.bat"
+        "bin\\scaladoc.bat"
     ],
     "env_set": {
         "SCALA_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://www.scala-lang.org/download/scala2.html",
-        "regex": "scala-([\\d.]+)\\.zip"
+        "github": "https://github.com/lampepfl/dotty/"
     },
     "autoupdate": {
-        "url": "https://downloads.typesafe.com/scala/$version/scala-$version.zip",
-        "extract_dir": "scala-$version"
+        "url": "https://github.com/lampepfl/dotty/releases/download/$version/scala3-$version.zip",
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        },
+        "extract_dir": "scala3-$version"
     }
 }

--- a/bucket/scala.json
+++ b/bucket/scala.json
@@ -3,7 +3,10 @@
     "description": "A modern multi-paradigm programming language designed to express common programming patterns in a concise, elegant, and type-safe way.",
     "homepage": "https://www.scala-lang.org/",
     "license": "BSD-3-Clause",
-    "notes": "This installs the latest version. If you haven't migrated yet, please use scala2 from the Versions bucket.",
+    "notes": [
+        "Scala 3 has been installed. If you haven't migrated yet, install versions/scala2.",
+        "Or follow the migration guide: https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html"
+    ],
     "suggest": {
         "JDK": "java/openjdk"
     },

--- a/bucket/scala.json
+++ b/bucket/scala.json
@@ -3,6 +3,7 @@
     "description": "A modern multi-paradigm programming language designed to express common programming patterns in a concise, elegant, and type-safe way.",
     "homepage": "https://www.scala-lang.org/",
     "license": "BSD-3-Clause",
+    "notes": "This installs the latest version. If you haven't migrated yet, please use scala2 from the Versions bucket.",
     "suggest": {
         "JDK": "java/openjdk"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to https://github.com/ScoopInstaller/Versions/pull/382
- Removed bin entries for clis no longer in v3
- Autoupdate moved to github for simplicity
- Note for those who haven't migrated to v3 to use v2 in the Versions bucket (see PR linked above)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
