### PR TITLE
hledger: Update to version 1.26, fix autoupdate

### DIFF
--- a/bucket/hledger.json
+++ b/bucket/hledger.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.25",
+    "version": "1.26",
     "description": "Lightweight, portable and dependable accounting tools",
     "homepage": "https://hledger.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/simonmichael/hledger/releases/download/1.25/hledger-windows.zip",
-            "hash": "19838b6e732ed10ee88b64aa806247a5c7b7c5d3266d804288972ce588e2e426"
+            "url": "https://github.com/simonmichael/hledger/releases/download/1.26/hledger-windows-x64.zip",
+            "hash": "9a116488f57b9624c3af579519b0f7b691325c64641c7ed915419ffb1fe090c1"
         }
     },
     "bin": [
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/simonmichael/hledger/releases/download/$version/hledger-windows.zip"
+                "url": "https://github.com/simonmichael/hledger/releases/download/$version/hledger-windows-x64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to change in file name: https://github.com/ScoopInstaller/Main/runs/6793470829?check_suite_focus=true#step:3:271

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
