### PR TITLE
diff-so-fancy: Add version 1.4.3

### DIFF
--- a/bucket/diff-so-fancy.json
+++ b/bucket/diff-so-fancy.json
@@ -4,14 +4,14 @@
     "homepage": "https://github.com/so-fancy/diff-so-fancy",
     "license": "MIT",
     "suggest": {
-        "git": "git"
+        "Perl": "perl"
     },
-    "url": "https://github.com/so-fancy/diff-so-fancy/releases/download/v1.4.3/diff-so-fancy#/diff-so-fancy",
+    "url": "https://github.com/so-fancy/diff-so-fancy/releases/download/v1.4.3/diff-so-fancy",
     "hash": "de90659705436cf17d9a8aaad7012c9ed82d7f16eadf1ecee3d6badb0717b73f",
     "pre_install": "Set-Content -Value '@perl.exe \"%~dp0diff-so-fancy\" %*' -Path \"$dir\\diff-so-fancy.bat\"",
     "bin": "diff-so-fancy.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/so-fancy/diff-so-fancy/releases/download/v$version/diff-so-fancy#/diff-so-fancy"
+        "url": "https://github.com/so-fancy/diff-so-fancy/releases/download/v$version/diff-so-fancy"
     }
 }

--- a/bucket/diff-so-fancy.json
+++ b/bucket/diff-so-fancy.json
@@ -1,17 +1,17 @@
 {
-    "url": "https://raw.githubusercontent.com/so-fancy/diff-so-fancy/master/diff-so-fancy",
-    "description": "Good-lookin' diffs. Actually… nah… The best-lookin' diffs.",
-    "homepage": "https://github.com/so-fancy/diff-so-fancy",
     "version": "1.4.3",
-    "hash": "fcd4953541843416297fc4d281a51dd4e790dcf9ee8c021699f0986e0c0f1695",
+    "description": "Make diffs human readable instead of machine readable to improve code quality and spot defects faster.",
+    "homepage": "https://github.com/so-fancy/diff-so-fancy",
     "license": "MIT",
     "suggest": {
         "git": "git"
     },
-    "depends": "perl",
-    "bin": "diff-so-fancy",
+    "url": "https://github.com/so-fancy/diff-so-fancy/releases/download/v1.4.3/diff-so-fancy#/diff-so-fancy",
+    "hash": "de90659705436cf17d9a8aaad7012c9ed82d7f16eadf1ecee3d6badb0717b73f",
+    "pre_install": "Set-Content -Value '@perl.exe \"%~dp0diff-so-fancy\" %*' -Path \"$dir\\diff-so-fancy.bat\"",
+    "bin": "diff-so-fancy.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/so-fancy/diff-so-fancy/$version/diff-so-fancy"
+        "url": "https://github.com/so-fancy/diff-so-fancy/releases/download/v$version/diff-so-fancy#/diff-so-fancy"
     }
 }

--- a/bucket/diff-so-fancy.json
+++ b/bucket/diff-so-fancy.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/so-fancy/diff-so-fancy",
+    "homepage": "https://github.com/so-fancy/diff-so-fancy",
+    "version": "1.4.3",
+    "hash": "819687fe6ead4b4d794477d6745292c6658bbc2bbe1a5e6c7d7b81f8a4c99fdc",
+    "license": "MIT",
+    "depends": "perl",
+    "bin": "diff-so-fancy"
+}

--- a/bucket/diff-so-fancy.json
+++ b/bucket/diff-so-fancy.json
@@ -1,9 +1,17 @@
 {
-    "url": "https://github.com/so-fancy/diff-so-fancy",
+    "url": "https://raw.githubusercontent.com/so-fancy/diff-so-fancy/master/diff-so-fancy",
+    "description": "Good-lookin' diffs. Actually… nah… The best-lookin' diffs.",
     "homepage": "https://github.com/so-fancy/diff-so-fancy",
     "version": "1.4.3",
-    "hash": "819687fe6ead4b4d794477d6745292c6658bbc2bbe1a5e6c7d7b81f8a4c99fdc",
+    "hash": "fcd4953541843416297fc4d281a51dd4e790dcf9ee8c021699f0986e0c0f1695",
     "license": "MIT",
+    "suggest": {
+        "git": "git"
+    },
     "depends": "perl",
-    "bin": "diff-so-fancy"
+    "bin": "diff-so-fancy",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/so-fancy/diff-so-fancy/$version/diff-so-fancy"
+    }
 }


### PR DESCRIPTION
It doesn't work yet but I'll be happy to have some help because this is my first formula.

I currently have the following error:

```
> diff-so-fancy
The system cannot find the path specified.
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
