### PR TITLE
chkcpu: Add version 2.14

### DIFF
--- a/bucket/chkcpu.json
+++ b/bucket/chkcpu.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.14",
+    "description": "Checks CPU Vendor, Model, Internal speed, and L1 cache mode settings.",
+    "homepage": "http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm"
+    },
+    "url": "http://web.inter.nl.net/hcc/J.Steunebrink/ckcpu214.zip",
+    "hash": "ce9142e29000f8299750a1880056a8a812c0fef91cac16b843ad947b18114d16",
+    "bin": [
+        "chkcpu32.exe",
+        [
+            "chkcpu32.exe",
+            "chkcpu"
+        ]
+    ]
+}


### PR DESCRIPTION
close #1672

[CHKCPU](http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm) is a tool that checks CPU Vendor, Model, Internal speed, and L1 cache mode settings.

**NOTES**:
* **checkver/autoupdate** is not needed because the last update was in 2017.
* **license**: See http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm
  ```
  DOS version: CHKCPU v1.26
  Win32 version: CHKCPU32 v2.14
  Both programs are dated 06/06/2017, have the same update status regarding the CPU model data, and they are both freeware.
  ```
* About `chkcpu32.bat`:
  - The manual says `CHKCPU32.BAT  ;a batch file for easy use of the program`
  - The content is:
    ```
    @echo off
    if exist chkcpu32.exe goto run
    goto error
    
    :run
    chkcpu32.exe /v
    goto done
    
    :error
    @echo  =====================================================
    @echo  = ERROR: The Chkcpu32.exe program was not found.    =
    @echo  = Please copy Chkcpu32.exe to the same folder as    =
    @echo  = the Chkcpu32.bat file and run Chkcpu32.bat again. =
    @echo  =====================================================
    
    :done
    @echo.
    pause
    ```
  - I think the batch file mainly **exists for the pause**, when user double-clicks to open the app, this prevents the cmd window from closing. Therefore I did not add it to **bin**. 