### PR TITLE
azure-kubelogin: Add version 0.11.0

### DIFF
--- a/bucket/azure-kubelogin.json
+++ b/bucket/azure-kubelogin.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.0.11",
+    "description": "A client-go credential (exec) plugin implementing azure authentication.",
+    "homepage": "https://github.com/Azure/kubelogin/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Azure/kubelogin/releases/download/v0.0.11/kubelogin-win-amd64.zip",
+            "hash": "8d509b64638bf2acba247b5333b8dc1f16a578ecb1917b562ec1ee938e49d85f"
+        }
+    },
+    "bin": "bin\\windows_amd64\\kubelogin.exe",
+    "checkver": {
+        "github": "https://github.com/Azure/kubelogin"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Azure/kubelogin/releases/download/v$version/kubelogin-win-amd64.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wrangler.json
+++ b/bucket/wrangler.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.19.10",
+    "version": "1.19.11",
     "description": "Cloudflare Workers project manager",
     "homepage": "https://developers.cloudflare.com/workers/tooling/wrangler",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cloudflare/wrangler/releases/download/v1.19.10/wrangler-v1.19.10-x86_64-pc-windows-msvc.tar.gz",
-            "hash": "9ac9bb9880898694c8eafcaf4f77fa8f9f96fb1ee8f0110de44fbb5521e9bd92"
+            "url": "https://github.com/cloudflare/wrangler/releases/download/v1.19.11/wrangler-v1.19.11-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "cffc8f97d44c081e77e36a1814b46cebb8703a5e41a62fe960c838c641088625"
         }
     },
     "extract_dir": "dist",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR adds Azure Kubelogin which is required to authenticate with an AKS cluster.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
