### PR TITLE
wasmer: Update manifest

### DIFF
--- a/bucket/wasmer.json
+++ b/bucket/wasmer.json
@@ -15,7 +15,6 @@
     },
     "bin": [
         "bin\\wax.cmd",
-        "bin\\wapm.exe",
         "bin\\wasmer.exe"
     ],
     "innosetup": true,


### PR DESCRIPTION
- Update `bin`

fixes:
```
❯ scoop install wasmer
Installing 'wasmer' (2.3.0) [64bit]
Loading wasmer-windows.exe from cache
Checking hash of wasmer-windows.exe ... ok.
Extracting wasmer-windows.exe ... done.
Linking ~\scoop\apps\wasmer\current => ~\scoop\apps\wasmer\2.3.0
Creating shim for 'wax'.
Creating shim for 'wapm'.
Can't shim 'bin\wapm.exe': File doesn't exist.
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
