### PR TITLE
scrcpy: add icon to shortcut

### DIFF
--- a/bucket/scrcpy.json
+++ b/bucket/scrcpy.json
@@ -23,7 +23,9 @@
     "shortcuts": [
         [
             "scrcpy-noconsole.vbs",
-            "scrcpy"
+            "scrcpy",
+            "",
+            "scrcpy.exe"
         ]
     ],
     "checkver": "github",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- New icon was recently made for scrcpy but it was only released as png so could not be added to shortcut
- Now it is included in exe as an ico: https://github.com/Genymobile/scrcpy/commit/cfcbc2ac218612b2e9d2322ceb98ec99d7cd9381

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
