### PR TITLE
procs: Update to version 0.12.1, fix autoupdate

### DIFF
--- a/bucket/procs.json
+++ b/bucket/procs.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "A modern replacement for ps(1)",
     "homepage": "https://github.com/dalance/procs",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dalance/procs/releases/download/v0.12.1/procs-v0.12.1-x86_64-win.zip",
-            "hash": "0ccd5e8e2f55244c602a705deafc514cae4b0847deacf67eebdb74f54691475d",
+            "url": "https://github.com/dalance/procs/releases/download/v0.12.2/procs-v0.12.2-x86_64-windows.zip",
+            "hash": "e313abc8d56af2640ec3e6e83f281833cad862db665fba5054e914bfe3540047",
             "extract_dir": "target\\x86_64-pc-windows-msvc\\release"
         }
     },
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/dalance/procs/releases/download/v$version/procs-v$version-x86_64-win.zip"
+                "url": "https://github.com/dalance/procs/releases/download/v$version/procs-v$version-x86_64-windows.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Main/runs/6366361112?check_suite_focus=true#step:3:266

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
