### PR TITLE
stylua: Update to version 0.13.0, fix autoupdate

### DIFF
--- a/bucket/stylua.json
+++ b/bucket/stylua.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.12.5",
+    "version": "0.13.0",
     "description": "An opinionated Lua code formatter",
     "homepage": "https://github.com/JohnnyMorganz/StyLua",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v0.12.5/stylua-0.12.5-win64.zip",
-            "hash": "fc30d8258e8319cea94766747515b1dc15a236796a602471c6a638e10b29fb18"
+            "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v0.13.0/stylua-win64.zip",
+            "hash": "60c548e227b2fb115177f24fdd4acceb0eb4f6b9f8b3114978246c5455a09540"
         }
     },
     "bin": "stylua.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v$version/stylua-$version-win64.zip"
+                "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v$version/stylua-win64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to find download due to file name change: https://github.com/ScoopInstaller/Main/runs/5784628664?check_suite_focus=true#step:3:318

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
