### PR TITLE
sccache: Update to version 0.3.0

### DIFF
--- a/bucket/sccache.json
+++ b/bucket/sccache.json
@@ -16,7 +16,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/mozilla/sccache/releases/download/v$version/sccache-v$version-x86_64-pc-windows-msvc.tar.gz",
-                "extract_dir": "sccache-$version-x86_64-pc-windows-msvc"
+                "extract_dir": "sccache-v$version-x86_64-pc-windows-msvc"
             }
         },
         "hash": {

--- a/bucket/sccache.json
+++ b/bucket/sccache.json
@@ -11,16 +11,16 @@
         }
     },
     "bin": "sccache.exe",
-    "checkver": {
-        "url": "https://github.com/mozilla/sccache/releases",
-        "regex": "sccache-v([\\d.]+)-x86_64-pc-windows"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mozilla/sccache/releases/download/v$version/sccache-v$version-x86_64-pc-windows-msvc.tar.gz",
-                "extract_dir": "sccache-v$version-x86_64-pc-windows-msvc"
+                "url": "https://github.com/mozilla/sccache/releases/download/$version/sccache-$version-x86_64-pc-windows-msvc.tar.gz",
+                "extract_dir": "sccache-$version-x86_64-pc-windows-msvc"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/sccache.json
+++ b/bucket/sccache.json
@@ -1,25 +1,25 @@
 {
-    "version": "0.2.14",
+    "version": "0.2.15",
     "description": "Shared compilation cache used as a compiler wrapper to avoid compilation when possible, storing a cache in a remote storage.",
     "homepage": "https://github.com/mozilla/sccache",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mozilla/sccache/releases/download/0.2.14/sccache-0.2.14-x86_64-pc-windows-msvc.tar.gz",
-            "hash": "ba6bf184d2b0a78978629aaef0d9fe3ca57923e228d949b1932ec1a91ab4ceac",
-            "extract_dir": "sccache-0.2.14-x86_64-pc-windows-msvc"
+            "url": "https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "3dfecdbb85561c55e899d3ad039c671f806d283c49da0721c2ef5c1310d87965",
+            "extract_dir": "sccache-v0.2.15-x86_64-pc-windows-msvc"
         }
     },
     "bin": "sccache.exe",
     "checkver": {
         "url": "https://github.com/mozilla/sccache/releases",
-        "regex": "sccache-([\\d.]+)-x86_64-pc-windows"
+        "regex": "sccache-v([\\d.]+)-x86_64-pc-windows"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mozilla/sccache/releases/download/$version/sccache-$version-x86_64-pc-windows-msvc.tar.gz",
-                "extract_dir": "sccache-$version-x86_64-pc-windows-msvc"
+                "url": "https://github.com/mozilla/sccache/releases/download/v$version/sccache-v$version-x86_64-pc-windows-msvc.tar.gz",
+                "extract_dir": "sccache-v$version-x86_64-pc-windows-msvc"
             }
         }
     }

--- a/bucket/sccache.json
+++ b/bucket/sccache.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.2.15",
+    "version": "0.3.0",
     "description": "Shared compilation cache used as a compiler wrapper to avoid compilation when possible, storing a cache in a remote storage.",
     "homepage": "https://github.com/mozilla/sccache",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mozilla/sccache/releases/download/v0.2.15/sccache-v0.2.15-x86_64-pc-windows-msvc.tar.gz",
-            "hash": "3dfecdbb85561c55e899d3ad039c671f806d283c49da0721c2ef5c1310d87965",
-            "extract_dir": "sccache-v0.2.15-x86_64-pc-windows-msvc"
+            "url": "https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "f25e927584d79d0d5ad489e04ef01b058dad47ef2c1633a13d4c69dfb83ba2be",
+            "extract_dir": "sccache-v0.3.0-x86_64-pc-windows-msvc"
         }
     },
     "bin": "sccache.exe",

--- a/bucket/sccache.json
+++ b/bucket/sccache.json
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mozilla/sccache/releases/download/$version/sccache-$version-x86_64-pc-windows-msvc.tar.gz",
+                "url": "https://github.com/mozilla/sccache/releases/download/v$version/sccache-v$version-x86_64-pc-windows-msvc.tar.gz",
                 "extract_dir": "sccache-$version-x86_64-pc-windows-msvc"
             }
         },


### PR DESCRIPTION
This PR updates the version of sccache from v0.2.14, released on 2020-12-22, to v0.2.15, released on 2021-01-13.

There will likely be a PR soon for v0.3.0, but prebuilt binaries are not yet available on the GitHub release for that.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
