### PR TITLE
azcopy: update 64 bits hash

### DIFF
--- a/bucket/azcopy.json
+++ b/bucket/azcopy.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://aka.ms/downloadazcopy-v10-windows/#dl.zip",
-            "hash": "dab9d075b078da04b381f45459ebce87f147b8134fb86cb896463290cd87afa4",
+            "hash": "65d6699618e7e7d13525a5e9b9c2598a6051b7710e722345f54339faf690efa0",
             "extract_dir": "azcopy_windows_amd64_10.15.0"
         },
         "32bit": {


### PR DESCRIPTION
Updated 64 bits version hash (32 bit hash is ok)

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
