### PR TITLE
crc: update to version 1.40.0, new checkver

### DIFF
--- a/bucket/crc.json
+++ b/bucket/crc.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.36.0-4.9.8",
+    "version": "1.40.0",
     "description": "Manages a local OpenShift 4.x cluster optimized for testing and development purposes.",
     "homepage": "https://code-ready.github.io/crc/",
     "license": "Apache-2.0",
@@ -7,8 +7,8 @@
     "depends": "lessmsi",
     "architecture": {
         "64bit": {
-            "url": "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/1.36.0/crc-windows-installer.zip",
-            "hash": "e68b47d585681881004c038812c2dcde0f56894560ae73402d6115784eb41860",
+            "url": "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/1.40.0/crc-windows-installer.zip",
+            "hash": "e9ab2e55cc2f8e4837fd41c0e114363faaaf116b267cd15ab561fc0c5a480c8d",
             "pre_install": [
                 "# The trailing backslash(\\) in $dir\\ is required by lessmsi.",
                 "# '>nul', '2>&1' sets cmd stdout to $null, and stderr to stdout",
@@ -23,8 +23,8 @@
     },
     "bin": "crc.exe",
     "checkver": {
-        "github": "https://github.com/code-ready/crc",
-        "regex": "Release\\s([\\d.]+-[\\d.]+)"
+        "url": "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json",
+        "jsonpath": "$.version.crcVersion"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator failure at https://github.com/ScoopInstaller/Main/runs/5534119474?check_suite_focus=true#step:3:227
- Releases have been moved from GitHub to their website

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
