### PR TITLE
memcached: Update to v1.6.14, add autoupdate

### DIFF
--- a/bucket/memcached.json
+++ b/bucket/memcached.json
@@ -1,23 +1,34 @@
 {
     "##": "Check https://www.apachelounge.com/viewtopic.php?t=7919 for details about this pre-compiled binary package of memcached. memcached is built with both libevent 2.1 and 2.0 because libevent 2.1 is not compatible with Win7.",
-    "version": "1.6.12",
+    "version": "1.6.14",
     "description": "Distributed memory object caching system",
     "homepage": "https://memcached.org",
     "license": "BSD-3-Clause",
     "notes": "This package does not require Cygwin to run (all dependencies are included).",
-    "url": "https://github.com/nono303/memcached/archive/1.6.12.zip",
-    "hash": "c23dbf8d0fcbc5a373476fd5f67af40edddca676e1d9c60346aaa0a33cd68540",
+    "url": "https://github.com/nono303/memcached/archive/1.6.14.zip",
+    "hash": "5f73eb64f3b48c11d89e9454c344db86728973dd62d9f10ac367c0eb7795a91f",
     "architecture": {
         "64bit": {
-            "extract_dir": "memcached-1.6.12\\libevent-2.1\\x64"
+            "extract_dir": "memcached-1.6.14\\libevent-2.1\\x64"
         },
         "32bit": {
-            "extract_dir": "memcached-1.6.12\\libevent-2.1\\x86"
+            "extract_dir": "memcached-1.6.14\\libevent-2.1\\x86"
         }
     },
     "bin": "memcached.exe",
     "checkver": {
         "url": "https://raw.githubusercontent.com/nono303/memcached/master/README.md",
         "regex": "version\\s+\\[([\\d.]+)\\]"
+    },
+    "autoupdate": {
+        "url": "https://github.com/nono303/memcached/archive/$version.zip",
+        "architecture": {
+            "64bit": {
+                "extract_dir": "memcached-$version\\libevent-2.1\\x64"
+            },
+            "32bit": {
+                "extract_dir": "memcached-$version\\libevent-2.1\\x86"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator log, checkver found update but no autoupdate in manifest: https://github.com/ScoopInstaller/Main/runs/5616285619?check_suite_focus=true#step:3:246

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
