### PR TITLE
ccache: Update to version 4.6.1, fix autoupdate

### DIFF
--- a/bucket/ccache.json
+++ b/bucket/ccache.json
@@ -1,18 +1,18 @@
 {
-    "version": "4.6",
+    "version": "4.6.1",
     "description": "Compiler cache to speed up recompilation by caching previous compilations and detecting when the same compilation is being done again.",
     "homepage": "https://ccache.dev",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ccache/ccache/releases/download/v4.6/ccache-4.6-windows-64.zip",
-            "hash": "d7b4e8c89db51b044711590b3fbd238e57951fe91b30df197e4d7c00279ef78d",
-            "extract_dir": "ccache-4.6-windows-64"
+            "url": "https://github.com/ccache/ccache/releases/download/v4.6.1/ccache-4.6.1-windows-x86_64.zip",
+            "hash": "a6c6311973aa3d2aae22424895f2f968e5d661be003b25f1bd854a5c0cd57563",
+            "extract_dir": "ccache-4.6.1-windows-x86_64"
         },
         "32bit": {
-            "url": "https://github.com/ccache/ccache/releases/download/v4.6/ccache-4.6-windows-32.zip",
-            "hash": "aff5cca6d775b48d8fb46975e1529484049a05a15f7e6268feb2234c6c7cbf31",
-            "extract_dir": "ccache-4.6-windows-32"
+            "url": "https://github.com/ccache/ccache/releases/download/v4.6.1/ccache-4.6.1-windows-i686.zip",
+            "hash": "8489227fbb648ea59f43ea11817e0511224549d722bc1789f348913966d39604",
+            "extract_dir": "ccache-4.6.1-windows-i686"
         }
     },
     "bin": "ccache.exe",
@@ -22,12 +22,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ccache/ccache/releases/download/v$version/ccache-$version-windows-64.zip",
-                "extract_dir": "ccache-$version-windows-64"
+                "url": "https://github.com/ccache/ccache/releases/download/v$version/ccache-$version-windows-x86_64.zip",
+                "extract_dir": "ccache-$version-windows-x86_64"
             },
             "32bit": {
-                "url": "https://github.com/ccache/ccache/releases/download/v$version/ccache-$version-windows-32.zip",
-                "extract_dir": "ccache-$version-windows-32"
+                "url": "https://github.com/ccache/ccache/releases/download/v$version/ccache-$version-windows-i686.zip",
+                "extract_dir": "ccache-$version-windows-i686"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to filename change: https://github.com/ScoopInstaller/Main/runs/6485642942?check_suite_focus=true#step:3:207

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
