### PR TITLE
waifu2x-ncnn-vulkan: Add version 20210521

### DIFF
--- a/bucket/waifu2x-ncnn-vulkan.json
+++ b/bucket/waifu2x-ncnn-vulkan.json
@@ -6,18 +6,18 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/20210521/waifu2x-ncnn-vulkan-20210521-windows.zip",
-            "hash": "9569800CBE9575F5C1C5E13C491FC645FF0D447EAD5A853B5F2EFB2005B7417B"
+            "hash": "9569800CBE9575F5C1C5E13C491FC645FF0D447EAD5A853B5F2EFB2005B7417B",
+            "extract_dir": "waifu2x-ncnn-vulkan-20210521-windows"
         }
     },
-    "extract_dir": "waifu2x-ncnn-vulkan-20210521-windows",
     "bin": "waifu2x-ncnn-vulkan.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/$version/waifu2x-ncnn-vulkan-$version-windows.zip"
-            },
-        "extract_dir": "waifu2x-ncnn-vulkan-$version-windows"
+                "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/$version/waifu2x-ncnn-vulkan-$version-windows.zip",
+                "extract_dir": "waifu2x-ncnn-vulkan-$version-windows"
+            }
         }
     }
 }

--- a/bucket/waifu2x-ncnn-vulkan.json
+++ b/bucket/waifu2x-ncnn-vulkan.json
@@ -1,0 +1,23 @@
+{
+    "version": "20210521",
+    "description": "waifu2x converter ncnn version.",
+    "homepage": "https://github.com/nihui/waifu2x-ncnn-vulkan",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/20210521/waifu2x-ncnn-vulkan-20210521-windows.zip",
+            "hash": "9569800CBE9575F5C1C5E13C491FC645FF0D447EAD5A853B5F2EFB2005B7417B"
+        }
+    },
+    "extract_dir": "waifu2x-ncnn-vulkan-20210521-windows",
+    "bin": "waifu2x-ncnn-vulkan.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/$version/waifu2x-ncnn-vulkan-$version-windows.zip"
+            },
+        "extract_dir": "waifu2x-ncnn-vulkan-$version-windows"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds waifu2x-ncnn-vulkan version 20210521, a vulkan based image upscaling application.
Cli usage https://github.com/nihui/waifu2x-ncnn-vulkan#example-command.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3356
<!-- or -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
