### PR TITLE
atomicparsley: update to v20210715.151551.e7ad03a

### DIFF
--- a/bucket/atomicparsley.json
+++ b/bucket/atomicparsley.json
@@ -16,6 +16,10 @@
         "regex": "tree\\/([\\d.[a-f]+)\""
     },
     "autoupdate": {
-        "url": "https://github.com/wez/atomicparsley/releases/download/$version/AtomicParsleyWindows.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wez/atomicparsley/releases/download/$version/AtomicParsleyWindows.zip"
+            }
+        }
     }
 }

--- a/bucket/atomicparsley.json
+++ b/bucket/atomicparsley.json
@@ -1,10 +1,21 @@
 {
-    "version": "0.9.0",
+    "version": "20210715.151551.e7ad03a",
     "description": "Lightweight command line program for reading, parsing and setting metadata into MPEG-4 files",
-    "homepage": "http://atomicparsley.sourceforge.net/",
+    "homepage": "https://github.com/wez/atomicparsley",
     "license": "GPL-2.0-only",
-    "url": "https://downloads.sourceforge.net/project/atomicparsley/atomicparsley/AtomicParsley%20v0.9.0/AtomicParsley-win32-0.9.0.zip",
-    "hash": "f363630462ea01d7de948c3e4d231159fa91916d8d7f971a7e8b3bc478dbe846",
-    "extract_dir": "AtomicParsley-win32-0.9.0",
-    "bin": "AtomicParsley.exe"
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wez/atomicparsley/releases/download/20210715.151551.e7ad03a/AtomicParsleyWindows.zip",
+            "hash": "77514f707456ddd6e08bae8f1dd09243f100a03d2c50e8e2cdf195e1e340c46b"
+        }
+    },
+    "extract_dir": "Release",
+    "bin": "AtomicParsley.exe",
+    "checkver": {
+        "url": "https://github.com/wez/atomicparsley/releases",
+        "regex": "tree\\/([\\d.[a-f]+)\""
+    },
+    "autoupdate": {
+        "url": "https://github.com/wez/atomicparsley/releases/download/$version/AtomicParsleyWindows.zip"
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Old version was very old - released in 2006 and hasn't been updated since on Sourceforge
- Old version had a critical (!!) severity vulnerability - https://nvd.nist.gov/vuln/detail/CVE-2021-37232
- This fork has been updated recently and is linked to from Sourceforge discussion as the current active fork (& it is used by Homebrew)
- This release is now 64bit only

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
