### PR TITLE
argo: update to version 3.3.0

### DIFF
--- a/bucket/argo.json
+++ b/bucket/argo.json
@@ -1,21 +1,25 @@
 {
-    "version": "3.2.9",
+    "version": "3.3.0",
     "description": "Workflow engine for orchestrating parallel jobs on Kubernetes",
     "homepage": "https://github.com/argoproj/argo-workflows",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/argoproj/argo-workflows/releases/download/v3.2.9/argo-windows-amd64.gz",
-            "hash": "d476d118436d0f304895f36e0a6ce142404e0b7f2e81544af152f51faa87ae65"
+            "url": "https://github.com/argoproj/argo-workflows/releases/download/v3.3.0/argo-windows-amd64.exe.gz",
+            "hash": "bb5f0fa7769750cdeb0a301a2e518cbc093d20e3e59efb950d5cde1ff30bf283"
         }
     },
-    "pre_install": "Rename-Item $dir\\argo-windows-amd64 $dir\\argo.exe",
-    "bin": "argo.exe",
+    "bin": [
+        [
+            "argo-windows-amd64.exe",
+            "argo"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/argoproj/argo-workflows/releases/download/v$version/argo-windows-amd64.gz"
+                "url": "https://github.com/argoproj/argo-workflows/releases/download/v$version/argo-windows-amd64.exe.gz"
             }
         },
         "hash": {

--- a/bucket/argo.json
+++ b/bucket/argo.json
@@ -9,12 +9,8 @@
             "hash": "bb5f0fa7769750cdeb0a301a2e518cbc093d20e3e59efb950d5cde1ff30bf283"
         }
     },
-    "bin": [
-        [
-            "argo-windows-amd64.exe",
-            "argo"
-        ]
-    ],
+    "pre_install": "Rename-Item $dir\\argo-windows-amd64.exe $dir\\argo.exe",
+    "bin": "argo.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator error: https://github.com/ScoopInstaller/Main/runs/5585775074?check_suite_focus=true#step:3:196
- Simplify by removing pre_install because they no longer release the exe without an extension

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
