### PR TITLE
git-lfs@3.2.0: Fixed Can't create shim

### DIFF
--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -19,6 +19,7 @@
             "hash": "68d525f70d9bdb1e9e64c3fe156c2164739ee4990a2fb37bd9f101d59cd43a61"
         }
     },
+    "extract_dir": "git-lfs-3.2.0",
     "bin": "git-lfs.exe",
     "checkver": {
         "github": "https://github.com/git-lfs/git-lfs"
@@ -34,6 +35,7 @@
         },
         "hash": {
             "url": "$baseurl/sha256sums.asc"
-        }
+        },
+        "extract_dir": "git-lfs-$version"
     }
 }


### PR DESCRIPTION
The new update puts all files in a git-lfs-3.2.0 folder so I just added `extract_dir` property so things work.

Without this, it was causing an error while updating.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
