### PR TITLE
ani-cli: Add version 1.6

### DIFF
--- a/bucket/ani-cli.json
+++ b/bucket/ani-cli.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.6",
+    "description": "A cli to browse and watch anime",
+    "homepage": "https://github.com/pystardust/ani-cli",
+    "license": "GPL-3.0",
+    "url": "https://github.com/pystardust/ani-cli/releases/download/v1.6/ani-cli",
+    "hash": "e2e6ab7d9419d81b84b2300d3f9b45044d7e50b07e6378ce78a68a100deeaf52",
+    "depends": [
+        "aria2",
+        "mpv"
+    ],
+    "bin": "ani-cli",
+    "checkver": {
+        "github": "https://github.com/pystardust/ani-cli"
+    },
+    "autoupdate": {
+        "url": "https://github.com/pystardust/ani-cli/releases/download/v$version/ani-cli"
+    }
+}

--- a/bucket/ani-cli.json
+++ b/bucket/ani-cli.json
@@ -1,6 +1,6 @@
 {
     "version": "1.6",
-    "description": "A cli to browse and watch anime",
+    "description": "A cli to browse and watch anime. This tool scrapes the site gogoanime.",
     "homepage": "https://github.com/pystardust/ani-cli",
     "license": "GPL-3.0",
     "url": "https://github.com/pystardust/ani-cli/releases/download/v1.6/ani-cli",


### PR DESCRIPTION
ani-cli : A cli to browse and watch anime. This tool scrapes the site gogoanime.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
