### PR TITLE
rnr: Update to version 0.4.0, remove 32bit

### DIFF
--- a/bucket/rnr.json
+++ b/bucket/rnr.json
@@ -9,6 +9,7 @@
             "hash": "7c0a71730522b4737df95e6a5f2d2466bf08f0c2e6a2b9f81df6c599d2ed957b"
         }
     },
+    "extract_dir": "rnr-v0.4.0-x86_64-pc-windows-msvc",
     "bin": "rnr.exe",
     "checkver": "github",
     "autoupdate": {
@@ -16,6 +17,7 @@
             "64bit": {
                 "url": "https://github.com/ChuckDaniels87/rnr/releases/download/v$version/rnr-v$version-x86_64-pc-windows-msvc.zip"
             }
-        }
+        },
+        "extract_dir": "rnr-v$version-x86_64-pc-windows-msvc"
     }
 }

--- a/bucket/rnr.json
+++ b/bucket/rnr.json
@@ -1,16 +1,12 @@
 {
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "A command-line tool to batch rename files and directories",
     "homepage": "https://github.com/ChuckDaniels87/rnr",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ChuckDaniels87/rnr/releases/download/v0.3.0/rnr-v0.3.0-x86_64-pc-windows-msvc.zip",
-            "hash": "a0f181cff772dbc962066e683949cdefc69fd4d526564fb63d8c987bbe882538"
-        },
-        "32bit": {
-            "url": "https://github.com/ChuckDaniels87/rnr/releases/download/v0.3.0/rnr-v0.3.0-i686-pc-windows-msvc.zip",
-            "hash": "b1f317ba0088dd3f5ff248358a6d7dc0985a0538215cdfa08bc4975973359a2d"
+            "url": "https://github.com/ChuckDaniels87/rnr/releases/download/v0.4.0/rnr-v0.4.0-x86_64-pc-windows-msvc.zip",
+            "hash": "7c0a71730522b4737df95e6a5f2d2466bf08f0c2e6a2b9f81df6c599d2ed957b"
         }
     },
     "bin": "rnr.exe",
@@ -19,9 +15,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ChuckDaniels87/rnr/releases/download/v$version/rnr-v$version-x86_64-pc-windows-msvc.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/ChuckDaniels87/rnr/releases/download/v$version/rnr-v$version-i686-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator autoupdate failing due to lack of 32bit release:https://github.com/ScoopInstaller/Main/runs/5703245388?check_suite_focus=true#step%3A3%3A320=

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
