### PR TITLE
smartmontools: Fix update-smart-drivedb shim

### DIFF
--- a/bucket/smartmontools.json
+++ b/bucket/smartmontools.json
@@ -11,7 +11,7 @@
         "bin\\smartctl-nc.exe",
         "bin\\smartd.exe",
         "bin\\smartd_warning.cmd",
-        "bin\\update-smart-drivedb.exe",
+        "bin\\update-smart-drivedb.ps1",
         "bin\\wtssendmsg.exe"
     ],
     "checkver": {


### PR DESCRIPTION
Closes #3352

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
