### PR TITLE
ctop: add version 0.7.7

### DIFF
--- a/bucket/ctop.json
+++ b/bucket/ctop.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.7.7",
+    "description": "Top-like interface for container metrics.",
+    "homepage": "https://github.com/bcicen/ctop",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bcicen/ctop/releases/download/v0.7.7/ctop-0.7.7-windows-amd64#/ctop.exe",
+            "hash": "77a980cbd716e63fc6b3ca9ec8c78d5e602c3d02e88d4a7613033dd4caeda5a7"
+        }
+    },
+    "bin": "ctop.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bcicen/ctop/releases/download/v$version/ctop-$version-windows-amd64#/ctop.exe",
+                "hash": {
+                    "url": "$baseurl/sha256sums.txt"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds [ctop](https://github.com/bcicen/ctop) command-line utility

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
