### PR TITLE
gron: Add version 0.6.1

### DIFF
--- a/bucket/gron.json
+++ b/bucket/gron.json
@@ -1,6 +1,6 @@
 {
     "version": "0.6.1",
-    "description": "gron transforms JSON into discrete assignments to make it easier to grep for what you want and see the absolute 'path' to it.",
+    "description": "Transform JSON into discrete assignments to make it easier to grep and see the absolute 'path'.",
     "homepage": "https://github.com/tomnomnom/gron",
     "license": "MIT",
     "architecture": {

--- a/bucket/gron.json
+++ b/bucket/gron.json
@@ -13,19 +13,5 @@
             "hash": "0de1f46f693b36b1c1a3b6af2d013b3d1db1ee7e49e00d4dbafd58200e3704e2"
         }
     },
-    "bin": "gron.exe",
-    "checkver": {
-        "url": "https://github.com/tomnomnom/gron/releases",
-        "regex": "tag/v([\\d.]+)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-amd64-$version.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-386-$version.zip"
-            }
-        }
-    }
+    "bin": "gron.exe"
 }

--- a/bucket/gron.json
+++ b/bucket/gron.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.6.1",
+    "description": "gron transforms JSON into discrete assignments to make it easier to grep for what you want and see the absolute 'path' to it.",
+    "homepage": "https://github.com/tomnomnom/gron",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tomnomnom/gron/releases/download/v0.6.1/gron-windows-amd64-0.6.1.zip",
+            "hash": "50747640a28c46affd71c1dcb44b31772facc38a9a95bcd22077e141095e8b45"
+        },
+        "32bit": {
+            "url": "https://github.com/tomnomnom/gron/releases/download/v0.6.1/gron-windows-386-0.6.1.zip",
+            "hash": "0de1f46f693b36b1c1a3b6af2d013b3d1db1ee7e49e00d4dbafd58200e3704e2"
+        }
+    },
+    "bin": "gron.exe",
+    "checkver": {
+        "url": "https://github.com/tomnomnom/gron/releases",
+        "regex": "tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-amd64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-386-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
gron: Make JSON greppable! 
gron transforms JSON into discrete assignments to make it easier to grep for what you want and see the absolute 'path' to it. It eases the exploration of APIs that return large blobs of JSON but have terrible documentation.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
