### PR TITLE
sftpgo: Update to version 2.2.2, fix autoupdate

### DIFF
--- a/bucket/sftpgo.json
+++ b/bucket/sftpgo.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.2.0",
+    "version": "2.2.2",
     "description": "Fully featured and highly configurable SFTP server with optional HTTP, FTP/S and WebDAV support",
     "homepage": "https://github.com/drakkan/sftpgo",
     "license": "AGPL-3.0-only",
     "notes": "Register SFTPGo as Windows Service by running: \"sftpgo service install\" as Administrator",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/drakkan/sftpgo/releases/download/v2.2.0/sftpgo_v2.2.0_windows_portable_x86_64.zip",
-            "hash": "e8df32fbd29994475728384b17183da55775cd2abd4d4bca2d4afdd603544a82"
+            "url": "https://github.com/drakkan/sftpgo/releases/download/v2.2.2/sftpgo_v2.2.2_windows_portable.zip",
+            "hash": "1163ac441a4d4a4b1db3b8329a664627aa54bf96eb33abf385f4d3948b03dc7c"
         }
     },
     "bin": "sftpgo.exe",
@@ -17,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/drakkan/sftpgo/releases/download/v$version/sftpgo_v$version_windows_portable_x86_64.zip"
+                "url": "https://github.com/drakkan/sftpgo/releases/download/v$version/sftpgo_v$version_windows_portable.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator failure due to change in file name of portable release: https://github.com/ScoopInstaller/Main/runs/5703245388?check_suite_focus=true#step%3A3%3A327=

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
