### PR TITLE
pacparser: Add version 1.4.0

### DIFF
--- a/bucket/pacparser.json
+++ b/bucket/pacparser.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.4.0",
+    "description": "A library to parse proxy auto-config (PAC) files",
+    "homepage": "https://github.com/manugarg/pacparser",
+    "license": "LGPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/manugarg/pacparser/releases/download/v1.4.0/pacparser-v1.4.0-windows-amd64.zip",
+            "hash": "7c41042d38da3a250067b46263d407efd3ecba4e0ce87d82cfdfb3b965c1f1cd",
+            "extract_dir": "pacparser-v1.4.0-windows-amd64"
+        }
+    },
+    "bin": "pactester.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/manugarg/pacparser/releases/download/v$version/pacparser-v$version-windows-amd64.zip",
+                "extract_dir": "pacparser-v$version-windows-amd64"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add a new app manifest for the [pacparser](https://github.com/manugarg/pacparser) library which also includes a `pactester.exe` command line tool for testing proxy auto-config (PAC) scripts.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
