### PR TITLE
(chore): Add 7-zip 19.00 helper package

### DIFF
--- a/bucket/7zip-helper-19.00.json
+++ b/bucket/7zip-helper-19.00.json
@@ -1,0 +1,23 @@
+{
+    "version": "19.00",
+    "description": "7-Zip 19.00 helper package (for extracting files in other packages)",
+    "homepage": "https://www.7-zip.org/",
+    "license": "LGPL-2.1-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.sourceforge.net/project/sevenzip/7-Zip/19.00/7z1900-x64.msi",
+            "hash": "a7803233eedb6a4b59b3024ccf9292a6fffb94507dc998aa67c5b745d197a5dc"
+        },
+        "32bit": {
+            "url": "https://download.sourceforge.net/project/sevenzip/7-Zip/19.00/7z1900.msi",
+            "hash": "b49d55a52bc0eab14947c8982c413d9be141c337da1368a24aa0484cbb5e89cd"
+        }
+    },
+    "extract_dir": "Files\\7-Zip",
+    "bin": [
+        [
+            "7z.exe",
+            "7z-helper-19.00.exe"
+        ]
+    ]
+}

--- a/bucket/7zip19.00-helper.json
+++ b/bucket/7zip19.00-helper.json
@@ -17,7 +17,7 @@
     "bin": [
         [
             "7z.exe",
-            "7z-helper-19.00.exe"
+            "7z19.00-helper.exe"
         ]
     ]
 }


### PR DESCRIPTION
Related:
* https://github.com/ScoopInstaller/Extras/issues/8298
* https://github.com/ScoopInstaller/Scoop/issues/4647
* Also see [extras/winrar-helper](https://github.com/ScoopInstaller/Extras/blob/master/bucket/winrar-helper.json) manifest.

This adds a "helper package" that is only used for **extracting files in other packages**. It creates a specific shim named `7z19.00-helper.exe`, so that it will not affect existing installations of 7-zip.