### PR TITLE
megatools: Update to v1.11.0.20220519, fix checkver

### DIFF
--- a/bucket/megatools.json
+++ b/bucket/megatools.json
@@ -1,47 +1,38 @@
 {
-    "version": "1.10.2",
+    "version": "1.11.0.20220519",
     "description": "Collection of programs for accessing Mega.nz service from a command line.",
     "homepage": "https://megatools.megous.com/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://megatools.megous.com/builds/megatools-1.10.2-win64.zip",
-            "hash": "0c2dc2bd509ca739ca7d734f381930a3c8c58c5ea4b385d408c775c4082aebd9",
-            "extract_dir": "megatools-1.10.2-win64"
+            "url": "https://megatools.megous.com/builds/builds/megatools-1.11.0.20220519-win64.zip",
+            "hash": "3588d85606fec96c7477eafaf154695161025e29fa6bdcfdf827a14b3f1d4501",
+            "extract_dir": "megatools-1.11.0.20220519-win64"
         },
         "32bit": {
-            "url": "https://megatools.megous.com/builds/megatools-1.10.2-win32.zip",
-            "hash": "2724dfbc91c764540b3d3b12261c11f74f706b40b114639472388edef0743069",
-            "extract_dir": "megatools-1.10.2-win32"
+            "url": "https://megatools.megous.com/builds/builds/megatools-1.11.0.20220519-win32.zip",
+            "hash": "6779299eb778354b0b38809d8090bbdf5c6fcc9e7f7a96c9b4d279742351f865",
+            "extract_dir": "megatools-1.11.0.20220519-win32"
         }
     },
     "bin": [
-        "megacopy.exe",
-        "megadf.exe",
-        "megadl.exe",
-        "megaget.exe",
-        "megals.exe",
-        "megamkdir.exe",
-        "megaput.exe",
-        "megareg.exe",
-        "megarm.exe"
+        "megatools.exe"
     ],
     "persist": "mega.ini",
     "checkver": {
-        "url": "https://megatools.megous.com/builds/",
+        "url": "https://megatools.megous.com/builds/builds/",
         "regex": "megatools-([\\d.]+)-win32.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://megatools.megous.com/builds/megatools-$version-win64.zip",
+                "url": "https://megatools.megous.com/builds/builds/megatools-$version-win64.zip",
                 "extract_dir": "megatools-$version-win64"
             },
             "32bit": {
-                "url": "https://megatools.megous.com/builds/megatools-$version-win32.zip",
+                "url": "https://megatools.megous.com/builds/builds/megatools-$version-win32.zip",
                 "extract_dir": "megatools-$version-win32"
             }
-
         }
     }
 }

--- a/bucket/megatools.json
+++ b/bucket/megatools.json
@@ -15,9 +15,7 @@
             "extract_dir": "megatools-1.11.0.20220519-win32"
         }
     },
-    "bin": [
-        "megatools.exe"
-    ],
+    "bin": "megatools.exe",
     "persist": "mega.ini",
     "checkver": {
         "url": "https://megatools.megous.com/builds/builds/",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to check for updates: https://github.com/ScoopInstaller/Main/runs/6521484107?check_suite_focus=true#step:3:262
- Fixed checkver and autoupdate
- Updated bin. Now all commands are in one binary e.g. `megatools ls` rather than `megals`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
