### PR TITLE
go: update to version 1.18

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.17.8",
+    "version": "1.18",
     "description": "An open source programming language that makes it easy to build simple, reliable, and efficient software.",
     "homepage": "https://golang.org",
     "license": "BSD-3-Clause",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/go/go1.17.8.windows-amd64.zip",
-            "hash": "85ccf2608dca6ea9a46b6538c9e75e7cf2aebdf502379843b248e26b8bb110be"
+            "url": "https://dl.google.com/go/go1.18.windows-amd64.zip",
+            "hash": "65c5c0c709a7ca1b357091b10b795b439d8b50e579d3893edab4c7e9b384f435"
         },
         "32bit": {
-            "url": "https://dl.google.com/go/go1.17.8.windows-386.zip",
-            "hash": "2f3889642d706d7a4dd395ec4e08c00d962c845aa2998ca36a4493b0d0f071d9"
+            "url": "https://dl.google.com/go/go1.18.windows-386.zip",
+            "hash": "e23fd2a0509690fe7e63b2b1bcd4c39ed57b46ccde76f35dc0d16ca7fdbc5aaa"
         }
     },
     "extract_dir": "go",


### PR DESCRIPTION
Semver bump for Golang from 1.17.8 to 1.18

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
