### PR TITLE
tailwindcss: Add version 3.0.15

### DIFF
--- a/bucket/tailwindcss.json
+++ b/bucket/tailwindcss.json
@@ -1,0 +1,21 @@
+{
+    "version": "3.0.15",
+    "description": "TailwindCSS framework CLI for rapid UI development",
+    "homepage": "https://github.com/tailwindlabs/tailwindcss",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tailwindlabs/tailwindcss/releases/download/v3.0.15/tailwindcss-windows-x64.exe#/tailwindcss.exe",
+            "hash": "a0014bd1a20a485e4133d082f3f794b9d94a43330eda8a676aa6d886b6745b1b"
+        }
+    },
+    "bin": "tailwindcss.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tailwindlabs/tailwindcss/releases/download/v$version/tailwindcss-windows-x64.exe#/tailwindcss.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tailwindcss is a very popular and highly productive CSS framework.
Recently they managed turning node dependent package into standalone utility.

This adds `tailwindcss.eze`.

References:
Web: https://tailwindcss.com
Blog about a standalone cli: https://tailwindcss.com/blog/standalone-cli

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
