### PR TITLE
mob: Update hash extraction url

### DIFF
--- a/bucket/mob.json
+++ b/bucket/mob.json
@@ -18,7 +18,7 @@
             "64bit": {
                 "url": "https://github.com/remotemobprogramming/mob/releases/download/v$version/mob_v$version_windows_amd64.tar.gz",
                 "hash": {
-                    "url": "$baseurl/mob_v$version_windows_amd64_checksum.txt"
+                    "url": "$baseurl/mob_v$version_windows_amd64_sha256_checksum.txt"
                 }
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to extract hash: https://github.com/ScoopInstaller/Main/runs/6084790781?check_suite_focus=true#step:3:261

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
