### PR TITLE
algernon: Update to version 1.13.0, fix autoupdate

### DIFF
--- a/bucket/algernon.json
+++ b/bucket/algernon.json
@@ -1,15 +1,15 @@
 {
-    "version": "1.12.14",
+    "version": "1.13.0",
     "description": "Small self-contained pure-Go web server with Lua, Markdown, HTTP/2, QUIC, Redis and PostgreSQL support",
     "homepage": "https://algernon.roboticoverlords.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/xyproto/algernon/releases/download/1.12.14/algernon-1.12.14-windows.zip",
-            "hash": "c0a1e05ed3178585221fe79d11307eee96f59ce0b1caad26dc1d2ab6ddd29379"
+            "url": "https://github.com/xyproto/algernon/releases/download/v1.13.0/algernon-1.13.0-windows_x86_64_static.zip",
+            "hash": "4919f60d879b2707d6773954c53eeb8ad1ade49cd67a1eedf63d2692a8bcdcfd"
         }
     },
-    "extract_dir": "algernon-1.12.14",
+    "extract_dir": "algernon-1.13.0-windows_x86_64_static",
     "bin": "algernon.exe",
     "checkver": {
         "github": "https://github.com/xyproto/algernon"
@@ -17,9 +17,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/xyproto/algernon/releases/download/$version/algernon-$version-windows.zip"
+                "url": "https://github.com/xyproto/algernon/releases/download/v$version/algernon-$version-windows_x86_64_static.zip"
             }
         },
-        "extract_dir": "algernon-$version"
+        "extract_dir": "algernon-$version-windows_x86_64_static"
     }
 }

--- a/bucket/algernon.json
+++ b/bucket/algernon.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/xyproto/algernon/releases/download/v1.13.0/algernon-1.13.0-windows_x86_64_static.zip",
-            "hash": "4919f60d879b2707d6773954c53eeb8ad1ade49cd67a1eedf63d2692a8bcdcfd"
+            "hash": "4919f60d879b2707d6773954c53eeb8ad1ade49cd67a1eedf63d2692a8bcdcfd",
+            "extract_dir": "algernon-1.13.0-windows_x86_64_static"
         }
     },
-    "extract_dir": "algernon-1.13.0-windows_x86_64_static",
     "bin": "algernon.exe",
     "checkver": {
         "github": "https://github.com/xyproto/algernon"
@@ -17,9 +17,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/xyproto/algernon/releases/download/v$version/algernon-$version-windows_x86_64_static.zip"
+                "url": "https://github.com/xyproto/algernon/releases/download/v$version/algernon-$version-windows_x86_64_static.zip",
+                "extract_dir": "algernon-$version-windows_x86_64_static"
             }
-        },
-        "extract_dir": "algernon-$version-windows_x86_64_static"
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in released file name and tag with 'v': https://github.com/ScoopInstaller/Main/runs/6436788672?check_suite_focus=true#step:3:200

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
