### PR TITLE
sget: Fix checkver

### DIFF
--- a/bucket/sget.json
+++ b/bucket/sget.json
@@ -1,16 +1,19 @@
 {
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Safer, automatic verification of signatures and integration.",
     "homepage": "https://github.com/sigstore/cosign#sget",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sigstore/cosign/releases/download/v1.5.0/sget-windows-amd64.exe#/sget.exe",
-            "hash": "10918e3edaf08cfa877d25e4b71f3c5095da5dcde0624c3631bf08888963c29b"
+            "url": "https://github.com/sigstore/cosign/releases/download/v1.6.0/sget-windows-amd64.exe#/sget.exe",
+            "hash": "d71c58e54cb1c6cd03ad72180ca5d1552d2d8901814a67c574548e932d9f961d"
         }
     },
     "bin": "sget.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/sigstore/cosign/releases",
+        "regex": "tree\\/v([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/sget.json
+++ b/bucket/sget.json
@@ -10,7 +10,10 @@
         }
     },
     "bin": "sget.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/sigstore/cosign/releases",
+        "regex": "tree\\/v([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/sget.json
+++ b/bucket/sget.json
@@ -10,10 +10,7 @@
         }
     },
     "bin": "sget.exe",
-    "checkver": {
-        "url": "https://github.com/sigstore/cosign/releases",
-        "regex": "tree\\/v([\\d.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #3453
- Just checkver fix to see whether excavator picks up the latest update (1.6.0)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
