### PR TITLE
miller: Update to version 6.2.0, fix autoupdate

### DIFF
--- a/bucket/miller.json
+++ b/bucket/miller.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.0.0",
+    "version": "6.2.0",
     "description": "Like awk, sed, cut, join, and sort for data formats such as CSV, TSV, JSON, JSON Lines, and positionally-indexed.",
     "homepage": "https://miller.readthedocs.io",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/johnkerl/miller/releases/download/v6.0.0/miller_6.0.0_windows_amd64.tar.gz",
-            "hash": "cd78bc694b5c592bc6b091e92b9086d1ed8e72e8d29be7fe3a9fd8b6fe5beecd"
+            "url": "https://github.com/johnkerl/miller/releases/download/v6.2.0/miller-6.2.0-windows-amd64.zip",
+            "hash": "0a9c5207d15c183d57eeb66bf429bae6a83041f7faa55825477bfeae50c77c94"
         },
         "32bit": {
-            "url": "https://github.com/johnkerl/miller/releases/download/v6.0.0/miller_6.0.0_windows_386.tar.gz",
-            "hash": "ee223b950c843ba6df2259646492ac3dc455898cb1600454f4c9abae45c30ded"
+            "url": "https://github.com/johnkerl/miller/releases/download/v6.2.0/miller-6.2.0-windows-386.zip",
+            "hash": "e83850c11286832c6f3acba6bb2f863cc3bb0a8551f17eb1989d9d37d82876d1"
         }
     },
     "bin": "mlr.exe",
@@ -20,14 +20,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/johnkerl/miller/releases/download/v$version/miller_$version_windows_amd64.tar.gz"
+                "url": "https://github.com/johnkerl/miller/releases/download/v$version/miller-$version-windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/johnkerl/miller/releases/download/v$version/miller_$version_windows_386.tar.gz"
+                "url": "https://github.com/johnkerl/miller/releases/download/v$version/miller-$version-windows-386.zip"
             }
         },
         "hash": {
-            "url": "$baseurl/miller_$version_checksums.txt"
+            "url": "$baseurl/miller-$version-checksums.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator issue do to change to release file names (`_` --> `-`): https://github.com/ScoopInstaller/Main/runs/5657032696?check_suite_focus=true#step:3:287

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
