### PR TITLE
bind: update to version 9.16.26, add notes

### DIFF
--- a/bucket/bind.json
+++ b/bucket/bind.json
@@ -1,15 +1,16 @@
 {
-    "version": "9.16.25",
+    "version": "9.16.26",
     "description": "Versatile, classic, complete name server software.",
     "homepage": "https://www.isc.org/bind/",
     "license": "MPL-2.0",
+    "notes": "The 9.16 branch is the last stable Windows release of BIND. It is recommended to use the latest stable version through WSL instead. Please read the following for more info: https://www.isc.org/blogs/bind-update-summer2021/",
     "suggest": {
         "vcredist": "extras/vcredist2017"
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.isc.org/isc/bind9/9.16.25/BIND9.16.25.x64.zip",
-            "hash": "7cce5518a8ad882f15cdc5f87d2dfb7c04c187d6cee3212a94e497019e57263d"
+            "url": "https://downloads.isc.org/isc/bind9/9.16.26/BIND9.16.26.x64.zip",
+            "hash": "76ef2e0e567443a9051a0fa7df330952614940c026bc1377c79153261a169b6d"
         }
     },
     "installer": {
@@ -24,7 +25,7 @@
     "persist": "etc",
     "checkver": {
         "url": "https://www.isc.org/download/",
-        "regex": "(?sm)>Current-Stable.*?/([\\d.]+)/"
+        "regex": "BIND([\\d.]+).x64.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to 404 in Excavator: https://github.com/ScoopInstaller/Main/runs/5534119474?check_suite_focus=true#step:3:196
- Also adds note about 9.16.x being the last version of BIND for Windows (checkver was failing because the latest version has no Windows release)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
