### PR TITLE
scaleway-cli: Update to version 2.5.1, fix autoupdate

### DIFF
--- a/bucket/scaleway-cli.json
+++ b/bucket/scaleway-cli.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.3.1",
+    "version": "2.5.1",
     "description": "Manage BareMetal Servers from Command Line (as easily as with Docker).",
     "homepage": "https://github.com/scaleway/scaleway-cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.3.1/scw-2.3.1-windows-x86_64.exe#/scw.exe",
-            "hash": "3aa8f1251c5bc137225af83bbad2d86df19fcda262b4724d84ffac2e712448e9"
+            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.5.1/scaleway-cli_2.5.1_windows_amd64.exe#/scw.exe",
+            "hash": "e61712ebb597d90e0f6d540c331ded0d20e2030e74c093b22c03614cbd3fee49"
         },
         "32bit": {
-            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.3.1/scw-2.3.1-windows-386.exe#/scw.exe",
-            "hash": "85f69b8139dd632b8182536ea400bc2afc8fc7c0bdc6e67c88754853fe88b69b"
+            "url": "https://github.com/scaleway/scaleway-cli/releases/download/v2.5.1/scaleway-cli_2.5.1_windows_386.exe#/scw.exe",
+            "hash": "d1dc93ad8f336d4b140a358903bc736128f1d3dbeed7c12a17e546369849e7ac"
         }
     },
     "bin": "scw.exe",
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/scaleway/scaleway-cli/releases/download/v$version/scw-$version-windows-x86_64.exe#/scw.exe"
+                "url": "https://github.com/scaleway/scaleway-cli/releases/download/v$version/scaleway-cli_$version_windows_amd64.exe#/scw.exe"
             },
             "32bit": {
-                "url": "https://github.com/scaleway/scaleway-cli/releases/download/v$version/scw-$version-windows-386.exe#/scw.exe"
+                "url": "https://github.com/scaleway/scaleway-cli/releases/download/v$version/scaleway-cli_$version_windows_386.exe#/scw.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update to 2.5.1: https://github.com/ScoopInstaller/Main/runs/5830137476?check_suite_focus=true#step:3:318

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
