### PR TITLE
MongoDB stable only

### DIFF
--- a/bucket/mongodb.json
+++ b/bucket/mongodb.json
@@ -48,7 +48,7 @@
         "log"
     ],
     "checkver": {
-        "url": "http://downloads.mongodb.org.s3.amazonaws.com/current.json",
+        "url": "http://downloads.mongodb.org/current.json",
         "jsonpath": "$.versions[0].version"
     },
     "autoupdate": {

--- a/bucket/mongodb.json
+++ b/bucket/mongodb.json
@@ -49,7 +49,7 @@
     ],
     "checkver": {
         "url": "http://downloads.mongodb.org/current.json",
-        "jsonpath": "$.versions[0].version"
+        "regex": "version\": \"(\\d+(\\.\\d+)*)\""
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This PR:
- Updates the checkver URL. The existing checkver URL ( http://downloads.mongodb.org.s3.amazonaws.com/current.json ) has SSL issues (missing CN). 
- Changes the jsonpath to a regex to restrict the matched versions to stable releases only. Unfortunately I couldn't write a valid jsonpath to do the same.


Closes #3259

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
