### PR TITLE
coq: Fix license to include its components

### DIFF
--- a/bucket/coq.json
+++ b/bucket/coq.json
@@ -2,7 +2,10 @@
     "version": "2022.01.0",
     "description": "A formal proof management system. It provides a formal language to write mathematical definitions, executable algorithms and theorems together with an environment for semi-interactive development of machine-checked proofs.",
     "homepage": "https://coq.inria.fr/",
-    "license": "LGPL-2.1-only",
+    "license": {
+        "identifier": "Proprietary, LGPL-2.1-only, LGPL-3.0-or-later, MIT, GPL-2.0-only, BSD-2-Clause-FreeBSD, CECILL-C, BSD-3-Clause, CECILL-B, ...",
+        "url": "https://github.com/AbsInt/CompCert/blob/master/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/coq/platform/releases/download/2022.01.0/Coq-Platform-8.14.2022.01-installer-windows-x86_64_signed.exe#/dl.7z",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/coq/platform/pull/234#issuecomment-1079630937 - a request to fix the wrong license in Scoop's manifest.

I have included most of the licenses used by the packages that Coq Platform includes, see the list for the current version here: https://github.com/coq/platform/blob/2022.01.0/doc/PackageTable%7E8.14%7E2022.01.csv

I put the Proprietary license first because the package `coq-compcert` is licensed under the INRIA Non-Commercial License Agreement, which I link in the manifest.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
