### PR TITLE
dapr-cli: Update LICENSE to Apache 2.0

### DIFF
--- a/bucket/dapr-cli.json
+++ b/bucket/dapr-cli.json
@@ -2,7 +2,7 @@
     "version": "1.6.0",
     "description": "Command-line tools for Dapr",
     "homepage": "https://github.com/dapr/cli",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/dapr/cli/releases/download/v1.6.0/dapr_windows_amd64.zip",


### PR DESCRIPTION
Update LICENSE to Apache 2.0

Closes #3346

Related: https://github.com/dapr/cli/commits/master/LICENSE