### PR TITLE
mariadb: Update to v10.7.3, fix checkver, remove 32bit

### DIFF
--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.6.5",
+    "version": "10.7.3",
     "description": "Community developed fork of MySQL server.",
     "homepage": "https://mariadb.org",
     "license": "GPL-2.0-only",
@@ -13,14 +13,9 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://downloads.mariadb.com/MariaDB/mariadb-10.6.5/winx64-packages/mariadb-10.6.5-winx64.zip",
-            "hash": "ca56070e4d099c412987f09b73755fe874b83f951facd0fa81b8f76463569a3b",
-            "extract_dir": "mariadb-10.6.5-winx64"
-        },
-        "32bit": {
-            "url": "https://downloads.mariadb.com/MariaDB/mariadb-10.6.5/win32-packages/mariadb-10.6.5-win32.zip",
-            "hash": "e1c9f7aa9c8d1eefceae837ed794a1d6fa596bb86b82024e5fd187b33030fa23",
-            "extract_dir": "mariadb-10.6.5-win32"
+            "url": "https://downloads.mariadb.com/MariaDB/mariadb-10.7.3/winx64-packages/mariadb-10.7.3-winx64.zip",
+            "hash": "7e8496ff5fe03753ac810a523a7072a37a5c8eb053c845e7624aa97457a2e372",
+            "extract_dir": "mariadb-10.7.3-winx64"
         }
     },
     "post_install": [
@@ -60,17 +55,14 @@
     "persist": "data",
     "checkver": {
         "url": "https://downloads.mariadb.org/rest-api/mariadb/all-releases/",
-        "jsonpath": "$.releases[?(@.status=='stable')].release_number"
+        "jsonpath": "$.releases[?(@.status=='stable')].release_number",
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://downloads.mariadb.com/MariaDB/mariadb-$version/winx64-packages/mariadb-$version-winx64.zip",
                 "extract_dir": "mariadb-$version-winx64"
-            },
-            "32bit": {
-                "url": "https://downloads.mariadb.com/MariaDB/mariadb-$version/win32-packages/mariadb-$version-win32.zip",
-                "extract_dir": "mariadb-$version-win32"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator checkver issue due to jsonpath retrieving a list of all stable versions rather than just the latest: https://github.com/ScoopInstaller/Main/runs/5682704169?check_suite_focus=true#step:3:276
- Remove 32bit as 10.6.5 was the last version with a 32bit release: https://mariadb.org/download/?t=mariadb&o=true&p=mariadb&r=10.6.5&os=windows&cpu=x86&pkg=msi

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
