### PR TITLE
openssl: Set OPENSSL_MODULES environment variable

### DIFF
--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -14,7 +14,6 @@
         }
     },
     "innosetup": true,
-    "bin": "bin\\openssl.exe",
     "env_add_path": "bin",
     "env_set": {
         "OPENSSL_CONF": "$dir\\bin\\cnf\\openssl.cnf",

--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -19,7 +19,8 @@
     "env_set": {
         "OPENSSL_CONF": "$dir\\bin\\cnf\\openssl.cnf",
         "OPENSSL_LIB_DIR": "$dir\\lib",
-        "OPENSSL_INCLUDE_DIR": "$dir\\include"
+        "OPENSSL_INCLUDE_DIR": "$dir\\include",
+        "OPENSSL_MODULES": "$dir\\bin"
     },
     "checkver": "Win32 OpenSSL v([^\\s]+)",
     "autoupdate": {


### PR DESCRIPTION
Required for OpenSSL to locate various modules (aka. providers).

Closes #3335

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
