### PR TITLE
aspell: Add version 0.60.8-2

### DIFF
--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -1,5 +1,5 @@
 {
-    "##": "The dictionary (aspell6-en-2020.12.07-1-x86_64.pkg.tar.zst) has to be updated manually.",
+    "##": "The dictionary (mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst) has to be updated manually.",
     "version": "0.60.8-2",
     "description": "A spellchecker commonly used with emacs.",
     "homepage": "http://aspell.net/",
@@ -8,22 +8,22 @@
         "64bit": {
             "url": [
                 "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
-                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst"
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst#/dict"
             ],
             "hash": [
                 "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",
-                "76899c6adf0e62ba7f05f0712d07d6ab6b60ff3c02f65710128d7e928a3677f1"
+                "98745b2737dc107adcb76264c1de61489fd44b5e74f6c50cf8eb8f2c27f826f9"
             ],
             "extract_dir": "mingw64"
         },
         "32bit": {
             "url": [
                 "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-0.60.8-2-any.pkg.tar.zst",
-                "https://mirror.msys2.org/msys/x86_64/aspell6-en-2020.12.07-1-x86_64.pkg.tar.zst#/dict"
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst#/dict"
             ],
             "hash": [
                 "2db955f695185daefcf8209ecdc71fa3b9c37d211f50ccffaa548caa6507d4da",
-                "76899c6adf0e62ba7f05f0712d07d6ab6b60ff3c02f65710128d7e928a3677f1"
+                "98745b2737dc107adcb76264c1de61489fd44b5e74f6c50cf8eb8f2c27f826f9"
             ],
             "extract_dir": "mingw32"
         }
@@ -31,7 +31,7 @@
     "pre_install": [
         "# Renaming again to '.tar.zst', otherwise zstd.exe will stop and report an error.",
         "Rename-Item \"$dir\\dict\" \"$dir\\dict.tar.zst\"",
-        "Expand-ZstdArchive \"$dir\\dict.tar.zst\" \"$dir\" -ExtractDir 'usr' -Removal | Out-Null"
+        "Expand-ZstdArchive \"$dir\\dict.tar.zst\" \"$dir\" -ExtractDir 'mingw64' -Removal | Out-Null"
     ],
     "bin": [
         "bin\\aspell.exe",

--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.60.8-2",
+    "description": "A spellchecker commonly used with emacs.",
+    "homepage": "http://aspell.net/",
+    "license": "LGPL-2.1-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.nus.edu.sg/mirror/msys2/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
+            "hash": "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",
+            "extract_dir": "mingw64"
+        },
+        "32bit": {
+            "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-0.60.8-2-any.pkg.tar.zst",
+            "hash": "2db955f695185daefcf8209ecdc71fa3b9c37d211f50ccffaa548caa6507d4da",
+            "extract_dir": "mingw32"
+        }
+    },
+    "bin": [
+        "bin\\aspell.exe",
+        "bin\\word-list-compress.exe"
+    ],
+    "checkver": {
+        "url": "https://packages.msys2.org/package/mingw-w64-x86_64-aspell?repo=mingw64",
+        "regex": "mingw-w64-x86_64-aspell-([\\d.-]+)-any"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.nus.edu.sg/mirror/msys2/mingw/mingw64/mingw-w64-x86_64-aspell-$version-any.pkg.tar.zst",
+                "hash": {
+                    "url": "https://packages.msys2.org/package/mingw-w64-x86_64-aspell?repo=mingw64",
+                    "regex": "$sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-$version-any.pkg.tar.zst",
+                "hash": {
+                    "url": "https://packages.msys2.org/package/mingw-w64-i686-aspell?repo=mingw32",
+                    "regex": "$sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -8,7 +8,7 @@
         "64bit": {
             "url": [
                 "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
-                "https://mirror.msys2.org/msys/x86_64/aspell6-en-2020.12.07-1-x86_64.pkg.tar.zst#/dict"
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst"
             ],
             "hash": [
                 "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",

--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -5,7 +5,7 @@
     "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
-            "url": "https://download.nus.edu.sg/mirror/msys2/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
+            "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
             "hash": "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",
             "extract_dir": "mingw64"
         },
@@ -20,22 +20,22 @@
         "bin\\word-list-compress.exe"
     ],
     "checkver": {
-        "url": "https://packages.msys2.org/package/mingw-w64-x86_64-aspell?repo=mingw64",
+        "url": "https://packages.msys2.org/package/mingw-w64-x86_64-aspell",
         "regex": "mingw-w64-x86_64-aspell-([\\d.-]+)-any"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.nus.edu.sg/mirror/msys2/mingw/mingw64/mingw-w64-x86_64-aspell-$version-any.pkg.tar.zst",
+                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-$version-any.pkg.tar.zst",
                 "hash": {
-                    "url": "https://packages.msys2.org/package/mingw-w64-x86_64-aspell?repo=mingw64",
+                    "url": "https://packages.msys2.org/package/mingw-w64-x86_64-aspell",
                     "regex": "$sha256"
                 }
             },
             "32bit": {
                 "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-$version-any.pkg.tar.zst",
                 "hash": {
-                    "url": "https://packages.msys2.org/package/mingw-w64-i686-aspell?repo=mingw32",
+                    "url": "https://packages.msys2.org/package/mingw-w64-i686-aspell",
                     "regex": "$sha256"
                 }
             }

--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -22,7 +22,7 @@
         "32bit": {
             "url": [
                 "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-0.60.8-2-any.pkg.tar.zst",
-                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst"
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-en-2020.12.07-1-any.pkg.tar.zst"
             ],
             "hash": [
                 "2db955f695185daefcf8209ecdc71fa3b9c37d211f50ccffaa548caa6507d4da",
@@ -30,7 +30,7 @@
             ],
             "extract_dir": [
                 "mingw32",
-                "mingw64"
+                "mingw32"
             ]
         }
     },

--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -8,31 +8,32 @@
         "64bit": {
             "url": [
                 "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
-                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst#/dict"
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst"
             ],
             "hash": [
                 "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",
                 "98745b2737dc107adcb76264c1de61489fd44b5e74f6c50cf8eb8f2c27f826f9"
             ],
-            "extract_dir": "mingw64"
+            "extract_dir": [
+                "mingw64",
+                "mingw64"
+            ]
         },
         "32bit": {
             "url": [
                 "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-0.60.8-2-any.pkg.tar.zst",
-                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst#/dict"
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst"
             ],
             "hash": [
                 "2db955f695185daefcf8209ecdc71fa3b9c37d211f50ccffaa548caa6507d4da",
                 "98745b2737dc107adcb76264c1de61489fd44b5e74f6c50cf8eb8f2c27f826f9"
             ],
-            "extract_dir": "mingw32"
+            "extract_dir": [
+                "mingw32",
+                "mingw64"
+            ]
         }
     },
-    "pre_install": [
-        "# Renaming again to '.tar.zst', otherwise zstd.exe will stop and report an error.",
-        "Rename-Item \"$dir\\dict\" \"$dir\\dict.tar.zst\"",
-        "Expand-ZstdArchive \"$dir\\dict.tar.zst\" \"$dir\" -ExtractDir 'mingw64' -Removal | Out-Null"
-    ],
     "bin": [
         "bin\\aspell.exe",
         "bin\\word-list-compress.exe"

--- a/bucket/aspell.json
+++ b/bucket/aspell.json
@@ -1,20 +1,38 @@
 {
+    "##": "The dictionary (aspell6-en-2020.12.07-1-x86_64.pkg.tar.zst) has to be updated manually.",
     "version": "0.60.8-2",
     "description": "A spellchecker commonly used with emacs.",
     "homepage": "http://aspell.net/",
     "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
-            "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
-            "hash": "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",
+            "url": [
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-aspell-0.60.8-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/aspell6-en-2020.12.07-1-x86_64.pkg.tar.zst#/dict"
+            ],
+            "hash": [
+                "84e02ec8e81fefb20e429c6a991529de8a3c2d0296f7b781e92f2e8937d32427",
+                "76899c6adf0e62ba7f05f0712d07d6ab6b60ff3c02f65710128d7e928a3677f1"
+            ],
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-0.60.8-2-any.pkg.tar.zst",
-            "hash": "2db955f695185daefcf8209ecdc71fa3b9c37d211f50ccffaa548caa6507d4da",
+            "url": [
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-aspell-0.60.8-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/msys/x86_64/aspell6-en-2020.12.07-1-x86_64.pkg.tar.zst#/dict"
+            ],
+            "hash": [
+                "2db955f695185daefcf8209ecdc71fa3b9c37d211f50ccffaa548caa6507d4da",
+                "76899c6adf0e62ba7f05f0712d07d6ab6b60ff3c02f65710128d7e928a3677f1"
+            ],
             "extract_dir": "mingw32"
         }
     },
+    "pre_install": [
+        "# Renaming again to '.tar.zst', otherwise zstd.exe will stop and report an error.",
+        "Rename-Item \"$dir\\dict\" \"$dir\\dict.tar.zst\"",
+        "Expand-ZstdArchive \"$dir\\dict.tar.zst\" \"$dir\" -ExtractDir 'usr' -Removal | Out-Null"
+    ],
     "bin": [
         "bin\\aspell.exe",
         "bin\\word-list-compress.exe"


### PR DESCRIPTION
closes #3481

[ASpell](http://aspell.net/) is a spellchecker commonly used with *emacs*.

**NOTES**:
* *ASpell* can work properly without installing "dependencies" such as `gcc-libs`, `gettext`, etc.

* *ASpell* requires dictionary files (`mingw-w64-x86_64-aspell-en-2020.12.07-1-any.pkg.tar.zst`) to run spell checks.

* We can test the package by:
```
Invoke-WebRequest 'https://github.com/ScoopInstaller/Scoop/raw/master/LICENSE' -OutFile 'license.txt' 
aspell check license.txt
```