### PR TITLE
ect: Update to version 0.9, fix autoupdate

### DIFF
--- a/bucket/ect.json
+++ b/bucket/ect.json
@@ -1,21 +1,20 @@
 {
-    "version": "0.8.3",
+    "version": "0.9",
     "description": "Fast and effective C++ file optimizer.",
     "homepage": "https://github.com/fhanau/Efficient-Compression-Tool",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fhanau/Efficient-Compression-Tool/releases/download/v0.8.3/ect-0.8.3-Win64.exe.zip",
-            "hash": "EE310F0EDE7BF281859694C6472C970580610819FBF06A17CCA244668548C07D"
+            "url": "https://github.com/fhanau/Efficient-Compression-Tool/releases/download/v0.9/ect-0.9-win64.zip",
+            "hash": "d88af074ff14515bf047feb4040ef62886d51eec528f007035bcd56748361569"
         }
     },
     "bin": "ect.exe",
-    "pre_install": "Rename-Item \"$dir\\ect-$version.exe\" \"$dir\\ect.exe\"",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/fhanau/Efficient-Compression-Tool/releases/download/v$version/ect-$version-Win64.exe.zip"
+                "url": "https://github.com/fhanau/Efficient-Compression-Tool/releases/download/v$version/ect-$version-win64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in download file name: https://github.com/ScoopInstaller/Main/runs/6666958615?check_suite_focus=true#step:3:237

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
