### PR TITLE
Update simple-http-server to 0.6.1 (download URL changed)

### DIFF
--- a/bucket/simple-http-server.json
+++ b/bucket/simple-http-server.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.4.2",
+    "version": "0.6.1",
     "description": "Simple http server",
     "homepage": "https://github.com/TheWaWaR/simple-http-server",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/TheWaWaR/simple-http-server/releases/download/0.4.2/simple-http-server-win64.zip",
-            "hash": "05dec305f1f6bbfa0d343abdbc288e473139c6ee878c907bc079b94e7cc35944"
+            "url": "https://github.com/TheWaWaR/simple-http-server/releases/download/v0.6.1/x86_64-pc-windows-msvc-simple-http-server.exe#/simple-http-server.exe",
+            "hash": "57039d94af3b3c6b46b0020ab0f05c5a6bf6faadf89e8956aca2224a9134ddc1"
         }
     },
     "bin": "simple-http-server.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/TheWaWaR/simple-http-server/releases/download/$version/simple-http-server-win64.zip"
+                "url": "https://github.com/TheWaWaR/simple-http-server/releases/download/$version/x86_64-pc-windows-msvc-simple-http-server.exe#/simple-http-server.exe"
             }
         }
     }

--- a/bucket/simple-http-server.json
+++ b/bucket/simple-http-server.json
@@ -15,6 +15,9 @@
             "64bit": {
                 "url": "https://github.com/TheWaWaR/simple-http-server/releases/download/$version/x86_64-pc-windows-msvc-simple-http-server.exe#/simple-http-server.exe"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
This PR updates simple-http-server to the latest version (0.6.1). Autoupdate doesn't work since release artifacts names have changed since current version 0.4.2.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
