### PR TITLE
cmder: handle spaces in %USERPROFILE%

### DIFF
--- a/bucket/cmder-full.json
+++ b/bucket/cmder-full.json
@@ -15,7 +15,7 @@
         [
             "Cmder.exe",
             "Cmder",
-            "/start %USERPROFILE%"
+            "/start \"%USERPROFILE%\""
         ]
     ],
     "persist": [

--- a/bucket/cmder.json
+++ b/bucket/cmder.json
@@ -15,7 +15,7 @@
         [
             "Cmder.exe",
             "Cmder",
-            "/start %USERPROFILE%"
+            "/start \"%USERPROFILE%\""
         ]
     ],
     "persist": [


### PR DESCRIPTION
If a Windows user has a name with spaces in it, `cmder` will fail to start.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
