### PR TITLE
clink-flex-prompt: Persist config files

### DIFF
--- a/bucket/clink-flex-prompt.json
+++ b/bucket/clink-flex-prompt.json
@@ -8,6 +8,10 @@
     },
     "url": "https://github.com/chrisant996/clink-flex-prompt/releases/download/v0.9/clink-flex-prompt-0.9.zip",
     "hash": "6dcfac3805c334699cc65998913ba9c711e17ee015b258ea3618cd004d90da6d",
+    "pre_install": [
+        "ensure \"$persist_dir\" | Out-Null",
+        "Get-ChildItem \"$persist_dir\\*\" flexprompt_*config.lua | Copy-Item -Destination \"$dir\" -ErrorAction SilentlyContinue"
+    ],
     "installer": {
         "script": [
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
@@ -21,6 +25,7 @@
     },
     "uninstaller": {
         "script": [
+            "Get-ChildItem \"$dir\\*\" flexprompt_*config.lua | Copy-Item -Destination \"$persist_dir\" -ErrorAction SilentlyContinue",
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
             "   clink uninstallscripts \"$dir\"",
             "} elseif ($Env:CMDER_ROOT) {",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3537

> Moved the flexprompt_autoconfig.lua file to the profile directory (unless one already exists in the script directory).
> 
> https://github.com/chrisant996/clink-flex-prompt/releases/tag/v0.9

should the configfiles (flexprompt_*config.lua) be created directly in the $dir(script dir)?

```
pre_install: [
"ensure \"$persist_dir\" | Out-Null",
"if (!(Test-Path \"$persist_dir\\flexprompt_autoconfig.lua\")) { New-Item -Path \"$dir\\flexprompt_autoconfig.lua\" -Force -ErrorAction SilentlyContinue | Out-Null }",
"if (!(Test-Path \"$persist_dir\\flexprompt_config.lua\")) { New-Item -Path \"$dir\\flexprompt_config.lua\" -Force -ErrorAction SilentlyContinue | Out-Null }"
],
...
"persist": [
"flexprompt_autoconfig.lua",
"flexprompt_config.lua"
]
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
