### PR TITLE
qaac: Update to v2.75, fix autoupdate

### DIFF
--- a/bucket/qaac.json
+++ b/bucket/qaac.json
@@ -1,20 +1,20 @@
 {
-    "version": "2.73",
+    "version": "2.75",
     "description": "A command line AAC/ALAC encoder frontend based on Apple encoder.",
     "homepage": "https://sites.google.com/site/qaacpage/",
     "license": {
         "identifier": "Public Domain,...",
         "url": "https://github.com/nu774/qaac/blob/master/COPYING"
     },
-    "url": "https://github.com/nu774/qaac/releases/download/2.73/qaac_2.73.zip",
-    "hash": "0d658be7531d5a6503003ab7d2fa69714fb70ce9039a19d107c6a52ee5098da3",
+    "url": "https://github.com/nu774/qaac/releases/download/v2.75/qaac_2.75.zip",
+    "hash": "3f6f9cad9b568e4407f152c02e7539ee093bb4fcabf6e59de238c6e773ed0a46",
     "notes": [
         "To fix 'ERROR: CoreAudioToolbox.dll: The specified module could not be found.',",
         "See: https://hydrogenaud.io/index.php?topic=117089.0"
     ],
     "architecture": {
         "64bit": {
-            "extract_dir": "qaac_2.73\\x64",
+            "extract_dir": "qaac_2.75\\x64",
             "bin": [
                 [
                     "qaac64.exe",
@@ -27,7 +27,7 @@
             ]
         },
         "32bit": {
-            "extract_dir": "qaac_2.73\\x86",
+            "extract_dir": "qaac_2.75\\x86",
             "bin": [
                 "qaac.exe",
                 "refalac.exe"
@@ -38,7 +38,7 @@
         "github": "https://github.com/nu774/qaac"
     },
     "autoupdate": {
-        "url": "https://github.com/nu774/qaac/releases/download/$version/qaac_$version.zip",
+        "url": "https://github.com/nu774/qaac/releases/download/v$version/qaac_$version.zip",
         "architecture": {
             "64bit": {
                 "extract_dir": "qaac_$version\\x64"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update (`$version` --> `v$version`): https://github.com/ScoopInstaller/Main/runs/6622488283?check_suite_focus=true#step:3:316

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
