### PR TITLE
avr-gcc: Manually shim avr-gcc-$version.exe

### DIFF
--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -56,7 +56,7 @@
         "}",
         "$shim_exe = \"$scoopdir\\apps\\scoop\\current\\supporting\\shims\\$shim_build\\shim.exe\"",
         "Copy-Item $shim_exe \"$scoopdir\\shims\\avr-gcc-$version.exe\"",
-        "Set-Content \"$scoopdir\\shims\\avr-gcc-$version.shim\" \"path = `\"$dir\\avr-gcc-$version.exe`\"\" -Encoding UTF8"
+        "Set-Content \"$scoopdir\\shims\\avr-gcc-$version.shim\" \"path = `\"$dir\\bin\\avr-gcc-$version.exe`\"\" -Encoding UTF8"
     ],
     "uninstaller": {
         "script": "Remove-Item \"$scoopdir\\shims\\avr-gcc-$version.exe\", \"$scoopdir\\shims\\avr-gcc-$version.shim\""

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -48,18 +48,10 @@
     ],
     "post_install": [
         "# manually shim bin\\avr-gcc-$version.exe",
-        "Write-Host \"Creating shim for 'avr-gcc-$version.exe'.\"",
-        "if($cfg.shim) {",
-        "    $shim_build = $cfg.shim",
-        "} else {",
-        "    $shim_build = 'kiennq'",
-        "}",
-        "$shim_exe = \"$scoopdir\\apps\\scoop\\current\\supporting\\shims\\$shim_build\\shim.exe\"",
-        "Copy-Item $shim_exe \"$scoopdir\\shims\\avr-gcc-$version.exe\"",
-        "Set-Content \"$scoopdir\\shims\\avr-gcc-$version.shim\" \"path = `\"$dir\\bin\\avr-gcc-$version.exe`\"\" -Encoding UTF8"
+        "scoop shim add \"avr-gcc-$version.exe\" \"$dir\\bin\\avr-gcc-$version.exe\""
     ],
     "uninstaller": {
-        "script": "Remove-Item \"$scoopdir\\shims\\avr-gcc-$version.exe\", \"$scoopdir\\shims\\avr-gcc-$version.shim\""
+        "script": "scoop shim rm \"avr-gcc-$version.exe\""
     },
     "checkver": {
         "github": "https://github.com/ZakKemble/avr-gcc-build"

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -48,10 +48,10 @@
     ],
     "post_install": [
         "# manually shim bin\\avr-gcc-$version.exe",
-        "scoop shim add \"avr-gcc-$version.exe\" \"$dir\\bin\\avr-gcc-$version.exe\""
+        "scoop shim add \"avr-gcc-$version\" \"$dir\\bin\\avr-gcc-$version.exe\""
     ],
     "uninstaller": {
-        "script": "scoop shim rm \"avr-gcc-$version.exe\""
+        "script": "scoop shim rm \"avr-gcc-$version\""
     },
     "checkver": {
         "github": "https://github.com/ZakKemble/avr-gcc-build"

--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -24,7 +24,6 @@
         "bin\\avr-cpp.exe",
         "bin\\avr-elfedit.exe",
         "bin\\avr-g++.exe",
-        "bin\\avr-gcc-11.1.0.exe",
         "bin\\avr-gcc-ar.exe",
         "bin\\avr-gcc-nm.exe",
         "bin\\avr-gcc-ranlib.exe",
@@ -47,6 +46,21 @@
         "bin\\avr-strings.exe",
         "bin\\avr-strip.exe"
     ],
+    "post_install": [
+        "# manually shim bin\\avr-gcc-$version.exe",
+        "Write-Host \"Creating shim for 'avr-gcc-$version.exe'.\"",
+        "if($cfg.shim) {",
+        "    $shim_build = $cfg.shim",
+        "} else {",
+        "    $shim_build = 'kiennq'",
+        "}",
+        "$shim_exe = \"$scoopdir\\apps\\scoop\\current\\supporting\\shims\\$shim_build\\shim.exe\"",
+        "Copy-Item $shim_exe \"$scoopdir\\shims\\avr-gcc-$version.exe\"",
+        "Set-Content \"$scoopdir\\shims\\avr-gcc-$version.shim\" \"path = `\"$dir\\avr-gcc-$version.exe`\"\" -Encoding UTF8"
+    ],
+    "uninstaller": {
+        "script": "Remove-Item \"$scoopdir\\shims\\avr-gcc-$version.exe\", \"$scoopdir\\shims\\avr-gcc-$version.shim\""
+    },
     "checkver": {
         "github": "https://github.com/ZakKemble/avr-gcc-build"
     },


### PR DESCRIPTION
* Fixes #3623

* Both `avr-gcc.exe` and `avr-gcc-$version.exe` exists in the package.
   Although they are the same thing (SHA-256 is the same), I think `avr-gcc-$version.exe` exists for some reason.
  We should keep it as it is, rather than just ignoring `avr-gcc-$version.exe`.