### PR TITLE
wrangler2: Add version 2.0.5

### DIFF
--- a/bucket/wrangler2.json
+++ b/bucket/wrangler2.json
@@ -4,10 +4,10 @@
     "homepage": "https://developers.cloudflare.com/workers/tooling/wrangler",
     "license": "MIT|Apache-2.0",
     "depends": "nodejs",
-	"url": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.5.tgz",
-	"hash": "8e5812c17299981b6c9c42352bd3ccb44fa183c54dc05868b133ef499185b1d8",
-	"extract_dir": "package",
-	"post_install": [
+    "url": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.5.tgz",
+    "hash": "8e5812c17299981b6c9c42352bd3ccb44fa183c54dc05868b133ef499185b1d8",
+    "extract_dir": "package",
+    "post_install": [
         "cd $dir",
         "npm install"
     ],

--- a/bucket/wrangler2.json
+++ b/bucket/wrangler2.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.5",
+    "description": "Cloudflare Workers project manager",
+    "homepage": "https://developers.cloudflare.com/workers/tooling/wrangler",
+    "license": "MIT|Apache-2.0",
+    "depends": "nodejs",
+	"url": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.5.tgz",
+	"hash": "8e5812c17299981b6c9c42352bd3ccb44fa183c54dc05868b133ef499185b1d8",
+	"extract_dir": "package",
+	"post_install": [
+        "cd $dir",
+        "npm install"
+    ],
+    "bin": [
+        [
+            "node.exe",
+            "wrangler2",
+            "$dir\\wrangler-dist\\cli.js"
+        ]
+    ],
+    "checkver": {
+        "url": "https://registry.npmjs.org/wrangler/latest",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "url": "https://registry.npmjs.org/wrangler/-/wrangler-$version.tgz"
+    }
+}


### PR DESCRIPTION
Wrangler2 is the v2 family of the Cloudflare tool called "wrangler". It is not the same codebase and is maintained seperately, hence I would propose to keep the original "wrangler" for now. [List of differences](https://developers.cloudflare.com/workers/wrangler/compare-v1-v2/)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
