### PR TITLE
yosys: Remove autoupdate, add archive URL & outdated note

### DIFF
--- a/bucket/yosys.json
+++ b/bucket/yosys.json
@@ -1,7 +1,7 @@
 {
     "version": "0.9",
     "description": "Framework for Verilog RTL synthesis",
-    "homepage": "http://www.clifford.at/yosys/about.html",
+    "homepage": "https://yosyshq.net/yosys/",
     "license": "ISC",
     "notes": "Separate binaries are no longer released for Yosys, but updated versions are included in OSS CAD Suite (versions/oss-cad-suite-nightly)",
     "url": "https://web.archive.org/web/20210622104453/http://www.clifford.at/yosys/nogit/win32/yosys-win32-mxebin-0.9.zip",

--- a/bucket/yosys.json
+++ b/bucket/yosys.json
@@ -3,19 +3,12 @@
     "description": "Framework for Verilog RTL synthesis",
     "homepage": "http://www.clifford.at/yosys/about.html",
     "license": "ISC",
-    "url": "http://www.clifford.at/yosys/nogit/win32/yosys-win32-mxebin-0.9.zip",
+    "notes": "Separate binaries are no longer released for Yosys, but it is included in OSS CAD Suite (versions/oss-cad-suite-nightly)",
+    "url": "https://web.archive.org/web/20210622104453/http://www.clifford.at/yosys/nogit/win32/yosys-win32-mxebin-0.9.zip",
     "hash": "d638d860dff1f351c15ff0caeaa668742649677b874b1a9bdb0b6ce0e54840f5",
     "extract_dir": "yosys-win32-mxebin-0.9",
     "bin": [
         "yosys.exe",
         "yosys-abc.exe"
-    ],
-    "checkver": {
-        "url": "http://www.clifford.at/yosys/download.html",
-        "regex": "yosys-win32-mxebin-([\\d.]+)\\.zip"
-    },
-    "autoupdate": {
-        "url": "http://www.clifford.at/yosys/nogit/win32/yosys-win32-mxebin-$version.zip",
-        "extract_dir": "yosys-win32-mxebin-$version"
-    }
+    ]
 }

--- a/bucket/yosys.json
+++ b/bucket/yosys.json
@@ -3,7 +3,7 @@
     "description": "Framework for Verilog RTL synthesis",
     "homepage": "http://www.clifford.at/yosys/about.html",
     "license": "ISC",
-    "notes": "Separate binaries are no longer released for Yosys, but it is included in OSS CAD Suite (versions/oss-cad-suite-nightly)",
+    "notes": "Separate binaries are no longer released for Yosys, but updated versions are included in OSS CAD Suite (versions/oss-cad-suite-nightly)",
     "url": "https://web.archive.org/web/20210622104453/http://www.clifford.at/yosys/nogit/win32/yosys-win32-mxebin-0.9.zip",
     "hash": "d638d860dff1f351c15ff0caeaa668742649677b874b1a9bdb0b6ce0e54840f5",
     "extract_dir": "yosys-win32-mxebin-0.9",

--- a/bucket/yosys.json
+++ b/bucket/yosys.json
@@ -4,7 +4,7 @@
     "homepage": "https://yosyshq.net/yosys/",
     "license": "ISC",
     "notes": "Separate binaries are no longer released for Yosys, but updated versions are included in OSS CAD Suite (versions/oss-cad-suite-nightly)",
-    "url": "https://web.archive.org/web/20210622104453/http://www.clifford.at/yosys/nogit/win32/yosys-win32-mxebin-0.9.zip",
+    "url": "https://github.com/ScoopInstaller/Binary/raw/master/yosys/yosys-win32-mxebin-0.9.zip",
     "hash": "d638d860dff1f351c15ff0caeaa668742649677b874b1a9bdb0b6ce0e54840f5",
     "extract_dir": "yosys-win32-mxebin-0.9",
     "bin": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to perform checkver: https://github.com/ScoopInstaller/Main/runs/5784628664?check_suite_focus=true#step:3:321
- It looks as if the site where Yosys was previously hosted has been hacked/bought in order to promote some online casinos: https://clifford.at/
- The download page previously looked like this: https://web.archive.org/web/20210622104453/http://www.clifford.at/yosys/download.html
- On the old download page, there was a GitHub link to https://github.com/cliffordwolf/yosys, which redirects to https://github.com/YosysHQ/yosys and links to their new homepage https://yosyshq.net/yosys/
- On their website you can find old links to Yosys' download page - https://yosyshq.net/yosys/download.html - which now says that Yosys is best downloaded as part of OSS CAD Suite: https://github.com/YosysHQ/oss-cad-suite-build
- I made a PR for adding OSS CAD Suite to versions https://github.com/ScoopInstaller/Versions/pull/475, so I made a note to tell users of this manifest to update by using the package in Versions (this version was released 26 Aug 2019, latest is 0.15)
- This manifest will continue to work because the download has been moved to the one hosted on archive.org, it has the same hash so it should be identical (I have tested it works)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
