### PR TITLE
goreleaser@1.3.0: Fix hash check

### DIFF
--- a/bucket/goreleaser.json
+++ b/bucket/goreleaser.json
@@ -27,7 +27,8 @@
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.txt"
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256  $basename\\n"
         }
     }
 }


### PR DESCRIPTION
I just realised what the issue was with goreleasers hash check, they now have `.sbom`  signatures for all the files in the checksums so the hash check was matching the record ending with `.sbom` as it came first.
