### PR TITLE
gitea: fix check version autoupdate regex 

### DIFF
--- a/bucket/gitea.json
+++ b/bucket/gitea.json
@@ -40,8 +40,8 @@
         "data"
     ],
     "checkver": {
-        "url": "https://blog.gitea.io/",
-        "regex": "Gitea.*?([\\d.]+)"
+        "url": "http://dl.gitea.io/gitea",
+        "regex": "Current Release ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/gitea.json
+++ b/bucket/gitea.json
@@ -40,7 +40,7 @@
         "data"
     ],
     "checkver": {
-        "url": "http://dl.gitea.io/gitea",
+        "url": "https://dl.gitea.io/gitea",
         "regex": "Current Release ([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
Fix broken regex that check against blog entry,
and change against Current version

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
