### PR TITLE
pacproxy: Add version 2.0.5

### DIFF
--- a/bucket/pacproxy.json
+++ b/bucket/pacproxy.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.0.5",
+    "description": "A no-frills local HTTP proxy server powered by a proxy auto-config (PAC) file",
+    "homepage": "https://github.com/williambailey/pacproxy",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/williambailey/pacproxy/releases/download/v2.0.5/pacproxy_2.0.5_windows_amd64.tar.gz",
+            "hash": "53d42fcd456c6c7a35fef258da29d57721a6b4f43cbfe2cf997e877be8e6cad0",
+            "extract_dir": "pacproxy_2.0.5_windows_amd64"
+        },
+        "32bit": {
+            "url": "https://github.com/williambailey/pacproxy/releases/download/v2.0.5/pacproxy_2.0.5_windows_386.tar.gz",
+            "hash": "d9e13027b09c1b9d8b8a154711fd10ffc14b872970fc5926d94ebf7d53f983e8",
+            "extract_dir": "pacproxy_2.0.5_windows_386"
+        }
+    },
+    "bin": "pacproxy.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/williambailey/pacproxy/releases/download/v$version/pacproxy_$version_windows_amd64.tar.gz",
+                "extract_dir": "pacproxy_$version_windows_amd64"
+            },
+            "32bit": {
+                "url": "https://github.com/williambailey/pacproxy/releases/download/v$version/pacproxy_$version_windows_386.tar.gz",
+                "extract_dir": "pacproxy_$version_windows_386"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Add a new app manifest for the [pacproxy](https://github.com/williambailey/pacproxy) tool which is handy when you are working in an environment with many different proxy servers and your applications don't support proxy auto-configuration.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
