### PR TITLE
coq: update to version 2022.01.0

### DIFF
--- a/bucket/coq.json
+++ b/bucket/coq.json
@@ -1,16 +1,16 @@
 {
-    "version": "2021.02.1",
+    "version": "2022.01.0",
     "description": "A formal proof management system. It provides a formal language to write mathematical definitions, executable algorithms and theorems together with an environment for semi-interactive development of machine-checked proofs.",
     "homepage": "https://coq.inria.fr/",
     "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/coq/platform/releases/download/2021.02.1/coq-platform-2021.02.1-installer-windows-x86_64.exe#/dl.7z",
-            "hash": "96941bd0c1096813fb6832088cc0950b3f65acd0e3ed97deca412df8768e10d2"
+            "url": "https://github.com/coq/platform/releases/download/2022.01.0/Coq-Platform-8.14.2022.01-installer-windows-x86_64_signed.exe#/dl.7z",
+            "hash": "3e1951f604398b569403eb0f4c0ae6623eb7073e632228609af1ef86c589a31c"
         },
         "32bit": {
-            "url": "https://github.com/coq/platform/releases/download/2021.02.1/coq-platform-2021.02.1-installer-windows-i686.exe#/dl.7z",
-            "hash": "1c6c8a23865bba588814e95f8ac4e9a7c20e2fd80b67e0648e2e1479e0391793"
+            "url": "https://github.com/coq/platform/releases/download/2022.01.0/Coq-Platform-8.14.2022.01-installer-windows-i686_signed.exe#/dl.7z",
+            "hash": "d45a07422c3ca017142515e8cef7c995c280ebb107326398ccae02aac31d563e"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\" -Recurse -Force",

--- a/bucket/coq.json
+++ b/bucket/coq.json
@@ -28,8 +28,5 @@
     ],
     "env_set": {
         "COQBIN": "bin"
-    },
-    "checkver": {
-        "github": "https://github.com/coq/platform"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator update available - https://github.com/ScoopInstaller/Main/runs/5534119474?check_suite_focus=true#step:3:228
- No autoupdate because no stable file names at the moment, raised it as a problem here: https://github.com/coq/platform/issues/164#issuecomment-1067416021

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
