### PR TITLE
tor: Use archive.torproject.org for stable download links

### DIFF
--- a/bucket/tor.json
+++ b/bucket/tor.json
@@ -9,11 +9,11 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://dist.torproject.org/torbrowser/11.0.13/tor-win64-0.4.7.7.zip",
+            "url": "https://archive.torproject.org/tor-package-archive/torbrowser/11.0.13/tor-win64-0.4.7.7.zip",
             "hash": "ba2a8610e13656262bc4b0da33e814f0eff3a32d4e255d4a65a77cd78ed2b3e5"
         },
         "32bit": {
-            "url": "https://dist.torproject.org/torbrowser/11.0.13/tor-win32-0.4.7.7.zip",
+            "url": "https://archive.torproject.org/tor-package-archive/torbrowser/11.0.13/tor-win32-0.4.7.7.zip",
             "hash": "6af0088460d61a5e60971aea94562a3bed2fb597da6b8ac77948a5f6424dfa29"
         }
     },
@@ -48,10 +48,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dist.torproject.org/torbrowser/$matchBrowser/tor-win64-$matchTor.zip"
+                "url": "https://archive.torproject.org/tor-package-archive/torbrowser/$matchBrowser/tor-win64-$matchTor.zip"
             },
             "32bit": {
-                "url": "https://dist.torproject.org/torbrowser/$matchBrowser/tor-win32-$matchTor.zip"
+                "url": "https://archive.torproject.org/tor-package-archive/torbrowser/$matchBrowser/tor-win32-$matchTor.zip"
             }
         }
     }


### PR DESCRIPTION
Looks like using https://archive.torproject.org for stable download links is the way to go ( https://github.com/ScoopInstaller/Main/pull/3514#issuecomment-1103957218 ), here's the corresponding PR, hashes check out on my end. 