### PR TITLE
fix sdkmanager path

### DIFF
--- a/bucket/android-clt.json
+++ b/bucket/android-clt.json
@@ -14,7 +14,7 @@
         "    New-Item \"$dir\\platform-tools\" -ItemType Junction -Target \"$(appdir adb $global)\\current\\platform-tools\" | Out-Null",
         "}"
     ],
-    "env_add_path": "cmdline-tools\\bin",
+    "env_add_path": "cmdline-tools\\latest\\bin",
     "env_set": {
         "ANDROID_SDK_ROOT": "$dir"
     },


### PR DESCRIPTION
https://developer.android.com/studio/command-line/sdkmanager
"The sdkmanager tool is provided in the Android SDK Tools package (25.2.3 and higher) and is located in android_sdk/cmdline-tools/latest/bin/."

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
