### PR TITLE
libavif: Add version 0.9.0

### DIFF
--- a/bucket/libavif.json
+++ b/bucket/libavif.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.9.0",
+    "description": "Tools and library for encoding and decoding AV1 video streams (.avif)",
+    "homepage": "https://github.com/AOMediaCodec/libavif",
+    "license": "BSD-2-Clause",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/AOMediaCodec/libavif/releases/download/v0.9.0/avifdec.exe",
+                "https://github.com/AOMediaCodec/libavif/releases/download/v0.9.0/avifenc.exe",
+                "https://github.com/AOMediaCodec/libavif/releases/download/v0.9.0/libavif_vs2019_x64_4fedf0bb_Release.zip"
+            ],
+            "hash": [
+                "e199d58a505257758db05f4246069b7ca596fc89bcbbfc2f99691571457c00b0",
+                "753b8ed9f292c95acc7600345e5c4ff765337587ced9cea2058cf6272fe0fb2f",
+                "4aa41b3dfc9c91d4bd47bad39922a9239bb1b3732d4d6f3a2cb2c22d131c9d0e"
+            ]
+        }
+    },
+    "bin": [
+        "avifdec.exe",
+        "avifenc.exe"
+    ],
+    "checkver": {
+        "url": "https://github.com/AOMediaCodec/libavif/releases",
+        "regex": "v([\\d.]+)/libavif_vs(?<vs>\\d+)_x64_(?<commit>\\w+)_Release\\.zip"
+    },
+    "autoupdate": {
+        "url": [
+            "https://github.com/AOMediaCodec/libavif/releases/download/v$version/avifdec.exe",
+            "https://github.com/AOMediaCodec/libavif/releases/download/v$version/avifenc.exe",
+            "https://github.com/AOMediaCodec/libavif/releases/download/v$version/libavif_vs$matchVs_x64_$matchCommit_Release.zip"
+        ]
+    }
+}


### PR DESCRIPTION
close #2640

**libavif** ([homepage](https://github.com/AOMediaCodec/libavif)) ([Wikipedia](https://en.wikipedia.org/wiki/AVIF#Support)) is tool and library for encoding and decoding AV1 video streams (.avif).

**NOTES**:
* `avifdec.exe` and `avifenc.exe` does not depend on the library (`.lib` files).
However, I think it won't hurt to include them as well, in case that some users may need to develop their programs using the headers and the library. (It is relatively small compared to the binaries, takes only about 100KB)