### PR TITLE
tor: Update invalid download url (torbrowser version segment /11.0.7/ -> /11.0.10/)

### DIFF
--- a/bucket/tor.json
+++ b/bucket/tor.json
@@ -9,12 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://dist.torproject.org/torbrowser/11.0.7/tor-win64-0.4.6.10.zip",
-            "hash": "8eb81cae2a54103483c2740c22c75bdd01f646a3c38e88a011da4e4bafbd34e6"
+            "url": "https://dist.torproject.org/torbrowser/11.0.10/tor-win64-0.4.6.10.zip",
+            "hash": "ecf6ccb6c39421d048bac95091758d3c48fd43b8e7fb1b3d7203910ef05a82e4"
         },
         "32bit": {
-            "url": "https://dist.torproject.org/torbrowser/11.0.7/tor-win32-0.4.6.10.zip",
-            "hash": "9c7be9e0c62a8e98b4cac161bdd0f65b8f8163a0045e654c626a4eda127ed819"
+            "url": "https://dist.torproject.org/torbrowser/11.0.10/tor-win32-0.4.6.10.zip",
+            "hash": "d3f62317507dbe1a1aa74b9e0e03996dbded2143f94409270828f6a8bcdda16a"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Url has been updated to the most recent torbrowser version 11.0.10 per https://dist.torproject.org/torbrowser/ since 11.0.7 isn't offered anymore and the current download link 404s: https://dist.torproject.org/torbrowser/11.0.7/tor-win64-0.4.6.10.zip .

The underlying tor version is the same `0.4.6.10` but I get different file hashes (that probably should be verified).  
  
Updating this part of the url seems to be necessary around every three months, given torbrowser following the ESR release schedule, while keeping the three latest stable versions hosted:

https://gitlab.torproject.org/tpo/applications/tor-browser/-/wikis/Release-Schedule
https://wiki.mozilla.org/Release_Management/Calendar
https://dist.torproject.org/torbrowser/


Relates to #3304
  

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
