### PR TITLE
dafny: update to 3.5.0, add hash

### DIFF
--- a/bucket/dafny.json
+++ b/bucket/dafny.json
@@ -1,11 +1,12 @@
 {
-    "version": "3.2.0",
+    "version": "3.5.0",
     "description": "A programming language with a program verifier",
     "homepage": "https://dafny-lang.github.io/dafny/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dafny-lang/dafny/releases/download/v3.2.0/dafny-3.2.0-x64-win.zip",
+            "url": "https://github.com/dafny-lang/dafny/releases/download/v3.5.0/dafny-3.5.0-x64-win.zip",
+            "hash": "5226037164174899d3f9078348d0f7ad06ff5c158e60836e6122bd98ff9bd03a",
             "extract_dir": "dafny"
         }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator failure due to lack of hash in manifest: https://github.com/ScoopInstaller/Main/runs/5585775074?check_suite_focus=true#step:3:230

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
