### PR TITLE
Add dig.exe to bin list for bind.json

### DIFF
--- a/bucket/bind.json
+++ b/bucket/bind.json
@@ -21,7 +21,38 @@
             "Remove-Item \"$dir\\*\" -Exclude 'bin'"
         ]
     },
-    "env_add_path": "bin",
+    "bin": [
+        "bin\\arpaname.exe",
+        "bin\\ddns-confgen.exe",
+        "bin\\delv.exe",
+        "bin\\dig.exe",
+        "bin\\dnssec-cds.exe",
+        "bin\\dnssec-dsfromkey.exe",
+        "bin\\dnssec-importkey.exe",
+        "bin\\dnssec-keyfromlabel.exe",
+        "bin\\dnssec-keygen.exe",
+        "bin\\dnssec-revoke.exe",
+        "bin\\dnssec-settime.exe",
+        "bin\\dnssec-signzone.exe",
+        "bin\\dnssec-verify.exe",
+        "bin\\host.exe",
+        "bin\\mdig.exe",
+        "bin\\named-checkconf.exe",
+        "bin\\named-checkzone.exe",
+        "bin\\named-compilezone.exe",
+        "bin\\named-journalprint.exe",
+        "bin\\named-rrchecker.exe",
+        "bin\\named.exe",
+        "bin\\nsec3hash.exe",
+        [
+            "bin\\nslookup.exe",
+            "nslookup-bind"
+        ],
+        "bin\\nsupdate.exe",
+        "bin\\rndc-confgen.exe",
+        "bin\\rndc.exe",
+        "bin\\tsig-keygen.exe"
+    ],
     "persist": "etc",
     "checkver": {
         "url": "https://www.isc.org/download/",


### PR DESCRIPTION
Add dig.exe to bin list for bind.json so it is searchable by `scoop search dig`. 

`dig` is a common tool used for advanced DNS lookup, it is part of `bind`, unless people know this, they might not know to install `bind`. Current `bind.json` adds bind `bin` path user's ENV, so no shim is necessary, this just make `dig` searchable.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
