### PR TITLE
pget: Add version 0.1.1

### DIFF
--- a/bucket/pget.json
+++ b/bucket/pget.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/Code-Hex/pget",
+    "description": "A command-line Downloader using parallel requests",
+    "version": "0.1.1",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Code-Hex/pget/releases/download/v0.1.1/pget_0.1.1_Windows_x86_64.zip",
+            "hash": "71a80c387fe277f411e5ed314194a68699997e0c0b1530b80ea79b4072add8ed"
+        },
+        "32bit": {
+            "url": "https://github.com/Code-Hex/pget/releases/download/v0.1.1/pget_0.1.1_Windows_i386.zip",
+            "hash": "e20dc7a2e9d83a5df2edda75b85649efa105129820e6283cffbdf66bd549112a"
+        }
+    },
+    "bin": "pget.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Code-Hex/pget/releases/download/v$version/pget_$version_Windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Code-Hex/pget/releases/download/v$version/pget_$version_Windows_i386.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/pget_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

A command-line utility like wget but with parallel requests.

No persist and no depends.