### PR TITLE
r|rtools: Update to 4.2.x

### DIFF
--- a/bucket/r.json
+++ b/bucket/r.json
@@ -2,11 +2,14 @@
     "version": "4.2.0",
     "description": "A free software environment for statistical computing and graphics.",
     "homepage": "https://www.r-project.org",
-    "license": "GPL-2.0-only",
+    "license": "GPL-2.0-or-later",
     "notes": [
-        "For source packages installation, please install 'rtools'.",
+        "This version requires UCRT, which is part of Windows since Windows 10 and Windows Server 2016.",
         "",
-        "You'll need to type 'r.ps1' or 'r.cmd' to run R, because in Powershell 'r' runs the last command. Alternatively 'rterm' can be used to start the interactive R terminal session.",
+        "For source packages installation, please install 'rtools'.",
+        "For 32bit edition, please install 'versions/r41'.",
+        "",
+        "You'll need to type 'r.exe' to run R, because in Powershell 'r' runs the last command. Alternatively 'rterm' can be used to start the interactive R terminal session.",
         "",
         "You can remove Powershell's 'r' command with:",
         "    rm alias:\\r",
@@ -15,11 +18,11 @@
         "",
         "Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements."
     ],
-    "url": "https://cloud.r-project.org/bin/windows/base/R-4.2.0-win.exe",
-    "hash": "md5:7f73761dfaab031f1cbb25530c8dba9c",
     "innosetup": true,
     "architecture": {
         "64bit": {
+            "url": "https://cloud.r-project.org/bin/windows/base/old/4.2.0/R-4.2.0-win.exe",
+            "hash": "md5:7f73761dfaab031f1cbb25530c8dba9c",
             "bin": [
                 "bin\\x64\\R.exe",
                 "bin\\x64\\Rcmd.exe",
@@ -35,36 +38,18 @@
             ]
         }
     },
-    "installer": {
-        "script": [
-            "Remove-Item \"$dir\\bin\\R,*.exe\" -Force",
-            "Copy-Item \"$dir\\bin\\R.exe\" \"$dir\\bin\\Rscript.exe\"",
-            "if (Test-Path (appdir 'rtools' $global)) {",
-            "   $renvloc = \"$dir\\etc\\Renviron.site\"",
-            "   $rtoolsloc = versiondir 'rtools' (current_version 'rtools' $global) $global",
-            "   if (Test-Path $renvloc) {",
-            "       $renv = Get-Content $renvloc -Encoding ASCII",
-            "   } else {",
-            "       $renv = @()",
-            "   }",
-            "   $rtoolspath = \"$rtoolsloc\\usr\\bin\"",
-            "   if ($renv -cmatch 'PATH=') {",
-            "       $renv = $renv -replace 'PATH=\"(.*)', ('PATH=\"' + $rtoolspath + ';$1')",
-            "   } else {",
-            "       $renv += \"`r`nPATH=\", '\"', $rtoolspath, ';${PATH}\"' -join ''",
-            "   }",
-            "   $renv | Set-Content $renvloc -Encoding ASCII",
-            "}"
-        ]
-    },
     "checkver": {
         "url": "https://cloud.r-project.org/bin/windows/base/",
         "regex": "R-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://cloud.r-project.org/bin/windows/base/R-$version-win.exe",
-        "hash": {
-            "url": "$baseurl/md5sum.R-$version.txt"
+        "architecture": {
+            "64bit": {
+                "url": "https://cloud.r-project.org/bin/windows/base/old/$version/R-$version-win.exe",
+                "hash": {
+                    "url": "$baseurl/md5sum.R-$version.txt"
+                }
+            }
         }
     }
 }

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1.3",
+    "version": "4.2.0",
     "description": "A free software environment for statistical computing and graphics.",
     "homepage": "https://www.r-project.org",
     "license": "GPL-2.0-only",
@@ -15,12 +15,11 @@
         "",
         "Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements."
     ],
-    "url": "https://cloud.r-project.org/bin/windows/base/old/4.1.3/R-4.1.3-win.exe",
-    "hash": "md5:f02b305ebec458e8ba0fea9ebb0cebb3",
+    "url": "https://cloud.r-project.org/bin/windows/base/R-4.2.0-win.exe",
+    "hash": "md5:7f73761dfaab031f1cbb25530c8dba9c",
     "innosetup": true,
     "architecture": {
         "64bit": {
-            "pre_install": "Rename-Item \"$dir\\bin\\R,2.exe\" 'R.exe'",
             "bin": [
                 "bin\\x64\\R.exe",
                 "bin\\x64\\Rcmd.exe",
@@ -31,22 +30,6 @@
             "shortcuts": [
                 [
                     "bin\\x64\\Rgui.exe",
-                    "R"
-                ]
-            ]
-        },
-        "32bit": {
-            "pre_install": "Rename-Item \"$dir\\bin\\R,1.exe\" 'R.exe'",
-            "bin": [
-                "bin\\i386\\R.exe",
-                "bin\\i386\\Rcmd.exe",
-                "bin\\i386\\Rgui.exe",
-                "bin\\i386\\Rscript.exe",
-                "bin\\i386\\Rterm.exe"
-            ],
-            "shortcuts": [
-                [
-                    "bin\\i386\\Rgui.exe",
                     "R"
                 ]
             ]
@@ -75,13 +58,13 @@
         ]
     },
     "checkver": {
-        "url": "https://cloud.r-project.org/bin/windows/base/md5sum.txt",
+        "url": "https://cloud.r-project.org/bin/windows/base/",
         "regex": "R-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://cloud.r-project.org/bin/windows/base/old/$version/R-$version-win.exe",
+        "url": "https://cloud.r-project.org/bin/windows/base/R-$version-win.exe",
         "hash": {
-            "url": "$baseurl/md5sum.txt"
+            "url": "$baseurl/md5sum.R-$version.txt"
         }
     }
 }

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -79,7 +79,7 @@
         "regex": "R-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://cloud.r-project.org/bin/windows/base/R-$version-win.exe",
+        "url": "https://cloud.r-project.org/bin/windows/base/old/$version/R-$version-win.exe",
         "hash": {
             "url": "$baseurl/md5sum.txt"
         }

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -15,7 +15,7 @@
         "",
         "Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements."
     ],
-    "url": "https://cloud.r-project.org/bin/windows/base/R-4.1.3-win.exe",
+    "url": "https://cloud.r-project.org/bin/windows/base/old/4.1.3/R-4.1.3-win.exe",
     "hash": "md5:f02b305ebec458e8ba0fea9ebb0cebb3",
     "innosetup": true,
     "architecture": {

--- a/bucket/rtools.json
+++ b/bucket/rtools.json
@@ -1,76 +1,50 @@
 {
-    "version": "4.0.20220206",
+    "version": "4.2.5168.5107",
     "description": "Tools for building packages for R under Microsoft Windows, or for building R itself.",
     "homepage": "https://cloud.r-project.org/bin/windows/Rtools",
     "license": "BSD-3-Clause",
-    "notes": "For R 3.3.x to 3.6.x, please use 'versions/rtools35'.",
+    "notes": [
+        "For R 3.3.x to 3.6.x, please use 'versions/rtools35'.",
+        "For R 4.0.x to 4.1.x, please use 'versions/rtools40'."
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/r-windows/rtools-installer/releases/download/2022-02-06/rtools40-x86_64.exe",
-            "hash": "6f6b363ee7c7e58aaa51e58f37f910226e60f0dfd47417106250b5ce4d1c2727"
+            "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools42/files/rtools42-5168-5107.exe",
+            "hash": "f649229c94d4bf7f82b42856559a8e54e7b1962fd80e4979fba884044cc46c96"
         }
     },
     "innosetup": true,
     "installer": {
         "script": [
-            "'r', 'mro' | ForEach-Object {",
-            "   if ((Select-CurrentVersion $_ $global) -match '^4') {",
-            "       $renvloc = (versiondir $_ (Select-CurrentVersion $_ $global) $global) + '\\etc\\Renviron.site'",
-            "       if (Test-Path $renvloc) {",
-            "           $renv = Get-Content $renvloc -Encoding ASCII",
-            "       } else {",
-            "           $renv = @()",
-            "       }",
-            "       $rtoolspath = \"$dir\\usr\\bin\"",
-            "       if ($renv -cmatch 'PATH=') {",
-            "           $renv = $renv -replace 'PATH=\"(.*)', ('PATH=\"' + $rtoolspath + ';$1')",
-            "       } else {",
-            "           $renv += \"`r`nPATH=\", '\"', $rtoolspath, ';${PATH}\"' -join ''",
-            "       }",
-            "       $renv | Set-Content $renvloc -Encoding ASCII",
-            "   }",
-            "}",
-            "if (Test-Path 'C:\\rtools40') {",
-            "   if ($null -eq (Get-Item 'C:\\rtools40').LinkType) {",
-            "       Rename-Item -Path 'C:\\rtools40' -NewName 'rtools40.old' -Force",
+            "if (Test-Path 'C:\\rtools42') {",
+            "   if ($null -eq (Get-Item 'C:\\rtools42').LinkType) {",
+            "       Rename-Item -Path 'C:\\rtools42' -NewName 'rtools42.old' -Force",
             "   } else {",
-            "       Remove-Item -Path 'C:\\rtools40' -Force",
+            "       Remove-Item -Path 'C:\\rtools42' -Force",
             "   }",
             "}",
-            "New-Item -Path 'C:\\rtools40' -Target \"$dir\" -ItemType Junction | Out-Null"
+            "New-Item -Path 'C:\\rtools42' -Target \"$dir\" -ItemType Junction | Out-Null"
         ]
     },
     "uninstaller": {
         "script": [
-            "'r', 'mro' | ForEach-Object {",
-            "   if ((Select-CurrentVersion $_ $global) -match '^4') {",
-            "       $renvloc = (versiondir $_ (Select-CurrentVersion $_ $global) $global) + '\\etc\\Renviron.site'",
-            "       if (Test-Path $renvloc) {",
-            "           $renv = Get-Content $renvloc -Encoding ASCII",
-            "       } else {",
-            "           $renv = @()",
-            "       }",
-            "       $renv = $renv -replace '[^;\"]*rtools.*?;', ''",
-            "       $renv | Set-Content $renvloc -Encoding ASCII",
-            "   }",
+            "if ((Test-Path 'C:\\rtools42') -and ($null -ne (Get-Item 'C:\\rtools42').LinkType)) {",
+            "   Remove-Item -Path 'C:\\rtools42' -Force",
             "}",
-            "if ((Test-Path 'C:\\rtools40') -and ($null -ne (Get-Item 'C:\\rtools40').LinkType)) {",
-            "   Remove-Item -Path 'C:\\rtools40' -Force",
-            "}",
-            "if (Test-Path 'C:\\rtools40.old') {",
-            "   Rename-Item -Path 'C:\\rtools40.old' -NewName 'rtools40' -Force",
+            "if (Test-Path 'C:\\rtools42.old') {",
+            "   Rename-Item -Path 'C:\\rtools42.old' -NewName 'rtools42' -Force",
             "}"
         ]
     },
     "checkver": {
-        "github": "https://github.com/r-windows/rtools-installer",
-        "regex": "/tag/(\\d+)-(\\d+)-(\\d+)",
-        "replace": "4.0.${1}${2}${3}"
+        "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools42/files/",
+        "regex": ">rtools42\\-(\\d+)\\-(\\d+).exe<",
+        "replace": "4.2.${1}.${2}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/r-windows/rtools-installer/releases/download/$match1-$match2-$match3/rtools40-x86_64.exe"
+                "url": "https://cloud.r-project.org/bin/windows/Rtools/rtools42/files/rtools42-$match1-$match2.exe"
             }
         }
     }


### PR DESCRIPTION
~The existing 4.1.3-win.exe link doesn't work (try it). This is the correct one.~

Update R and RTools to 4.2.x

- Closes #3532
- Closes #3544

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
