### PR TITLE
gauche: update to version 0.9.11-p1

### DIFF
--- a/bucket/gauche.json
+++ b/bucket/gauche.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.9.11",
+    "version": "0.9.11-p1",
     "description": "Scheme Scripting Engine",
     "homepage": "https://practical-scheme.net/gauche/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/shirok/Gauche/releases/download/release0_9_11/Gauche-mingw-0.9.11-64bit.msi",
-            "hash": "ef91ec769e0e9456eae4786545081b704c26aee454700d7f705b00ad4b8065a4"
+            "url": "https://github.com/shirok/Gauche/releases/download/release0_9_11_p1/Gauche-mingw-0.9.11-p1-64bit.msi",
+            "hash": "c2cc6e99753c371b3c2eb509ffb4a3ff808e63e2da50f1dcbe3c2b0f42299d4c"
         },
         "32bit": {
-            "url": "https://github.com/shirok/Gauche/releases/download/release0_9_11/Gauche-mingw-0.9.11-32bit.msi",
-            "hash": "37c5247e3c48ed723556bc4db16d98ed75050945b2e28ec70584f0584d2b6c8e"
+            "url": "https://github.com/shirok/Gauche/releases/download/release0_9_11_p1/Gauche-mingw-0.9.11-p1-32bit.msi",
+            "hash": "e7d0b0fbb506dffb9cab2eda2708bec8e29e7e8960b410f760d1990222a7a07c"
         }
     },
     "extract_dir": "Gauche",

--- a/bucket/gauche.json
+++ b/bucket/gauche.json
@@ -30,7 +30,7 @@
     ],
     "checkver": {
         "github": "https://github.com/shirok/Gauche",
-        "regex": "mingw-([\\d.]+)-\\d+bit\\.msi"
+        "regex": "mingw-([\\d.\\-p]+)-\\d+bit\\.msi"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator failure due to patch release not being standard name: https://github.com/ScoopInstaller/Main/runs/5585775074?check_suite_focus=true#step:3:250

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
