### PR TITLE
forcebindip: Add version 1.32

### DIFF
--- a/bucket/forcebindip.json
+++ b/bucket/forcebindip.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.32",
+    "description": "Bind any Windows application to a specific interface or IP address.",
+    "homepage": "https://r1ch.net/projects/forcebindip",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://r1ch.net/projects/forcebindip"
+    },
+    "notes": [
+        "Even if your OS is 64 bit, many applications are still 32 bit.",
+        "Use 'ForceBindIP' with 32 bit applications, and 'ForceBindIP64' with 64 bit applications."
+    ],
+    "url": "https://r1ch.net/assets/forcebindip/ForceBindIP-1.32.zip",
+    "hash": "9e52a88262093d3a50c19a5b46ecc22d9f4a95bcc7c2e968fadd5c5942024b1a",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                "ForceBindIP.exe",
+                "ForceBindIP64.exe"
+            ]
+        },
+        "32bit": {
+            "bin": "ForceBindIP.exe"
+        }
+    }
+}


### PR DESCRIPTION
* closes #1630

[ForceBindIP](https://r1ch.net/projects/forcebindip) is a tool that can bind any Windows application to a specific interface or IP address.

**NOTES**:
* There is an [existing manifest](https://github.com/batkiz/backit/blob/master/bucket/forcebindip.json) in a custom bucket.
* *autoupdate* is not needed because last update was in 2017.