### PR TITLE
hashcat: add a wrapper batch script which will call the executable from the installation folder

### DIFF
--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -3,7 +3,6 @@
     "description": "Advanced password recovery tool",
     "homepage": "https://hashcat.net/hashcat/",
     "license": "MIT",
-    "notes": "This program is used with a batch script as a wrapper. Hascat requires the user to cd into its installation directory. The batch script does that for you, so you need not worry.",
     "architecture": {
         "64bit": {
             "url": "https://hashcat.net/files/hashcat-6.2.5.7z",

--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -10,9 +10,7 @@
         }
     },
     "extract_dir": "hashcat-6.2.5",
-    "pre_install": [
-        "Write-Output \"@echo off`r`npushd $dir`r`nhashcat.exe %*`r`npopd\" > $dir\\hashcat.cmd"
-    ],
+    "pre_install": "Set-Content -Value \"@echo off`r`npushd $dir`r`nhashcat.exe %*`r`npopd\" -Path \"$dir\\hashcat.cmd\"",
     "bin": "hashcat.cmd",
     "checkver": {
         "github": "https://github.com/hashcat/hashcat"

--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -3,7 +3,7 @@
     "description": "Advanced password recovery tool",
     "homepage": "https://hashcat.net/hashcat/",
     "license": "MIT",
-    "notes": "You need to move to the installation folder of hashcat and invoke it from there. Otherwise you'll get this error: ./hashcat.hctune: No such file or directory",
+    "notes": "This program is used with a batch script as a wrapper. Hascat requires the user to cd into its installation directory. The batch script does that for you, so you need not worry.",
     "architecture": {
         "64bit": {
             "url": "https://hashcat.net/files/hashcat-6.2.5.7z",
@@ -11,7 +11,10 @@
         }
     },
     "extract_dir": "hashcat-6.2.5",
-    "bin": "hashcat.exe",
+    "pre_install": [
+        "Write-Output \"@echo off`r`npushd $dir`r`nhashcat.exe %*`r`npopd\" > $dir\\hashcat.cmd"
+    ],
+    "bin": "hashcat.cmd",
     "checkver": {
         "github": "https://github.com/hashcat/hashcat"
     },

--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -3,6 +3,7 @@
     "description": "Advanced password recovery tool",
     "homepage": "https://hashcat.net/hashcat/",
     "license": "MIT",
+    "notes": "You need to move to the installation folder of hashcat and invoke it from there. Otherwise you'll get this error: ./hashcat.hctune: No such file or directory",
     "architecture": {
         "64bit": {
             "url": "https://hashcat.net/files/hashcat-6.2.5.7z",


### PR DESCRIPTION
Relates to #2804 and [hashcat/hashcat/#2403](https://github.com/hashcat/hashcat/issues/2403)

Hashcat cannot be used as a system-wide installed executable. The user needs to cd into the directory hascat binary is in and invoke it from there. Otherwise they will get the following error:

```
./hashcat.hctune: No such file or directory
```