### PR TITLE
autojump: Add version 0.4.0

### DIFF
--- a/bucket/autojump.json
+++ b/bucket/autojump.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.4.0",
+    "description": "Rust implementation of autojump, a tool that helps navigate your filesystem in the command line, by recording the directories you use the most.",
+    "homepage": "https://github.com/xen0n/autojump-rs",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/xen0n/autojump-rs/releases/download/0.4.0/autojump-0.4.0-x86_64-pc-windows-msvc.zip",
+            "hash": "dbb20a7a347d538dff2ba66c36cd8cb4e03bd14b072ae8b35c157bf76f74cde0"
+        },
+        "32bit": {
+            "url": "https://github.com/xen0n/autojump-rs/releases/download/0.4.0/autojump-0.4.0-i686-pc-windows-msvc.zip",
+            "hash": "0a7fe9676fd2d5e57f3479710e8fb0fe65654cff81dda3eaec2c9716036b3f44"
+        }
+    },
+    "bin": "autojump.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/xen0n/autojump-rs/releases/download/$version/autojump-$version-x86_64-pc-windows-msvc.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/xen0n/autojump-rs/releases/download/$version/autojump-$version-i686-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes #3520

[AutoJump](https://github.com/xen0n/autojump-rs) is a tool that helps navigate your filesystem in the command line, by recording the directories you use the most.

**NOTES**:
* about package name:
> As autojump(the python version) requires python, I hope we can just name it as autojump instead of autojump-rs? (#3520)
* *persist* is not needed because config is at `$Env:AppData\autojump`.