### PR TITLE
dotter: Update to version 0.12.10, fix autoupdate

### DIFF
--- a/bucket/dotter.json
+++ b/bucket/dotter.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.12.9",
+    "version": "0.12.10",
     "description": "Dotfile manager and templater",
     "homepage": "https://github.com/SuperCuber/dotter",
     "license": "Unlicense",
     "notes": "To set up dotter, check instructions on 'https://github.com/SuperCuber/dotter/wiki/Setup-and-Configuration'",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/SuperCuber/dotter/releases/download/0.12.9/dotter.exe",
-            "hash": "e4d5144b51d1c29be532c7444286d145acaf1f3743f370cece4b538b5d4aa94e"
+            "url": "https://github.com/SuperCuber/dotter/releases/download/v0.12.10/dotter.exe",
+            "hash": "cee5a4dcfdd67bcf8379d26d72b4220f7e1294be353d0ab5fddce0cb6d364e15"
         }
     },
     "bin": "dotter.exe",
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/SuperCuber/dotter/releases/download/$version/dotter.exe"
+                "url": "https://github.com/SuperCuber/dotter/releases/download/v$version/dotter.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to autoupdate again... (see #3401)
- `$version` changed back to `v$version`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
