### PR TITLE
trufflehog: Add version 3.4.3

### DIFF
--- a/bucket/trufflehog.json
+++ b/bucket/trufflehog.json
@@ -18,7 +18,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v$version/trufflehog_$version_checksums.txt"
+            "url": "$baseurl/trufflehog_$version_checksums.txt"
         }
     }
 }

--- a/bucket/trufflehog.json
+++ b/bucket/trufflehog.json
@@ -1,0 +1,24 @@
+{
+    "version": "3.4.3",
+    "description": "Find leaked credentials",
+    "homepage": "https://github.com/trufflesecurity/trufflehog",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v3.4.3/trufflehog_3.4.3_windows_amd64.tar.gz",
+            "hash": "e10b28dfc388d0ba8bdb6e84187f6b90ce3b86238f61f31bec2c07394876d895"
+        }
+    },
+    "bin": "trufflehog.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v$version/trufflehog_$version_windows_amd64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/trufflesecurity/trufflehog/releases/download/v$version/trufflehog_$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Add TruffleHog (utility to find leaked credentials).

More info: https://github.com/trufflesecurity/trufflehog

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
