### PR TITLE
doxygen: Update to version 1.9.3, remove 32bit

### DIFF
--- a/bucket/doxygen.json
+++ b/bucket/doxygen.json
@@ -1,16 +1,12 @@
 {
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "Documentation generator from annotated source code.",
     "homepage": "http://www.doxygen.nl/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "http://doxygen.nl/files/doxygen-1.9.2.windows.x64.bin.zip",
-            "hash": "9acc9f0f3e1141d5a9f80191290b2d1c441e7e2788095b691de5efc406d1a3db"
-        },
-        "32bit": {
-            "url": "http://doxygen.nl/files/doxygen-1.9.2.windows.bin.zip",
-            "hash": "8b3b46ef2f3ebf8392ec2ae9386ca64b65de33e8c2c56d4e9d3c55c4f6b1c3fc"
+            "url": "http://doxygen.nl/files/doxygen-1.9.3.windows.x64.bin.zip",
+            "hash": "575b1a27cb907675d24f2c348a4d95d9cdd6a2000f6a8d8bfc4c3a20b2e120f5"
         }
     },
     "bin": [
@@ -26,9 +22,6 @@
         "architecture": {
             "64bit": {
                 "url": "http://doxygen.nl/files/doxygen-$version.windows.x64.bin.zip"
-            },
-            "32bit": {
-                "url": "http://doxygen.nl/files/doxygen-$version.windows.bin.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator failure to get 32bit version as it has been removed: https://github.com/ScoopInstaller/Main/runs/5650708572?check_suite_focus=true#step:3:264

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
