### PR TITLE
wait-for-it: Add version 0.2.9

### DIFF
--- a/bucket/wait-for-it.json
+++ b/bucket/wait-for-it.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.9",
+    "description": "Utility to wait on the availability of a TCP host and port",
+    "homepage": "https://github.com/roerohan/wait-for-it",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/roerohan/wait-for-it/releases/download/v0.2.9/wait-for-it_win64.exe#/wait-for-it.exe",
+            "hash": "06d016efbcbb0d9d272a8fbcf140b5cc4a669b2d952fe6111bf6599ece12cb0a"
+        }
+    },
+    "bin": "wait-for-it.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/roerohan/wait-for-it/releases/download/v$version/wait-for-it_win64.exe#/wait-for-it.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Popular and simple utility used to wait for TCP connections until a service is up.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
