### PR TITLE
Add note to the 1password-cli manifest notifying about changes in command schema

### DIFF
--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -17,6 +17,11 @@
         }
     },
     "bin": "op.exe",
+    "notes": [
+        "1Password CLI v2 completely changes the commands schema! Either migrate your setup, following ",
+        "instructions on https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts ",
+        "or install 1Password CLI v1 from https://github.com/ScoopInstaller/Versions bucket."
+    ],
     "checkver": {
         "url": "https://app-updates.agilebits.com/product_history/CLI2",
         "regex": "/op_windows_amd64_v([\\d.]+)\\.zip"

--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -20,7 +20,7 @@
     "notes": [
         "1Password CLI v2 completely changes the commands schema! Either migrate your setup, following ",
         "instructions on https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts ",
-        "or install 1Password CLI v1 from https://github.com/ScoopInstaller/Versions bucket."
+        "or install 1Password CLI v1 from the Versions bucket."
     ],
     "checkver": {
         "url": "https://app-updates.agilebits.com/product_history/CLI2",


### PR DESCRIPTION
Add note to the 1password-cli manifest notifying about changes in command schema. Note contains link to the migration guide and informs about 1password-cli v1 is available in Versions bucket.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
