### PR TITLE
goodbyedpi: Add version 0.2.1

### DIFF
--- a/bucket/goodbyedpi.json
+++ b/bucket/goodbyedpi.json
@@ -8,12 +8,6 @@
     "hash": "acb0568cfc184cdd52c235c9ccc51a38fd78eb57564dcf7dce5188b9ad93f391",
     "extract_dir": "goodbyedpi-0.2.1",
     "bin": "goodbyedpi.exe",
-    "shortcuts": [
-        [
-            "goodbyedpi.exe",
-            "GoodbyeDPI"
-        ]
-    ],
     "architecture": {
         "64bit": {
             "pre_install": [

--- a/bucket/goodbyedpi.json
+++ b/bucket/goodbyedpi.json
@@ -3,7 +3,6 @@
     "description": "Bypass Deep Packet Inspection systems found in many Internet Service Providers which block access to certain websites.",
     "homepage": "https://github.com/ValdikSS/GoodbyeDPI",
     "license": "Apache-2.0",
-    "notes": "Follow the instructions on 'https://github.com/ValdikSS/GoodbyeDPI#readme' to set up GoodbyeDPI",
     "url": "https://github.com/ValdikSS/GoodbyeDPI/releases/download/0.2.1/goodbyedpi-0.2.1.zip",
     "hash": "acb0568cfc184cdd52c235c9ccc51a38fd78eb57564dcf7dce5188b9ad93f391",
     "extract_dir": "goodbyedpi-0.2.1",

--- a/bucket/goodbyedpi.json
+++ b/bucket/goodbyedpi.json
@@ -1,0 +1,36 @@
+{
+    "version": "0.2.1",
+    "description": "Bypass Deep Packet Inspection systems found in many Internet Service Providers which block access to certain websites.",
+    "homepage": "https://github.com/ValdikSS/GoodbyeDPI",
+    "license": "Apache-2.0",
+    "notes": "Follow the instructions on 'https://github.com/ValdikSS/GoodbyeDPI#readme' to set up GoodbyeDPI",
+    "url": "https://github.com/ValdikSS/GoodbyeDPI/releases/download/0.2.1/goodbyedpi-0.2.1.zip",
+    "hash": "acb0568cfc184cdd52c235c9ccc51a38fd78eb57564dcf7dce5188b9ad93f391",
+    "extract_dir": "goodbyedpi-0.2.1",
+    "bin": "goodbyedpi.exe",
+    "shortcuts": [
+        [
+            "goodbyedpi.exe",
+            "GoodbyeDPI"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "pre_install": [
+                "Move-Item \"$dir\\x86_64\\*\" \"$dir\\\"",
+                "Remove-Item \"$dir\\x86\", \"$dir\\x86_64\" -Force -Recurse"
+            ]
+        },
+        "32bit": {
+            "pre_install": [
+                "Move-Item \"$dir\\x86\\*\" \"$dir\\\"",
+                "Remove-Item \"$dir\\x86\", \"$dir\\x86_64\" -Force -Recurse"
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ValdikSS/GoodbyeDPI/releases/download/$version/goodbyedpi-$version.zip",
+        "extract_dir": "goodbyedpi-$version"
+    }
+}


### PR DESCRIPTION
closes https://github.com/ScoopInstaller/Extras/issues/8094

supersedes https://github.com/ScoopInstaller/Extras/pull/8096


[GoodbyeDPI](https://github.com/ValdikSS/GoodbyeDPI) is a tool to bypass Deep Packet Inspection systems found in many Internet Service Providers which block access to certain websites.