### PR TITLE
nu: Update to version 0.6.4

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -1,13 +1,12 @@
 {
-    "version": "0.63.0",
+    "version": "0.64.0",
     "description": "A modern shell written in Rust",
     "homepage": "https://www.nushell.sh",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/nushell/nushell/releases/download/0.63.0/nu_0_63_0_windows.zip",
-            "hash": "8b598022ca31b919ccb10e3468d0b161df24f983e68bd4dbbdcbd35f5207e57e",
-            "extract_dir": "nu_0_63_0_windows\\nushell-0.63.0"
+            "url": "https://github.com/nushell/nushell/releases/download/0.64.0/nu-0.64.0-x86_64-pc-windows-msvc.zip",
+            "hash": "1fbb4df9378d3f27f5eb6e75ebc3820b942f3d1ef458d29629419966559a8c9c"
         }
     },
     "bin": "nu.exe",
@@ -17,8 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/nushell/nushell/releases/download/$version/nu_$underscoreVersion_windows.zip",
-                "extract_dir": "nu_$underscoreVersion_windows\\nushell-$version"
+                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-x86_64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Nushell changed its Windows artifact naming and ZIP content strategy.
This PR adapts the manifest accordingly.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
