### PR TITLE
px: Update to version 0.6.1, fix autoupdate

### DIFF
--- a/bucket/px.json
+++ b/bucket/px.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "An HTTP proxy server to automatically authenticate through an NTLM proxy.",
     "homepage": "https://github.com/genotrance/px",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/genotrance/px/releases/download/v0.6.0/px-v0.6.0.zip",
-            "hash": "e1f6e5d923abdc0c143ba4c7a3970bfa6e669220df7d1484a3b71fcce9e18351"
+            "url": "https://github.com/genotrance/px/releases/download/v0.6.1/px-v0.6.1-windows.zip",
+            "hash": "3385a2f21171500dd87a28589961aad3d5ea310e67c55c49968dc6f9017c61ff"
         }
     },
     "bin": "px.exe",
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/genotrance/px/releases/download/v$version/px-v$version.zip"
+                "url": "https://github.com/genotrance/px/releases/download/v$version/px-v$version-windows.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update because file name format changed: https://github.com/ScoopInstaller/Main/runs/5847467824?check_suite_focus=true#step:3:312

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
