### PR TITLE
mosdns: Add version 3.9.0

### DIFF
--- a/bucket/mosdns.json
+++ b/bucket/mosdns.json
@@ -1,0 +1,22 @@
+{
+    "version": "3.9.0",
+    "description": "A DNS forwarder",
+    "homepage": "https://github.com/IrineSistiana/mosdns",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/IrineSistiana/mosdns/releases/download/v3.9.0/mosdns-windows-amd64.zip",
+            "hash": "7c08530870f8ea8b81206e89861ecd228dd6bca118c6197d94b48466757c02ed"
+        }
+    },
+    "bin": "mosdns.exe",
+    "persist": "config.yaml",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/IrineSistiana/mosdns/releases/download/v$version/mosdns-windows-amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add [mosdns](https://github.com/IrineSistiana/mosdns), a DNS forwarder.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
