### PR TITLE
oh-my-posh3@7.22.0: rename oh-my-posh3 to oh-my-posh

### DIFF
--- a/bucket/oh-my-posh.json
+++ b/bucket/oh-my-posh.json
@@ -6,19 +6,19 @@
     "notes": "Refer to 'https://ohmyposh.dev/docs/windows#replace-your-existing-prompt' for shell specific configurations.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v7.22.0/posh-windows-amd64.7z",
+            "url": "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v7.22.0/posh-windows-amd64.7z",
             "hash": "c41677eed25efb83e1d6f65cbb47854ce150958aae70a4a3acfbcd3684a0c334"
         }
     },
     "bin": "bin\\oh-my-posh.exe",
     "persist": "themes",
     "checkver": {
-        "github": "https://github.com/JanDeDobbeleer/oh-my-posh3"
+        "github": "https://github.com/JanDeDobbeleer/oh-my-posh"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JanDeDobbeleer/oh-my-posh3/releases/download/v$version/posh-windows-amd64.7z"
+                "url": "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$version/posh-windows-amd64.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Based on @JanDeDobbeleer scoop install manifest and redirect/rename, `oh-my-posh3` is now `oh-my-posh`. 
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Reference:
https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/oh-my-posh.json
Closes #3321
Relates to #1843

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
