### PR TITLE
zoxide: Remove `env_set` and `persist`

### DIFF
--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -3,7 +3,10 @@
     "description": "A faster way to navigate your filesystem",
     "homepage": "https://github.com/ajeetdsouza/zoxide",
     "license": "MIT",
-    "notes": "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload",
+    "notes": [
+        "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload",
+        "_ZO_DATA_DIR is located at $env:APPDATA\\zoxide by default"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.8.0/zoxide-v0.8.0-x86_64-pc-windows-msvc.zip",

--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -11,10 +11,6 @@
         }
     },
     "bin": "zoxide.exe",
-    "env_set": {
-        "_ZO_DATA_DIR": "$dir\\data"
-    },
-    "persist": "data",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -3,10 +3,7 @@
     "description": "A faster way to navigate your filesystem",
     "homepage": "https://github.com/ajeetdsouza/zoxide",
     "license": "MIT",
-    "notes": [
-        "See https://github.com/ajeetdsouza/zoxide#powershell for zoxide autoload",
-        "_ZO_DATA_DIR is located at $env:APPDATA\\zoxide by default"
-    ],
+    "notes": "_ZO_DATA_DIR is located at $env:APPDATA\\zoxide by default",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.8.0/zoxide-v0.8.0-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
Each user should have their own database, and if zoxide is installed globally, it fails to write to the data directory when not running as admin, so the default value set by zoxide (`$Env:APPDATA`) is already ok.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
