### PR TITLE
ktunnel: Add version 1.4.7

### DIFF
--- a/bucket/ktunnel.json
+++ b/bucket/ktunnel.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.4.7",
+    "description": "CLI tool to expose your local resources to Kubernetes.",
+    "homepage": "https://github.com/omrikiei/ktunnel",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/omrikiei/ktunnel/releases/download/v1.4.7/ktunnel_1.4.7_Windows_x86_64.tar.gz",
+            "hash": "54731ff6aaf9fbfbe4bc484b8626b802a684e9d271f321b0e3a30887ee3bd7e4"
+        }
+    },
+    "bin": "ktunnel.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/omrikiei/ktunnel/releases/download/v$version/ktunnel_$version_Windows_x86_64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
* closes #3626

[KTunnel](https://github.com/omrikiei/ktunnel) is a CLI tool to expose your local resources to Kubernetes.

**NOTES**:
* **persist**: I cannot find any config file being produced after testing the app. Also, according to the app's **usage**, it looks like the app can work fine without any config file.

> https://github.com/omrikiei/ktunnel#-usage-
Expose your local machine as a service in the cluster
This will allow pods in the cluster to access your local web app (listening on port 8000) via http (i.e kubernetes applications can send requests to myapp:8000)
　　ktunnel expose myapp 80:8000
　　ktunnel expose myapp 80:8000 -r #deployment & service will be reused if exists or they will be created

> Inject to an existing deployment
This will currently only work for deployments with 1 replica - it will expose a listening port on the pod through a tunnel to your local machine
　　ktunnel inject deployment mydeployment 3306