### PR TITLE
update au.hash in response to Scoop#4619

### DIFF
--- a/bucket/bitwarden-cli.json
+++ b/bucket/bitwarden-cli.json
@@ -18,8 +18,7 @@
             "64bit": {
                 "url": "https://github.com/bitwarden/cli/releases/download/v$version/bw-windows-$version.zip",
                 "hash": {
-                    "url": "$baseurl/bw-windows-sha256-$version.txt",
-                    "regex": "$sha256"
+                    "url": "$baseurl/bw-windows-sha256-$version.txt"
                 }
             }
         }

--- a/bucket/oh-my-posh.json
+++ b/bucket/oh-my-posh.json
@@ -22,8 +22,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256",
-            "regex": "$sha256"
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/schemacrawler.json
+++ b/bucket/schemacrawler.json
@@ -19,8 +19,7 @@
             "64bit": {
                 "url": "https://github.com/schemacrawler/SchemaCrawler-Installers/releases/download/v$version/SchemaCrawler-$version.msi",
                 "hash": {
-                    "url": "$url.SHA256",
-                    "regex": "$sha256"
+                    "url": "$url.SHA256"
                 }
             }
         }


### PR DESCRIPTION
Since https://github.com/ScoopInstaller/Scoop/pull/4619 is now in `master`, we can simplify these manifests.