### PR TITLE
gpac: Add version 1.0.1-rev0

### DIFF
--- a/bucket/gpac.json
+++ b/bucket/gpac.json
@@ -1,0 +1,46 @@
+{
+    "version": "1.0.1-rev0",
+    "description": "Multimedia framework developed for research and academic purposes",
+    "homepage": "https://gpac.wp.imt.fr/",
+    "license": "LGPL-2.1-or-later",
+    "suggest": {
+        "Visual C++ Redistributable": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "http://download.tsi.telecom-paristech.fr/gpac/release/1.0.1/gpac-1.0.1-rev0-gd8538e8a-master-x64.exe#/dl.7z",
+            "hash": "5c7e615f928a286eaec97cfbd32e6445605b6f04f5f4ef0d2108e57eff8a0fe6"
+        },
+        "32bit": {
+            "url": "http://download.tsi.telecom-paristech.fr/gpac/release/1.0.1/gpac-1.0.1-rev0-gd8538e8a-master-win32.exe#/dl.7z",
+            "hash": "2ef807be236cbe22945d4c62ad3c99c920013ac344f38f981ed067935ae90fdb"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
+        "if (!(Test-Path \"$persist_dir\\GPAC.cfg\")) {New-Item \"$dir\\GPAC.cfg\" -ItemType File | Out-Null}"
+    ],
+    "bin": [
+        "gpac.exe",
+        "mp4box.exe",
+        "mp4client.exe"
+    ],
+    "persist": [
+        "Storage",
+        "GPAC.cfg"
+    ],
+    "checkver": {
+        "url": "https://gpac.wp.imt.fr/downloads/",
+        "regex": "gpac-([\\w.-]+)-(?<commit>\\w+)-master-x64\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.tsi.telecom-paristech.fr/gpac/release/$matchHead/gpac-$version-$matchCommit-master-x64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "http://download.tsi.telecom-paristech.fr/gpac/release/$matchHead/gpac-$version-$matchCommit-master-win32.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
close #1246

**GPAC** ([homepage](https://gpac.wp.imt.fr/)) ([Wikipedia](https://en.wikipedia.org/wiki/GPAC_Project_on_Advanced_Content)) is a multimedia framework developed for research and academic purposes.

**NOTES**:
* More details can be found in [the project Wiki](https://github.com/gpac/gpac/wiki).
* **suggest**: The installer is bundled with *VCRedist 2015*. Since [VCRedist2022 covers the feature of 2015-2022](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170), I put `vcredist2022` in suggest.