### PR TITLE
openssl: fix license URL

### DIFF
--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -2,10 +2,7 @@
     "version": "3.0.1",
     "description": "TLS/SSL toolkit",
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
-    "license": {
-        "identifier": "Apache-2.0",
-        "url": "https://www.openssl.org/source/license-openssl-ssleay.txt"
-    },
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://slproweb.com/download/Win64OpenSSL-3_0_1.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

My correction of OpenSSL license information in #3078 was not complete.
I forgot to remove the URL to the old OpenSSL 1.x license
We only need to declare the identifier since it is already known by Scoop.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
