### PR TITLE
autossh: Add version 1.4g

### DIFF
--- a/bucket/autossh.json
+++ b/bucket/autossh.json
@@ -20,9 +20,13 @@
         "regex": "tag/([\\w.]+)"
     },
     "autoupdate": {
-        "url": [
-            "https://github.com/jazzl0ver/autossh/releases/download/$version/autossh.exe",
-            "https://github.com/jazzl0ver/autossh/releases/download/$version/msys-2.0.dll"
-        ]
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://github.com/jazzl0ver/autossh/releases/download/$version/autossh.exe",
+                    "https://github.com/jazzl0ver/autossh/releases/download/$version/msys-2.0.dll"
+                ]
+            }
+        }
     }
 }

--- a/bucket/autossh.json
+++ b/bucket/autossh.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.4g",
+    "description": "Automatically restart SSH sessions and tunnels, in case they drop.",
+    "homepage": "https://www.harding.motd.ca/autossh/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/jazzl0ver/autossh/releases/download/1.4g/autossh.exe",
+                "https://github.com/jazzl0ver/autossh/releases/download/1.4g/msys-2.0.dll"
+            ],
+            "hash": [
+                "b05e9599fa6e9ff9d2a57e141bdca0eb7f5829e8fd67e37e878863a4fd46469f",
+                "462fcdec4f2e390d806e2cc21874db208645d69bf9d70a1d0f4981164569db79"
+            ]
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/jazzl0ver/autossh",
+        "regex": "tag/([\\w.]+)"
+    },
+    "autoupdate": {
+        "url": [
+            "https://github.com/jazzl0ver/autossh/releases/download/$version/autossh.exe",
+            "https://github.com/jazzl0ver/autossh/releases/download/$version/msys-2.0.dll"
+        ]
+    }
+}

--- a/bucket/autossh.json
+++ b/bucket/autossh.json
@@ -14,19 +14,5 @@
                 "462fcdec4f2e390d806e2cc21874db208645d69bf9d70a1d0f4981164569db79"
             ]
         }
-    },
-    "checkver": {
-        "github": "https://github.com/jazzl0ver/autossh",
-        "regex": "tag/([\\w.]+)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": [
-                    "https://github.com/jazzl0ver/autossh/releases/download/$version/autossh.exe",
-                    "https://github.com/jazzl0ver/autossh/releases/download/$version/msys-2.0.dll"
-                ]
-            }
-        }
     }
 }

--- a/bucket/autossh.json
+++ b/bucket/autossh.json
@@ -14,5 +14,6 @@
                 "462fcdec4f2e390d806e2cc21874db208645d69bf9d70a1d0f4981164569db79"
             ]
         }
-    }
+    },
+    "bin": "autossh.exe"
 }


### PR DESCRIPTION
close #1519

[AutoSSH](https://www.harding.motd.ca/autossh/) let the user automatically restart SSH sessions and tunnels, in case they drop.

**NOTES**
* checkver/autoupdate is not needed because the app has not been update since 2019.

**usage/help**:
```
> autossh
usage: autossh [-V] [-M monitor_port[:echo_port]] [-f] [SSH_OPTIONS]

    -M specifies monitor port. May be overridden by environment
       variable AUTOSSH_PORT. 0 turns monitoring loop off.
       Alternatively, a port for an echo service on the remote
       machine may be specified. (Normally port 7.)
    -f run in background (autossh handles this, and does not
       pass it to ssh.)
    -V print autossh version and exit.

Environment variables are:
    AUTOSSH_GATETIME    - how long must an ssh session be established
                          before we decide it really was established
                          (in seconds). Default is 30 seconds; use of -f
                          flag sets this to 0.
    AUTOSSH_LOGFILE     - file to log to (default is to use the syslog
                          facility)
    AUTOSSH_LOGLEVEL    - level of log verbosity
    AUTOSSH_MAXLIFETIME - set the maximum time to live (seconds)
    AUTOSSH_MAXSTART    - max times to restart (default is no limit)
    AUTOSSH_MESSAGE     - message to append to echo string (max 64 bytes)
    AUTOSSH_NTSERVICE   - tweak some things for running under cygrunsrv
    AUTOSSH_PATH        - path to ssh if not default
    AUTOSSH_PIDFILE     - write pid to this file
    AUTOSSH_POLL        - how often to check the connection (seconds)
    AUTOSSH_FIRST_POLL  - time before first connection check (seconds)
    AUTOSSH_PORT        - port to use for monitor connection
    AUTOSSH_DEBUG       - turn logging to maximum verbosity and log to
                          stderr
```