### PR TITLE
hopp-cli: Update to version 0.0.8

### DIFF
--- a/bucket/hopp-cli.json
+++ b/bucket/hopp-cli.json
@@ -1,16 +1,12 @@
 {
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "An HTTP CLI client for Hoppscotch, an alternative to curl/httpie",
     "homepage": "https://hoppscotch.io/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v0.0.7/hopp-cli_0.0.7_windows_x86_64.tar.gz",
-            "hash": "788c829ba0a1821a71f9503a8f40210923dc08e9ca70552c119d898665d4e252"
-        },
-        "32bit": {
-            "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v0.0.7/hopp-cli_0.0.7_windows_386.tar.gz",
-            "hash": "695b0598291c1176a8c86854529a2d8f2c60ae286bb5aed88d3cd0058fb3a916"
+            "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v0.0.8/hopp-cli_0.0.8_windows_x86_64.tar.gz",
+            "hash": "17307a8d0fa1b38174807a10218d23dffc0c58c46449912fe472595cc23acfef"
         }
     },
     "bin": "hopp-cli.exe",
@@ -21,9 +17,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v$version/hopp-cli_$version_windows_x86_64.tar.gz"
-            },
-            "32bit": {
-                "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v$version/hopp-cli_$version_windows_386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Relates to Excavator failure due to removal of 32bit release: https://github.com/ScoopInstaller/Main/runs/5606329917?check_suite_focus=true#step:3:261

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
