### PR TITLE
rcc: Add version 11.5.5

### DIFF
--- a/bucket/rcc.json
+++ b/bucket/rcc.json
@@ -1,0 +1,24 @@
+{
+    "version": "11.5.5",
+    "description": "Allows you to create, manage, and distribute Python-based self-contained automation packages.",
+    "homepage": "https://robocorp.com/docs/rcc/overview",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.robocorp.com/rcc/releases/v11.5.5/windows64/rcc.exe",
+            "hash": "220609582a405bb62f43fa06cd6fdf7f1b7b7edbcbca90d4d5f36c6a2d9b0ba8"
+        }
+    },
+    "bin": "rcc.exe",
+    "checkver": {
+        "url": "https://downloads.robocorp.com/rcc/releases/index.html",
+        "regex": "v([\\d.]+)/windows64/rcc\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.robocorp.com/rcc/releases/v$version/windows64/rcc.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes https://github.com/ScoopInstaller/Extras/issues/7986

[RCC](https://robocorp.com/docs/rcc/overview) is a set of tooling that allows you to create, manage, and distribute Python-based self-contained automation packages - or robots as we call them.

**NOTES**:
* The app is built in **64-bit**.
* persist is not needed because config is saved in project files (which can be created in *current working directory* by `rcc create`)