### PR TITLE
vcpkg: Add version 2022-05-05

### DIFF
--- a/bucket/vcpkg.json
+++ b/bucket/vcpkg.json
@@ -1,0 +1,16 @@
+{
+    "version": "2022-05-05",
+    "description": "C/C++ dependency manager from Microsoft For all platforms, buildsystems, and workflows",
+    "homepage": "https://vcpkg.io/",
+    "license": "MIT",
+    "url": "https://github.com/microsoft/vcpkg-tool/releases/download/2022-05-05/vcpkg.exe",
+    "hash": "50f50538f014a24bb50f6af07b4b78b15e326882f0dc6adca74e98d236121782",
+    "bin": "vcpkg.exe",
+    "checkver": {
+        "github": "https://github.com/microsoft/vcpkg-tool",
+        "regex": "tree/(\\d{4}-\\d{2}-\\d{2})"
+    },
+    "autoupdate": {
+        "url": "https://github.com/microsoft/vcpkg-tool/releases/download/$version/vcpkg.exe"
+    }
+}


### PR DESCRIPTION
* closes #3633

[vcpkg](https://vcpkg.io/) is a C/C++ dependency manager from Microsoft For all platforms, buildsystems, and workflows.

**NOTES**:
* The app is built in **32-bit**.
* *vcpkg* uses **release dates** for version number, but that doesn't mean they update very frequently. 
Last 3 versions was `2022-03-25`, `2022-03-30` and `2022-05-05`
https://github.com/microsoft/vcpkg-tool/releases/