### PR TITLE
curl: (curl-7.83.1_3) corrected "extract_dir" folder name for 32-bit and 64-bit

### DIFF
--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -7,12 +7,12 @@
         "64bit": {
             "url": "https://curl.haxx.se/windows/dl-7.83.1_2/curl-7.83.1_2-win64-mingw.tar.xz",
             "hash": "5e89a7b2eeef4e3f156c5cceeb4c343bd412f711d8aa8a50369a0c757ec05114",
-            "extract_dir": "curl-7.83.1-win64-mingw"
+            "extract_dir": "curl-7.83.1_3-win64-mingw"
         },
         "32bit": {
             "url": "https://curl.haxx.se/windows/dl-7.83.1_2/curl-7.83.1_2-win32-mingw.tar.xz",
             "hash": "a625adfc58f69aa21c6abbb9b9bbd2fe4e593f208464eab0ca51183f5e4a3553",
-            "extract_dir": "curl-7.83.1-win32-mingw"
+            "extract_dir": "curl-7.83.1_3-win32-mingw"
         }
     },
     "bin": "bin\\curl.exe",


### PR DESCRIPTION
This is a fix for error:
    Extracting curl-7.83.1_3-win64-mingw.tar.xz ... Could not find 'curl-7.83.1-win64-mingw'! (error 16)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
