### PR TITLE
haskell: Fix JSONPath in checkver

### DIFF
--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -30,7 +30,7 @@
     "env_add_path": "lib\\bin",
     "checkver": {
         "url": "https://api.github.com/repos/commercialhaskell/ghc/tags",
-        "jsonpath": "$.name",
+        "jsonpath": "$..name",
         "regex": "ghc-([\\d\\.]+)-release"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator error `Property 'name' not valid on JArray.` - https://github.com/ScoopInstaller/Main/runs/6003990163?check_suite_focus=true#step:3:263

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
