### PR TITLE
karate: Add version 1.1.0

### DIFF
--- a/bucket/karate.json
+++ b/bucket/karate.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.1.0",
+    "description": "Test automation tool that combines API test-automation, mocks, performance-testing and UI automation into a single framework.",
+    "homepage": "https://karatelabs.github.io/karate/",
+    "license": "MIT",
+    "suggest": {
+        "Java": "java/openjdk"
+    },
+    "url": "https://github.com/karatelabs/karate/releases/download/v1.1.0/karate-1.1.0.zip",
+    "hash": "585079ff5bb760fd26ac8ee85b31d6243f129f2aef127a1072a135fd57d264d2",
+    "extract_dir": "karate-1.1.0",
+    "pre_install": [
+        "$cont = Get-Content \"$dir\\karate.bat\"",
+        "$cont = 'cd /d \"%~dp0\"' + \"`n\" + $cont",
+        "Set-Content \"$dir\\karate.bat\" $cont -Encoding ascii"
+    ],
+    "bin": "karate.bat",
+    "persist": "target",
+    "checkver": {
+        "github": "https://github.com/karatelabs/karate"
+    },
+    "autoupdate": {
+        "url": "https://github.com/karatelabs/karate/releases/download/v$version/karate-$version.zip",
+        "extract_dir": "karate-$version"
+    }
+}


### PR DESCRIPTION
closes https://github.com/ScoopInstaller/Extras/issues/8294

[Karate](https://karatelabs.github.io/karate/) is a test automation tool that combines API test-automation, mocks, performance-testing and UI automation into a single framework.

**NOTES**:
* *Karate* uses a **.bat** file to help loading the args. It will not work properly if we just give args to `karate.jar`.
```
java -cp karate.jar;. com.intuit.karate.Main %*
```
* However, the app would not load properly if **working directory** is not at the same location of `karate.jar`. Therefore we need to `cd /d \"%~dp0\"` in *pre_install* for the shim to work.

* The app is built in 32-bit, according to the install guide.
```
The main pre-requisites are

a 64-bit Windows OS (32-bit may work, please let us know !)
a Java Runtime Environment (JRE, 32-bit will work !)
```