### PR TITLE
shadowsocks-rust@1.13.1: Fix hash

### DIFF
--- a/bucket/shadowsocks-rust.json
+++ b/bucket/shadowsocks-rust.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/shadowsocks/shadowsocks-rust/releases/download/v1.13.1/shadowsocks-v1.13.1.x86_64-pc-windows-msvc.zip",
-            "hash": "4d8f2dc1846799bd6ba648b61bcd6b22d97237aa1fb603ef8a64222bf85ba44f"
+            "hash": "35db8d121b4ec2f54803790e89636aed52da37a35a9bb1fee99cc87e9a9e1051"
         }
     },
     "bin": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- Closes #XXXX -->
<!-- or -->
<!-- Relates to #XXXX -->

Content of <https://github.com/shadowsocks/shadowsocks-rust/releases/download/v1.13.1/shadowsocks-v1.13.1.x86_64-pc-windows-msvc.zip.sha256>:

```text
35DB8D121B4EC2F54803790E89636AED52DA37A35A9BB1FEE99CC87E9A9E1051  shadowsocks-v1.13.1.x86_64-pc-windows-msvc.zip
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
