### PR TITLE
cacert: added env "SSL_CERT_FILE"

### DIFF
--- a/bucket/cacert.json
+++ b/bucket/cacert.json
@@ -6,6 +6,9 @@
     "license": "MPL-2.0",
     "url": "https://curl.haxx.se/ca/cacert-2022-03-29.pem#/cacert.pem",
     "hash": "1979e7fe618c51ed1c9df43bba92f977a0d3fe7497ffa2a5e80dfc559a1e5a29",
+    "env_set": {
+        "SSL_CERT_FILE": "$dir\\cacert.pem",
+    },
     "post_install": "if (Test-Path \"$(appdir curl $global)\") { Copy-Item \"$dir\\cacert.pem\" \"$(appdir curl $global)\\current\\bin\\curl-ca-bundle.crt\" }",
     "checkver": "cacert-([\\d-]+)\\.pem",
     "autoupdate": {

--- a/bucket/cacert.json
+++ b/bucket/cacert.json
@@ -7,7 +7,7 @@
     "url": "https://curl.haxx.se/ca/cacert-2022-03-29.pem#/cacert.pem",
     "hash": "1979e7fe618c51ed1c9df43bba92f977a0d3fe7497ffa2a5e80dfc559a1e5a29",
     "env_set": {
-        "SSL_CERT_FILE": "$dir\\cacert.pem",
+        "SSL_CERT_FILE": "$dir\\cacert.pem"
     },
     "post_install": "if (Test-Path \"$(appdir curl $global)\") { Copy-Item \"$dir\\cacert.pem\" \"$(appdir curl $global)\\current\\bin\\curl-ca-bundle.crt\" }",
     "checkver": "cacert-([\\d-]+)\\.pem",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
added `"SSL_CERT_FILE"` as enviroment because [axel](https://github.com/ScoopInstaller/Main/blob/master/bucket/axel.json) downloader requires it. Without that it fails to download anything unless you use `-k` switch which skips SSL certificate check of the URL and is insecure.

Will add `cacert` as dependency to axel.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
