### PR TITLE
emscripten: Add version 3.1.1

### DIFF
--- a/bucket/emscripten.json
+++ b/bucket/emscripten.json
@@ -1,0 +1,48 @@
+{
+    "version": "3.1.1",
+    "description": "LLVM to WebAssembly compiler. Compiles C/C++ to WebAssembly that can be run on most web browsers.",
+    "homepage": "https://emscripten.org/",
+    "license": "MIT|NCSA",
+    "notes": [
+        "Run \"emsdk install latest\" and \"emsdk activate latest\" to set up emsdk.",
+        "For more details, check \"https://emscripten.org/docs/getting_started/downloads.html\""
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.1.zip",
+            "hash": "604cadeecbd84eda429971d9b9a19e9fd8c2ecc3c2a1c2dc50a859dd5fcfb083"
+        }
+    },
+    "extract_dir": "emsdk-3.1.1",
+    "pre_install": "if(!(Test-Path \"$persist_dir\\.emscripten\")) {New-Item \"$dir\\.emscripten\" -ItemType File | Out-Null}",
+    "bin": [
+        "emsdk.bat",
+        "emsdk_env.bat"
+    ],
+    "shortcuts": [
+        [
+            "emcmdprompt.bat",
+            "EMScripten Command Prompt"
+        ]
+    ],
+    "persist": [
+        "java",
+        "node",
+        "python",
+        "upstream",
+        "zips",
+        ".emscripten"
+    ],
+    "checkver": {
+        "url": "https://github.com/emscripten-core/emsdk/tags",
+        "regex": "tag/([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/emscripten-core/emsdk/archive/refs/tags/$version.zip"
+            }
+        },
+        "extract_dir": "emsdk-$version"
+    }
+}


### PR DESCRIPTION
close #3219

[EMScripten](https://emscripten.org/) is an An LLVM to WebAssembly compiler. It compiles C/C++ to a machine code format (WebAssembly) that can be run on most web browsers, and is quickly becoming a standard.

**NOTES**:

* **license**: `Emscripten is available under 2 licenses, the MIT license and the
University of Illinois/NCSA Open Source License.` (https://emscripten.org/docs/introducing_emscripten/emscripten_license.html)

* `emcmdprompt.bat` opens `emsdk_env.bat` in a new window. I assume this is designed to start EMScripten environment via the shortcut (such as the case for **Anaconda**)

* I tested the app by the following steps:
1. install the package.
1. run `emsdk install latest` and `emsdk activate latest`.
1. create a file `example.c` with the following content:
```
#include <stdio.h>

int main() {
  printf("hello, world!\n");
  return 0;
}
```
4. open "EMScripten command prompt" (via the shortcut)
5. run `emcc -o example.js example.c`
    -> This generates `example.js` and `example.wasm`, in which `example.js` acts as a loader, and `example.wasm` contains actual compiled binary.
6. run `node example.js`
   -> will see `hello, world!` in echo.