### PR TITLE
ninja-kitware: Add version 1.10.2.g51db2.kitware.jobserver-1

### DIFF
--- a/bucket/ninja-kitware.json
+++ b/bucket/ninja-kitware.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.10.2.g51db2.kitware.jobserver-1",
+    "description": "A small build system with a focus on speed (Kitware fork).",
+    "homepage": "https://github.com/Kitware/ninja",
+    "license": "Apache-2.0",
+    "url": "https://github.com/Kitware/ninja/releases/download/v1.10.2.g51db2.kitware.jobserver-1/ninja-1.10.2.g51db2.kitware.jobserver-1_x86_64-pc-windows-msvc.zip",
+    "hash": "6695ef68138f6c34713e48bb1a44ea7627e868fbc658424cc81e7c08f934da92",
+    "extract_dir": "ninja-1.10.2.g51db2.kitware.jobserver-1_x86_64-pc-windows-msvc",
+    "bin": "ninja.exe",
+    "checkver": {
+        "github": "https://github.com/Kitware/ninja",
+        "regex": "/releases/tag/(?:v|V)?([\\w.-]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Kitware/ninja/releases/download/v$version/ninja-$version_x86_64-pc-windows-msvc.zip",
+        "extract_dir": "ninja-$version_x86_64-pc-windows-msvc"
+    }
+}

--- a/bucket/ninja-kitware.json
+++ b/bucket/ninja-kitware.json
@@ -1,18 +1,26 @@
 {
     "version": "1.10.2.g51db2.kitware.jobserver-1",
-    "description": "A small build system with a focus on speed (Kitware fork).",
+    "description": "A small build system with a focus on speed (Kitware fork with jobserver support).",
     "homepage": "https://github.com/Kitware/ninja",
     "license": "Apache-2.0",
-    "url": "https://github.com/Kitware/ninja/releases/download/v1.10.2.g51db2.kitware.jobserver-1/ninja-1.10.2.g51db2.kitware.jobserver-1_x86_64-pc-windows-msvc.zip",
-    "hash": "6695ef68138f6c34713e48bb1a44ea7627e868fbc658424cc81e7c08f934da92",
-    "extract_dir": "ninja-1.10.2.g51db2.kitware.jobserver-1_x86_64-pc-windows-msvc",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Kitware/ninja/releases/download/v1.10.2.g51db2.kitware.jobserver-1/ninja-1.10.2.g51db2.kitware.jobserver-1_x86_64-pc-windows-msvc.zip",
+            "hash": "6695ef68138f6c34713e48bb1a44ea7627e868fbc658424cc81e7c08f934da92",
+            "extract_dir": "ninja-1.10.2.g51db2.kitware.jobserver-1_x86_64-pc-windows-msvc"
+        }
+    },
     "bin": "ninja.exe",
     "checkver": {
         "github": "https://github.com/Kitware/ninja",
         "regex": "/releases/tag/(?:v|V)?([\\w.-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Kitware/ninja/releases/download/v$version/ninja-$version_x86_64-pc-windows-msvc.zip",
-        "extract_dir": "ninja-$version_x86_64-pc-windows-msvc"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Kitware/ninja/releases/download/v$version/ninja-$version_x86_64-pc-windows-msvc.zip",
+                "extract_dir": "ninja-$version_x86_64-pc-windows-msvc"
+            }
+        }
     }
 }

--- a/bucket/ninja.json
+++ b/bucket/ninja.json
@@ -3,13 +3,21 @@
     "description": "A small build system with a focus on speed.",
     "homepage": "https://ninja-build.org/",
     "license": "Apache-2.0",
-    "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip",
-    "hash": "bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip",
+            "hash": "bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f"
+        }
+    },
     "bin": "ninja.exe",
     "checkver": {
         "github": "https://github.com/ninja-build/ninja"
     },
     "autoupdate": {
-        "url": "https://github.com/ninja-build/ninja/releases/download/v$version/ninja-win.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ninja-build/ninja/releases/download/v$version/ninja-win.zip"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3243 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Note: ninja (Existing and this fork) provide 64-bit builds only but the manifests don't use `architecture`.
