### PR TITLE
lxc: Add version 4.22

### DIFF
--- a/bucket/lxc.json
+++ b/bucket/lxc.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/lxc/lxd",
     "license": "Apache-2.0",
     "url": "https://packages.chocolatey.org/lxc.4.22.nupkg",
-    "hash": "354f2d01d4874aaf58d7f7f44621c1b900881565671a37cb1540951fa3bc31ef",
+    "hash": "bd4bb1df187c883f7429d084ad78cef21fc3a4ec3d94904f8f63c977382b17e8",
     "extract_dir": "tools",
     "architecture": {
         "64bit": {

--- a/bucket/lxc.json
+++ b/bucket/lxc.json
@@ -1,29 +1,28 @@
 {
     "version": "4.22",
     "description": "LXD client",
-    "homepage": "https://github.com/lxc/lxd",
+    "homepage": "https://linuxcontainers.org/lxd",
     "license": "Apache-2.0",
-    "url": "https://packages.chocolatey.org/lxc.4.22.nupkg",
-    "hash": "bd4bb1df187c883f7429d084ad78cef21fc3a4ec3d94904f8f63c977382b17e8",
-    "extract_dir": "tools",
     "architecture": {
         "64bit": {
-            "bin": "lxc.exe"
+            "url": "https://packages.chocolatey.org/lxc.4.22.nupkg",
+            "hash": "bd4bb1df187c883f7429d084ad78cef21fc3a4ec3d94904f8f63c977382b17e8"
         }
     },
+    "extract_dir": "tools",
+    "bin": "lxc.exe",
     "checkver": {
         "url": "https://community.chocolatey.org/packages/lxc",
         "regex": "LXD client ([\\d.]+)</title>"
     },
     "autoupdate": {
-        "url": "https://packages.chocolatey.org/lxc.$version.nupkg",
-        "hash": {
-            "url": "https://community.chocolatey.org/packages/lxc",
-            "regex": "$sha256.*?$basename"
-        },
         "architecture": {
             "64bit": {
-                "bin": "lxc.exe"
+                "url": "https://packages.chocolatey.org/lxc.$version.nupkg",
+                "hash": {
+                    "url": "https://community.chocolatey.org/packages/lxc",
+                    "regex": "$sha256.*?$basename"
+                }
             }
         }
     }

--- a/bucket/lxc.json
+++ b/bucket/lxc.json
@@ -1,0 +1,30 @@
+{
+    "version": "4.22",
+    "description": "LXD client",
+    "homepage": "https://github.com/lxc/lxd",
+    "license": "Apache-2.0",
+    "url": "https://packages.chocolatey.org/lxc.4.22.nupkg",
+    "hash": "354f2d01d4874aaf58d7f7f44621c1b900881565671a37cb1540951fa3bc31ef",
+    "extract_dir": "tools",
+    "architecture": {
+        "64bit": {
+            "bin": "lxc.exe"
+        }
+    },
+    "checkver": {
+        "url": "https://community.chocolatey.org/packages/lxc",
+        "regex": "LXD client ([\\d.]+)</title>"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/lxc.$version.nupkg",
+        "hash": {
+            "url": "https://community.chocolatey.org/packages/lxc",
+            "regex": "$sha256.*?$basename"
+        },
+        "architecture": {
+            "64bit": {
+                "bin": "lxc.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
@rashil2000 here is a manifest derived from the sed one using chocolatey as a source.

Some thoughts I had though:
- ~~I'm not sure how the hash regex in autoupdate is supposed to work, there is a hash on the html of the page but it seems to be the hash for `lxc.exe` and some other files rather than the nupkg archive itself. Since this also seemed to be the case for sed as well I left it intact.~~
  I was looking in the wrong place 😅 all's good there.
- `lxc.exe` stores its configuration data and files in `~\.config/lxc` when necessary - is there an example of how I can easily persist a directory like that while keeping any potential existing user data from other installs?

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1668

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
