### PR TITLE
pnpm: Add checkver script that checks all release tags

### DIFF
--- a/bucket/pnpm.json
+++ b/bucket/pnpm.json
@@ -14,7 +14,7 @@
         "script": [
             "# Using checkver script to check through all release tags",
             "$url = 'https://api.github.com/repos/pnpm/pnpm/releases'",
-            "$latest_ver = [Version]::new(0,0,0,0) # note: Powershell 5 does not support casting 'float' to 'System.Version'",
+            "$latest_ver = [Version]::new(0,0,0,0) # note: Powershell 5 does not support casting 'int' or 'float' to 'System.Version'",
             "$releases = $(Invoke-WebRequest $url).Content | ConvertFrom-Json",
             "$releases | ForEach-Object {",
             "    if (!($_.tag_name -match '([\\d.]+)')) { return }",

--- a/bucket/pnpm.json
+++ b/bucket/pnpm.json
@@ -11,7 +11,20 @@
     },
     "bin": "pnpm.exe",
     "checkver": {
-        "github": "https://github.com/pnpm/pnpm"
+        "script": [
+            "# Using checkver script to check through all release tags",
+            "$url = 'https://api.github.com/repos/pnpm/pnpm/releases'",
+            "$latest_ver = [Version]::new(0,0,0,0) # note: Powershell 5 does not support casting 'float' to 'System.Version'",
+            "$releases = $(Invoke-WebRequest $url).Content | ConvertFrom-Json",
+            "$releases | ForEach-Object {",
+            "    if (!($_.tag_name -match '([\\d.]+)')) { return }",
+            "    $ver = [Version]::new($matches[1])",
+            "    if ($ver -gt $latest_ver) { $latest_ver = $ver }",
+            "}",
+            "if ($latest_ver -eq [Version]::new(0,0,0,0)) { error \"Could not match version string in '$url'\"; break }",
+            "Write-Output $latest_ver"
+        ],
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/pnpm/pnpm/releases/download/v$version/pnpm-win-x64.exe#/pnpm.exe"


### PR DESCRIPTION
* fixes #3663

* This adds a **checkver script** that checks all release tags, and picks up the latest one (greatest version number).

* I think this is necessary because the "revert" has happened more than once. See [file history](https://github.com/ScoopInstaller/Main/commits/master/bucket/pnpm.json) for example.

* Furthermore, we should probably implement something like this in *Scoop* itself. For example, we can add a **match_all** switch under `checkver` that performs **version comparison** (using Powershell's *System.Version* data type) amongst all regex matches.