### PR TITLE
poetry: Update manifest

### DIFF
--- a/bucket/poetry.json
+++ b/bucket/poetry.json
@@ -7,7 +7,10 @@
     "url": "https://install.python-poetry.org#/install-poetry.py",
     "hash": "761cdefb65de97882482d5edf29de6d90e42917447aabfde63a693206c4550c6",
     "installer": {
-        "script": "$env:POETRY_HOME=$dir; python3 $dir/$fname --version $version"
+        "script": [
+            "$env:POETRY_HOME=$dir",
+            "python3 \"$dir\\$fname\" --version $version"
+        ]
     },
     "bin": "venv\\Scripts\\poetry.exe",
     "checkver": {

--- a/bucket/poetry.json
+++ b/bucket/poetry.json
@@ -4,22 +4,21 @@
     "homepage": "https://python-poetry.org/",
     "license": "MIT",
     "depends": "python",
-    "url": "https://raw.githubusercontent.com/python-poetry/poetry/1.1.13/get-poetry.py",
-    "hash": "e973b3badb95a916bfe250c22eeb7253130fd87312afa326eb02b8bdcea8f4a7",
+    "url": "https://install.python-poetry.org#/install-poetry.py",
+    "hash": "761cdefb65de97882482d5edf29de6d90e42917447aabfde63a693206c4550c6",
     "installer": {
-        "script": "$env:POETRY_HOME=$dir; python $dir/$fname --version $version --no-modify-path -y"
+        "script": "$env:POETRY_HOME=$dir; python3 $dir/$fname --version $version"
     },
-    "uninstaller": {
-        "script": "$env:POETRY_HOME=$dir; python $dir/get-poetry.py --uninstall -y"
-    },
-    "bin": "bin\\poetry.bat",
-    "env_set": {
-        "POETRY_HOME": "$dir"
-    },
+    "post_install": [
+        "$symlink = \"$dir\\bin\\poetry.exe\"",
+        "$exe = \"$dir\\venv\\Scripts\\poetry.exe\"",
+        "New-Item $symlink -ItemType SymbolicLink -Target $exe -Force | Out-Null"
+    ],
+    "bin": "bin\\poetry.exe",
     "checkver": {
         "github": "https://github.com/python-poetry/poetry/"
     },
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/python-poetry/poetry/$version/get-poetry.py"
+        "url": "https://install.python-poetry.org#/install-poetry.py"
     }
 }

--- a/bucket/poetry.json
+++ b/bucket/poetry.json
@@ -8,7 +8,7 @@
     "hash": "761cdefb65de97882482d5edf29de6d90e42917447aabfde63a693206c4550c6",
     "installer": {
         "script": [
-            "$env:POETRY_HOME=$dir",
+            "$env:POETRY_HOME=\"$dir\"",
             "python3 \"$dir\\$fname\" --version $version"
         ]
     },

--- a/bucket/poetry.json
+++ b/bucket/poetry.json
@@ -9,12 +9,7 @@
     "installer": {
         "script": "$env:POETRY_HOME=$dir; python3 $dir/$fname --version $version"
     },
-    "post_install": [
-        "$symlink = \"$dir\\bin\\poetry.exe\"",
-        "$exe = \"$dir\\venv\\Scripts\\poetry.exe\"",
-        "New-Item $symlink -ItemType SymbolicLink -Target $exe -Force | Out-Null"
-    ],
-    "bin": "bin\\poetry.exe",
+    "bin": "venv\\Scripts\\poetry.exe",
     "checkver": {
         "github": "https://github.com/python-poetry/poetry/"
     },


### PR DESCRIPTION
- Use `install-poetry.py` instead of `get-poetry.py`

> Warning: The previous get-poetry.py installer is now deprecated, if you are currently using it you should migrate to the new, supported, install-poetry.py installer.
> 
> See: https://github.com/python-poetry/poetry#windows-powershell-install-instructions

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
