### PR TITLE
added retroarch and retroarch nightly

### DIFF
--- a/bucket/retroarch-nightly.json
+++ b/bucket/retroarch-nightly.json
@@ -1,0 +1,27 @@
+{
+    "version": "nightly",
+    "description": "RetroArch is a frontend for emulators, game engines and media players.",
+    "homepage": "https://www.retroarch.com/",
+    "license": "GPL-3.0",  
+    "architecture": {
+        "64bit": {
+            "url": "http://buildbot.libretro.com/nightly/windows/x86_64/RetroArch.7z",
+            "hash": "3b48f22a4ea1ecf65259e4f93ad12500042adb461690aa34d23f909242465f31"
+        },
+        "32bit": {
+            "url": "http://buildbot.libretro.com/nightly/windows/x86/RetroArch.7z",
+            "hash": "d9ab95f0038645e20924acd022bcc11236323192bac243dc07afb274bce954da",
+        }
+    },              
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://buildbot.libretro.com/nightly/windows/x86_64/RetroArch_update.7z",
+
+            },
+            "32bit": {
+                "url": "http://buildbot.libretro.com/nightly/windows/x86/RetroArch_update.7z"
+            }            
+        }
+    }
+}

--- a/bucket/retroarch.json
+++ b/bucket/retroarch.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.10.3",
+    "description": "RetroArch is a frontend for emulators, game engines and media players.",
+    "homepage": "https://www.retroarch.com/",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "http://buildbot.libretro.com/stable/1.10.3/windows/x86_64/RetroArch.7z",
+            "hash": "3b48f22a4ea1ecf65259e4f93ad12500042adb461690aa34d23f909242465f31"
+        },
+        "32bit": {
+            "url": "http://buildbot.libretro.com/stable/1.10.3/windows/x86/RetroArch.7z",
+            "hash": "d9ab95f0038645e20924acd022bcc11236323192bac243dc07afb274bce954da"
+        }
+    },               
+    "checkver": {
+        "github": "https://github.com/libretro/RetroArch",
+    },    
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://buildbot.libretro.com/stable/$version/windows/x86_64/RetroArch.7z",
+
+            },
+            "32bit": {
+                "url": "http://buildbot.libretro.com/stable/$version/windows/x86/RetroArch.7z"
+            },
+    "post_install": [
+        "Start-Process \"https://ra-link.web.app/r\""
+            ],                         
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
We have started to add RetroArch to do relevant package managers, started from WinGet(currently not merged). This changes includes RetroArch and RetroArch as separate downloadble. I also added ` "post_install": [
        "Start-Process \"https://ra-link.web.app/r\"" ` I am expecting when update performed it will redirect to our blog post where we explain what is included in the update. I tested on after installation section and it is working.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
