### PR TITLE
gtypist: Add version 2.9.5

### DIFF
--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -1,7 +1,7 @@
 {
     "version": "2.9.5",
     "description": "A universal typing tutor allowing one to practise regularly.",
-    "homepage": "https://www.gnu.org/software/gtypist/",
+    "homepage": "https://www.gnu.org/software/gtypist",
     "license": "GPL-3.0-or-later",
     "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-2.9.5-w32.7z",
     "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
@@ -10,7 +10,7 @@
         [
             "gtypist.exe",
             "gtypist",
-            "$dir/lessons/gtypist.typ"
+            "$dir\\lessons\\gtypist.typ"
         ]
     ]
 }

--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.9.5",
+    "description": "GNU Typist (also called gtypist) is a universal typing tutor. You can learn correct typing and improve your skills by practising its exercises on a regular basis.",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://www.gnu.org/licenses/gpl-3.0.html"
+    },
+    "bin": [["gtypist.exe", "gtypist", "$dir/lessons/gtypist.typ"]],
+    "homepage": "https://www.gnu.org/software/gtypist/",
+    "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-2.9.5-w32.7z",
+    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
+    "extract_dir": "gtypist-2.9.5-w32",
+    "checkver": {
+        "url": "https://www.gnu.org/software/gtypist/",
+        "regex": "The latest stable release of GNU Typist is version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-$version-w32.7z",
+        "extract_dir": "gtypist-$version-w32"
+    }
+}

--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -7,17 +7,15 @@
         "url": "https://www.gnu.org/licenses/gpl-3.0.html"
     },
     "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-2.9.5-w32.7z",
+    "bin": [["gtypist.exe", "gtypist", "$dir/lessons/gtypist.typ"]],
+    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
+    "extract_dir": "gtypist-2.9.5-w32",
     "autoupdate": {
         "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-$version-w32.7z",
         "extract_dir": "gtypist-$version-w32"
     },
-    "bin": [["gtypist.exe", "gtypist", "$dir/lessons/gtypist.typ"]],
     "checkver": {
         "url": "https://www.gnu.org/software/gtypist/",
         "regex": "The latest stable release of GNU Typist is version ([\\d.]+)"
-    },
-    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
-    "extract_dir": "gtypist-2.9.5-w32",
-
-    
+    } 
 }

--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -7,7 +7,13 @@
         "url": "https://www.gnu.org/licenses/gpl-3.0.html"
     },
     "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-2.9.5-w32.7z",
-    "bin": [["gtypist.exe", "gtypist", "$dir/lessons/gtypist.typ"]],
+    "bin": [
+        [
+            "gtypist.exe",
+            "gtypist",
+            "$dir/lessons/gtypist.typ"
+        ]
+    ],
     "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
     "extract_dir": "gtypist-2.9.5-w32",
     "autoupdate": {
@@ -17,5 +23,5 @@
     "checkver": {
         "url": "https://www.gnu.org/software/gtypist/",
         "regex": "The latest stable release of GNU Typist is version ([\\d.]+)"
-    } 
+    }
 }

--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -1,21 +1,23 @@
 {
     "version": "2.9.5",
     "description": "A universal typing tutor allowing one to practise regularly.",
+    "homepage": "https://www.gnu.org/software/gtypist/",
     "license": {
         "identifier": "GPL-3.0-or-later",
         "url": "https://www.gnu.org/licenses/gpl-3.0.html"
     },
-    "bin": [["gtypist.exe", "gtypist", "$dir/lessons/gtypist.typ"]],
-    "homepage": "https://www.gnu.org/software/gtypist/",
     "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-2.9.5-w32.7z",
-    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
-    "extract_dir": "gtypist-2.9.5-w32",
+    "autoupdate": {
+        "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-$version-w32.7z",
+        "extract_dir": "gtypist-$version-w32"
+    },
+    "bin": [["gtypist.exe", "gtypist", "$dir/lessons/gtypist.typ"]],
     "checkver": {
         "url": "https://www.gnu.org/software/gtypist/",
         "regex": "The latest stable release of GNU Typist is version ([\\d.]+)"
     },
-    "autoupdate": {
-        "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-$version-w32.7z",
-        "extract_dir": "gtypist-$version-w32"
-    }
+    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
+    "extract_dir": "gtypist-2.9.5-w32",
+
+    
 }

--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -1,6 +1,6 @@
 {
     "version": "2.9.5",
-    "description": "GNU Typist (also called gtypist) is a universal typing tutor. You can learn correct typing and improve your skills by practising its exercises on a regular basis.",
+    "description": "A universal typing tutor allowing one to practise regularly.",
     "license": {
         "identifier": "GPL-3.0-or-later",
         "url": "https://www.gnu.org/licenses/gpl-3.0.html"

--- a/bucket/gtypist.json
+++ b/bucket/gtypist.json
@@ -2,26 +2,15 @@
     "version": "2.9.5",
     "description": "A universal typing tutor allowing one to practise regularly.",
     "homepage": "https://www.gnu.org/software/gtypist/",
-    "license": {
-        "identifier": "GPL-3.0-or-later",
-        "url": "https://www.gnu.org/licenses/gpl-3.0.html"
-    },
+    "license": "GPL-3.0-or-later",
     "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-2.9.5-w32.7z",
+    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
+    "extract_dir": "gtypist-2.9.5-w32",
     "bin": [
         [
             "gtypist.exe",
             "gtypist",
             "$dir/lessons/gtypist.typ"
         ]
-    ],
-    "hash": "8f3a021833acc81ba9291062c91c956f88ebb4d9225b9a955cb8b60cd6cdb0d3",
-    "extract_dir": "gtypist-2.9.5-w32",
-    "autoupdate": {
-        "url": "http://ftp.gnu.org/gnu/gtypist/w32_binaries/gtypist-$version-w32.7z",
-        "extract_dir": "gtypist-$version-w32"
-    },
-    "checkver": {
-        "url": "https://www.gnu.org/software/gtypist/",
-        "regex": "The latest stable release of GNU Typist is version ([\\d.]+)"
-    }
+    ]
 }


### PR DESCRIPTION
gnu typist, also known as gtypist, is a typing tutor helps improving type skill.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
