### PR TITLE
refreshenv: Add version 2019.03.06

### DIFF
--- a/bucket/refreshenv.json
+++ b/bucket/refreshenv.json
@@ -1,0 +1,24 @@
+{
+    "version": "2019.03.06",
+    "description": "Provides a command to refresh environment variables in command prompt (cmd).",
+    "homepage": "https://chocolatey.org/",
+    "license": "Apache-2.0",
+    "url": "https://raw.githubusercontent.com/chocolatey/choco/master/src/chocolatey.resources/redirects/RefreshEnv.cmd",
+    "hash": "9b251737a6b6ace9fde45b64fd653b04575c6416f15112fbe1697a47b14990e6",
+    "bin": "RefreshEnv.cmd",
+    "checkver": {
+        "script": [
+            "# Using script to get version number from date, e.g. 6 Mar, 2019 -> 2019.03.06",
+            "$url = 'https://github.com/chocolatey/choco/commits/master/src/chocolatey.resources/redirects/RefreshEnv.cmd'",
+            "$regex = 'Commits on ([\\w\\s,]+)</h2>'",
+            "$cont = $(Invoke-WebRequest $url).Content",
+            "if(!($cont -match $regex)) { error \"Could match '$regex' on '$url'\"; return }",
+            "$script_ver = $(Get-Date $matches[1]).ToString('yyyy.MM.dd')",
+            "Write-Output $script_ver"
+        ],
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/chocolatey/choco/master/src/chocolatey.resources/redirects/RefreshEnv.cmd"
+    }
+}

--- a/bucket/refreshenv.json
+++ b/bucket/refreshenv.json
@@ -3,13 +3,13 @@
     "description": "Provides a command to refresh environment variables in command prompt (cmd).",
     "homepage": "https://chocolatey.org/",
     "license": "Apache-2.0",
-    "url": "https://raw.githubusercontent.com/chocolatey/choco/master/src/chocolatey.resources/redirects/RefreshEnv.cmd",
+    "url": "https://raw.githubusercontent.com/chocolatey/choco/HEAD/src/chocolatey.resources/redirects/RefreshEnv.cmd",
     "hash": "9b251737a6b6ace9fde45b64fd653b04575c6416f15112fbe1697a47b14990e6",
     "bin": "RefreshEnv.cmd",
     "checkver": {
         "script": [
             "# Using script to get version number from date, e.g. 6 Mar, 2019 -> 2019.03.06",
-            "$url = 'https://github.com/chocolatey/choco/commits/master/src/chocolatey.resources/redirects/RefreshEnv.cmd'",
+            "$url = 'https://github.com/chocolatey/choco/commits/HEAD/src/chocolatey.resources/redirects/RefreshEnv.cmd'",
             "$regex = 'Commits on ([\\w\\s,]+)</h2>'",
             "$cont = $(Invoke-WebRequest $url).Content",
             "if(!($cont -match $regex)) { error \"Could match '$regex' on '$url'\"; return }",
@@ -19,6 +19,6 @@
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/chocolatey/choco/master/src/chocolatey.resources/redirects/RefreshEnv.cmd"
+        "url": "https://raw.githubusercontent.com/chocolatey/choco/HEAD/src/chocolatey.resources/redirects/RefreshEnv.cmd"
     }
 }


### PR DESCRIPTION
[refreshenv](https://github.com/chocolatey/choco/blob/master/src/chocolatey.resources/redirects/RefreshEnv.cmd) is a script that provides a command to **refresh env variables** in command prompt **(cmd)**.

This script was created by the *Chocolatey* team, and it is "shipped with" Chocolatey. (`refreshenv` will be in PATH after you install Chocolatey)

This script is useful for *Scoop* users as well. For packages involving **env_add_path** (e.g. `gcc`, `perl`, `python`, ...), the changes would not be applied in the current session of **cmd**. *refreshenv* can be a solution to this problem.

**NOTES**:
* More information can be found in [this StackOverflow thread](https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w).