### PR TITLE
kotlin-native: Update to v1.6.21, fix checkver

### DIFF
--- a/bucket/kotlin-native.json
+++ b/bucket/kotlin-native.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.6.21-349.1",
+    "version": "1.6.21",
     "description": "An LLVM backend for the Kotlin compiler, runtime implementation, and native code generation facility using the LLVM toolchain for native binaries runnable without a virtual machine.",
     "homepage": "https://kotlinlang.org",
     "license": "Apache-2.0",
@@ -9,8 +9,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JetBrains/kotlin/releases/download/v1.6.21/kotlin-native-windows-x86_64-1.6.21-349.1.zip#/dl.zip_",
-            "hash": "9327eb3317ce636c0652b419836c4fffa0654c2bded71aff70c90635d4be4ab7"
+            "url": "https://github.com/JetBrains/kotlin/releases/download/v1.6.21/kotlin-native-windows-x86_64-1.6.21.zip#/dl.zip_",
+            "hash": "ac520bf2f66197fec1ff6c666432cb908bf49e39b9266dd6979fa6e2c0294206"
         }
     },
     "pre_install": [
@@ -33,7 +33,7 @@
     "env_add_path": "bin",
     "checkver": {
         "github": "https://github.com/JetBrains/kotlin",
-        "regex": "windows-x86_64-([\\d.]+-[\\d.]+)\\.zip"
+        "regex": "windows-x86_64-([\\d.\\-]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to update: https://github.com/ScoopInstaller/Main/runs/6722657756?check_suite_focus=true#step:3:252
- Simplifies regex to pick up versions with or without dashes

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
