### PR TITLE
ffmpeg: Persist font folder

### DIFF
--- a/bucket/ffmpeg-shared.json
+++ b/bucket/ffmpeg-shared.json
@@ -10,7 +10,6 @@
             "extract_dir": "ffmpeg-5.0-full_build-shared"
         }
     },
-    "pre_install": "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }",
     "post_install": [
         "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
         "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\" -ErrorAction SilentlyContinue"

--- a/bucket/ffmpeg-shared.json
+++ b/bucket/ffmpeg-shared.json
@@ -10,9 +10,7 @@
             "extract_dir": "ffmpeg-5.0-full_build-shared"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }"
-    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }",
     "post_install": [
         "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
         "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\" -ErrorAction SilentlyContinue"

--- a/bucket/ffmpeg-shared.json
+++ b/bucket/ffmpeg-shared.json
@@ -10,10 +10,14 @@
             "extract_dir": "ffmpeg-5.0-full_build-shared"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }"
+    ],
     "post_install": [
         "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
         "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\" -ErrorAction SilentlyContinue"
     ],
+    "persist": "fonts",
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -10,9 +10,7 @@
             "extract_dir": "ffmpeg-5.0-full_build"
         }
     },
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }"
-    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }",
     "post_install": [
         "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
         "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\" -ErrorAction SilentlyContinue"

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -10,7 +10,6 @@
             "extract_dir": "ffmpeg-5.0-full_build"
         }
     },
-    "pre_install": "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }",
     "post_install": [
         "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
         "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\" -ErrorAction SilentlyContinue"

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -10,10 +10,14 @@
             "extract_dir": "ffmpeg-5.0-full_build"
         }
     },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\fonts\")) { New-Item \"$dir\\fonts\" -ItemType Directory | Out-Null }"
+    ],
     "post_install": [
         "# Workaround for https://github.com/ScoopInstaller/Main/issues/2611",
         "Remove-Item \"$scoopdir\\shims\\ffmpeg.ps1\", \"$scoopdir\\shims\\ffplay.ps1\", \"$scoopdir\\shims\\ffprobe.ps1\" -ErrorAction SilentlyContinue"
     ],
+    "persist": "fonts",
     "bin": [
         "bin\\ffmpeg.exe",
         "bin\\ffplay.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
For ffmpeg to work with fonts correctly font folder is needed.
See https://web.archive.org/web/20200511024225/https://ffmpeg.zeranoe.com/forum/viewtopic.php?f=7&t=2554
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
