### PR TITLE
Update 1password-cli to version 2.0.0

### DIFF
--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -1,33 +1,33 @@
 {
-    "version": "1.12.4",
+    "version": "2.0.0",
     "description": "The 1Password command-line tool makes your 1Password account accessible entirely from the command line.",
-    "homepage": "https://support.1password.com/command-line/",
+    "homepage": "https://developer.1password.com/docs/cli",
     "license": {
         "identifier": "Shareware",
         "url": "https://1password.com/legal/terms-of-service/"
     },
     "architecture": {
         "64bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.4/op_windows_amd64_v1.12.4.zip",
-            "hash": "d14b7a864ebabc9b5ed95ea6b13e676a5795ede54b6187b4233249694478b1c9"
+            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.0.0/op_windows_amd64_v2.0.0.zip",
+            "hash": "1cc0f962fe190d27959ce9a4390c39a8baedc15338d4f779970f8d4288a04bd5"
         },
         "32bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.4/op_windows_386_v1.12.4.zip",
-            "hash": "a8e2ef405af14b8fb3482ed7f8b66a3f1383a2a86062589e3acc6bc446b13006"
+            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.0.0/op_windows_386_v2.0.0.zip",
+            "hash": "f2ab9100aaf75e48528069ee8e1171c758ce692cec6a467c3abbc1abb8385e8a"
         }
     },
     "bin": "op.exe",
     "checkver": {
-        "url": "https://app-updates.agilebits.com/product_history/CLI",
+        "url": "https://app-updates.agilebits.com/product_history/CLI2",
         "regex": "/op_windows_amd64_v([\\d.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cache.agilebits.com/dist/1P/op/pkg/v$version/op_windows_amd64_v$version.zip"
+                "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v$version/op_windows_amd64_v$version.zip"
             },
             "32bit": {
-                "url": "https://cache.agilebits.com/dist/1P/op/pkg/v$version/op_windows_386_v$version.zip"
+                "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v$version/op_windows_386_v$version.zip"
             }
         }
     }


### PR DESCRIPTION
This PR updates 1password-cli to v2.0.0. Note: v2 is a major release and changes command line API completely: https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
