### PR TITLE
zoxide: Update notes

### DIFF
--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -3,7 +3,7 @@
     "description": "A faster way to navigate your filesystem",
     "homepage": "https://github.com/ajeetdsouza/zoxide",
     "license": "MIT",
-    "notes": "_ZO_DATA_DIR is located at $env:APPDATA\\zoxide by default",
+    "notes": "_ZO_DATA_DIR is located at '$env:LOCALAPPDATA\\zoxide' by default",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.8.1/zoxide-v0.8.1-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
https://github.com/ajeetdsouza/zoxide#environment-variables

and `_ZO_DATA_DIR` should be set to $persist_dir, IMO
but i dont think data migration should be done via SCOOP, so i will not make a PR for this at the time.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
