### PR TITLE
evans: Update to version 0.10.6, fix autoupdate

### DIFF
--- a/bucket/evans.json
+++ b/bucket/evans.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.10.4",
+    "version": "0.10.6",
     "description": "More expressive gRPC client",
     "homepage": "https://evans.syfm.me",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ktr0731/evans/releases/download/0.10.4/evans_windows_amd64.tar.gz",
-            "hash": "52cbb39e17973a8bdd38445e625a30d60d7674aeb21da944ca3256ee774b1650"
+            "url": "https://github.com/ktr0731/evans/releases/download/v0.10.6/evans_windows_amd64.tar.gz",
+            "hash": "05eec7e101575c751308ee4f04bb2b3a948ea3382f527dff4bd7b79ff625201c"
         },
         "32bit": {
-            "url": "https://github.com/ktr0731/evans/releases/download/0.10.4/evans_windows_386.tar.gz",
-            "hash": "147d47c7b361a137c0a6e52b41d5803c547f49df24308db6480cc798b2513e98"
+            "url": "https://github.com/ktr0731/evans/releases/download/v0.10.6/evans_windows_386.tar.gz",
+            "hash": "6462500b252f75c3567098235d60350f360865edab600b41487f6f5707357e81"
         }
     },
     "bin": "evans.exe",
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ktr0731/evans/releases/download/$version/evans_windows_amd64.tar.gz"
+                "url": "https://github.com/ktr0731/evans/releases/download/v$version/evans_windows_amd64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/ktr0731/evans/releases/download/$version/evans_windows_386.tar.gz"
+                "url": "https://github.com/ktr0731/evans/releases/download/v$version/evans_windows_386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update - `$version` --> `v$version`: https://github.com/ScoopInstaller/Main/runs/6207462521?check_suite_focus=true#step:3:242

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
