### PR TITLE
xtensa-esp32-elf: Update to -patch3, fix checkver

### DIFF
--- a/bucket/xtensa-esp32-elf.json
+++ b/bucket/xtensa-esp32-elf.json
@@ -1,16 +1,16 @@
 {
-    "version": "8_4_0-esp-2021r2",
+    "version": "8_4_0-esp-2021r2-patch3",
     "description": "Toolchain for Xtensa (ESP32) based on GCC",
     "homepage": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/windows-setup-scratch.html",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-win64.zip",
-            "hash": "c35b7998f7f503e0cb22055d1e279ae14b6b0e09bb3ff3846b17d552ece9c247"
+            "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-win64.zip",
+            "hash": "9395315c07de0b9f05c9a6616ba1f05e76ab651053f2f40479163a8e03cfa830"
         },
         "32bit": {
-            "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-win32.zip",
-            "hash": "076a4171bdc33e5ced3952efffb233d70263dfa760e636704050597a9edf61db"
+            "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-win32.zip",
+            "hash": "fd147592928ef2d7092ba34b01ecd776fe26ba3d7e3f9b6b215a3b46e981ee2c"
         }
     },
     "extract_dir": "xtensa-esp32-elf",
@@ -47,15 +47,23 @@
     ],
     "checkver": {
         "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-tools.html",
-        "regex": "xtensa-esp32-elf-gcc([\\d_]+-esp-([\\w]+))-win64.zip"
+        "regex": "xtensa-esp32-elf-gcc([\\d_]+-esp-([\\w-]+))-win64.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-$match2/xtensa-esp32-elf-gcc$version-win64.zip"
+                "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-$match2/xtensa-esp32-elf-gcc$version-win64.zip",
+                "hash": {
+                    "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-tools.html",
+                    "regex": "win64.zip.+\\s.+SHA256: $sha256"
+                }
             },
             "32bit": {
-                "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-$match2/xtensa-esp32-elf-gcc$version-win32.zip"
+                "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-$match2/xtensa-esp32-elf-gcc$version-win32.zip",
+                "hash": {
+                    "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-tools.html",
+                    "regex": "win32.zip.+\\s.+SHA256: $sha256"
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator checkver not working: https://github.com/ScoopInstaller/Main/runs/5709628840?check_suite_focus=true#step%3A3%3A337=

- Added autoupdate hash extraction - is there a simpler way to not repeat the url?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
