### PR TITLE
kustomize: Update to version 4.5.3, fix checkver

### DIFF
--- a/bucket/kustomize.json
+++ b/bucket/kustomize.json
@@ -1,17 +1,17 @@
 {
-    "version": "4.5.2",
+    "version": "4.5.3",
     "description": "Customize raw, template-free YAML files for multiple purposes, leaving the original YAML untouched and usable as is.",
     "homepage": "https://github.com/kubernetes-sigs/kustomize",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.2/kustomize_v4.5.2_windows_amd64.tar.gz",
-            "hash": "3c6310caa6a23d17711a312f1a33690365ba6be9a806752aac215613fdf7c605"
+            "url": "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.5.3/kustomize_v4.5.3_windows_amd64.tar.gz",
+            "hash": "ad5ac5ed8d244309e4a41cfd61e87918096e159514e4867c9449409b67a6709f"
         }
     },
     "bin": "kustomize.exe",
     "checkver": {
-        "github": "https://github.com/kubernetes-sigs/kustomize",
+        "url": "https://github.com/kubernetes-sigs/kustomize/releases",
         "regex": "kustomize/v([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator not being able to find latest version, due to checkver not checking releases page: https://github.com/ScoopInstaller/Main/runs/5703245388?check_suite_focus=true#step%3A3%3A272=

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
