### PR TITLE
JEnv: Add version 2.0.0

### DIFF
--- a/bucket/jenv.json
+++ b/bucket/jenv.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.0.0",
+    "description": "Change your current Java version with one line",
+    "homepage": "https://github.com/FelixSelter/JEnv-for-Windows",
+    "license": "Apache-2.0",
+    "url": "https://github.com/FelixSelter/JEnv-for-Windows/releases/download/v2.0.0/JEnv-for-Windows.v2.0.0.zip",
+    "hash": "40b276da83e48ba9ed310b79d0d1c396b7adeaad8ce108a17f31e9b6412d1c0a",
+    "bin": [
+        "jenv.bat",
+        "java.bat"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/FelixSelter/JEnv-for-Windows/releases/download/v$version/JEnv-for-Windows.v$version.zip"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds https://github.com/FelixSelter/JEnv-for-Windows for managing Java versions.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

The Contributing Guide says that unless the architecture is 32-bit only, one should explicitly specify it.
JEnv is a set of Powershell scripts, so it's independent of architecture.
Should I specify the same autoupdate url twice then?