### PR TITLE
cake: remove autoupdate because no longer updated

### DIFF
--- a/bucket/cake.json
+++ b/bucket/cake.json
@@ -3,16 +3,11 @@
     "description": "Cake (C# Make) is a cross-platform build automation system with a C# DSL",
     "homepage": "https://cakebuild.net/",
     "license": "MIT",
+    "notes": "The Cake runner for .NET Framework is deprecated and no longer updated since Cake 2.0. It is suggested to use Cake .NET Tool for running Cake scripts. To upgrade, see https://cakebuild.net/docs/getting-started/upgrade#cake-1.x-to-cake-2.0",
     "suggest": {
         "NuGet": "nuget"
     },
     "url": "https://github.com/cake-build/cake/releases/download/v1.3.0/Cake-bin-net461-v1.3.0.zip",
     "hash": "52934fec19c02b668851b73d0fac9f3e6676be239e5bfef6af54b56fb91a244c",
-    "bin": "cake.exe",
-    "checkver": {
-        "github": "https://github.com/cake-build/cake"
-    },
-    "autoupdate": {
-        "url": "https://github.com/cake-build/cake/releases/download/v$version/Cake-bin-net461-v$version.zip"
-    }
+    "bin": "cake.exe"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator error: https://github.com/ScoopInstaller/Main/runs/5534119474?check_suite_focus=true#step:3:202
- Adds note explaining what the user should do to upgrade

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
