### PR TITLE
helix: Update to 22.03 and align new tag style

### DIFF
--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.6.0",
+    "version": "22.03",
     "description": "A post-modern modal text editor",
     "homepage": "https://helix-editor.com",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/helix-editor/helix/releases/download/v0.6.0/helix-v0.6.0-x86_64-windows.zip",
-            "hash": "23f4fe46f30e489938ad2fabfb768a024528eff437121356398f6839ddacb2b9",
-            "extract_dir": "helix-v0.6.0-x86_64-windows"
+            "url": "https://github.com/helix-editor/helix/releases/download/22.03/helix-22.03-x86_64-windows.zip",
+            "hash": "6ea24df6babe70f6ee28948b460f2a9bab5d7b970dbc74efb67f942168cd6b94",
+            "extract_dir": "helix-22.03-x86_64-windows"
         }
     },
     "bin": "hx.exe",
@@ -17,8 +17,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/helix-editor/helix/releases/download/v$version/helix-v$version-x86_64-windows.zip",
-                "extract_dir": "helix-v$version-x86_64-windows"
+                "url": "https://github.com/helix-editor/helix/releases/download/$version/helix-$version-x86_64-windows.zip",
+                "extract_dir": "helix-$version-x86_64-windows"
             }
         }
     }


### PR DESCRIPTION
They changed version tags from `vM.m.p` to `YY.MM` upon the release of `22.03` today.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
