### PR TITLE
avrdude: update to version 6.4

### DIFF
--- a/bucket/avrdude.json
+++ b/bucket/avrdude.json
@@ -1,17 +1,17 @@
 {
-    "version": "6.3-20171130",
+    "version": "6.4",
     "description": "AVRDUDE is software for programming Atmel AVR Microcontrollers",
-    "homepage": "https://osdn.net/projects/avrdude",
+    "homepage": "https://github.com/avrdudes/avrdude",
     "license": "GPL-2.0-or-later",
-    "architecture": {
-        "64bit": {
-            "url": "https://dotsrc.dl.osdn.net/osdn/avrdude/72328/avrdude-64.zip",
-            "hash": "b5f7cccd8c5cbd57d425c3302761990a3cd92479f988bcd54cd2d0d3856ad129"
-        },
-        "32bit": {
-            "url": "https://dotsrc.dl.osdn.net/osdn/avrdude/72328/avrdude.zip",
-            "hash": "f7c047d95ed5bf5b2e932ea5e36652f25a3b7eb2b22edea1c0986785013f07ef"
-        }
+    "url": "https://download.savannah.gnu.org/releases/avrdude/avrdude-6.4-mingw32.zip",
+    "hash": "d16d6ec2c721c7622925b27b8ed1536b3fc6f9015c1f22c8b47ac9b19fdb03ed",
+    "bin": "avrdude.exe",
+    "checkver": {
+        "url": "https://download.savannah.gnu.org/releases/avrdude/",
+        "regex": "avrdude-([\\d.]+)-mingw32.zip",
+        "reverse": true
     },
-    "bin": "avrdude.exe"
+    "autoupdate": {
+        "url": "https://download.savannah.gnu.org/releases/avrdude/avrdude-$version-mingw32.zip"
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Move homepage to GitHub page, where development has moved to from https://savannah.nongnu.org/projects/avrdude/, but releases are still there
- Old homepage was a fork that hasn't been updated since 2020
- Couldn't find different releases for 32/64bit although I can see they are being built here: https://github.com/avrdudes/avrdude/actions/runs/1974679826 (jobs on the left hand side include mingw32 and mingw64)
- `avrdude.conf` should not be persisted as it is not for user customised prefs

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
