### PR TITLE
bazel-buildtools: Add version 4.2.5

### DIFF
--- a/bucket/bazel-buildtools.json
+++ b/bucket/bazel-buildtools.json
@@ -1,0 +1,49 @@
+{
+    "version": "4.2.5",
+    "description": "Developer tools for working with Google's bazel buildtool.",
+    "homepage": "https://github.com/bazelbuild/buildtools",
+    "license": "Apache-2.0",
+    "suggest": {
+        "bazel": "bazel"
+    },
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildifier-windows-amd64.exe",
+                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildozer-windows-amd64.exe",
+                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/unused_deps-windows-amd64.exe"
+            ],
+            "hash": [
+                "4185a40d3154cacbe8b79f570b94e2c6f74fc9e317362b7d028c2e6c94edf9ba",
+                "2a9a7176cbd3b2f0ef989502128efbafd3b156ddabae93b9c979cd4017ffa300",
+                "77b092cd6aaaa1a57da3381bb7dcde3d9e5a8f7e74ff21a2b24ec722c765b9ed"
+            ]
+        }
+    },
+    "bin": [
+        [
+            "buildifier-windows-amd64.exe",
+            "buildifier"
+        ],
+        [
+            "buildozer-windows-amd64.exe",
+            "buildozer"
+        ],
+        [
+            "unused_deps-windows-amd64.exe",
+            "unused_deps"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildifier-windows-amd64.exe",
+                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildozer-windows-amd64.exe",
+                    "https://github.com/bazelbuild/buildtools/releases/download/$version/unused_deps-windows-amd64.exe"
+                ]
+            }
+        }
+    }
+}

--- a/bucket/bazel-buildtools.json
+++ b/bucket/bazel-buildtools.json
@@ -21,9 +21,9 @@
         }
     },
     "bin": [
-        "buildifier",
-        "buildozer",
-        "unused_deps"
+        "buildifier.exe",
+        "buildozer.exe",
+        "unused_deps.exe"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/bazel-buildtools.json
+++ b/bucket/bazel-buildtools.json
@@ -9,9 +9,9 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildifier-windows-amd64.exe",
-                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildozer-windows-amd64.exe",
-                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/unused_deps-windows-amd64.exe"
+                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildifier-windows-amd64.exe#/buildifier.exe",
+                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/buildozer-windows-amd64.exe#/buildozer.exe",
+                "https://github.com/bazelbuild/buildtools/releases/download/4.2.5/unused_deps-windows-amd64.exe#/unused_deps.exe"
             ],
             "hash": [
                 "4185a40d3154cacbe8b79f570b94e2c6f74fc9e317362b7d028c2e6c94edf9ba",
@@ -21,27 +21,18 @@
         }
     },
     "bin": [
-        [
-            "buildifier-windows-amd64.exe",
-            "buildifier"
-        ],
-        [
-            "buildozer-windows-amd64.exe",
-            "buildozer"
-        ],
-        [
-            "unused_deps-windows-amd64.exe",
-            "unused_deps"
-        ]
+        "buildifier",
+        "buildozer",
+        "unused_deps"
     ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": [
-                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildifier-windows-amd64.exe",
-                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildozer-windows-amd64.exe",
-                    "https://github.com/bazelbuild/buildtools/releases/download/$version/unused_deps-windows-amd64.exe"
+                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildifier-windows-amd64.exe#/buildifier.exe",
+                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildozer-windows-amd64.exe#/buildozer.exe",
+                    "https://github.com/bazelbuild/buildtools/releases/download/$version/unused_deps-windows-amd64.exe#/unused_deps.exe"
                 ]
             }
         }


### PR DESCRIPTION
buildifier is a tool for formatting bazel BUILD and .bzl files with a standard convention.
https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
