### PR TITLE
stern@1.21.0: switch from the abandoned repo to the current one

### DIFF
--- a/bucket/stern.json
+++ b/bucket/stern.json
@@ -18,7 +18,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/stern/stern/releases/tag/$version",
+            "url": "https://github.com/stern/stern/releases/tag/v$version",
             "regex": "(?sm)$basename:.*?$sha256"
         }
     }

--- a/bucket/stern.json
+++ b/bucket/stern.json
@@ -16,6 +16,9 @@
             "64bit": {
                 "url": "https://github.com/stern/stern/releases/download/v1.21.0/stern_1.21.0_windows_amd64.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/stern.json
+++ b/bucket/stern.json
@@ -16,10 +16,6 @@
             "64bit": {
                 "url": "https://github.com/stern/stern/releases/download/v1.21.0/stern_1.21.0_windows_amd64.tar.gz"
             }
-        },
-        "hash": {
-            "url": "https://github.com/stern/stern/releases/tag/v$version",
-            "regex": "(?sm)$basename:.*?$sha256"
         }
     }
 }

--- a/bucket/stern.json
+++ b/bucket/stern.json
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/stern/stern/releases/download/v1.21.0/stern_1.21.0_windows_amd64.tar.gz"
+                "url": "https://github.com/stern/stern/releases/download/v$version/stern_$version_windows_amd64.tar.gz"
             }
         },
         "hash": {

--- a/bucket/stern.json
+++ b/bucket/stern.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.11.0",
+    "version": "1.21.0",
     "description": "Multi pod and container log tailing for Kubernetes",
-    "homepage": "https://github.com/wercker/stern",
+    "homepage": "https://github.com/stern/stern",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wercker/stern/releases/download/1.11.0/stern_windows_amd64.exe#/stern.exe",
-            "hash": "75708b9acf6ef0eeffbe1f189402adc0405f1402e6b764f1f5152ca288e3109e"
+            "url": "https://github.com/stern/stern/releases/download/v1.21.0/stern_1.21.0_windows_amd64.tar.gz",
+            "hash": "c3f148576e604b250f4df4769079f7b69f62b2dfcdff10dc5fbd51815c297331"
         }
     },
     "bin": "stern.exe",
@@ -14,11 +14,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/wercker/stern/releases/download/$version/stern_windows_amd64.exe#/stern.exe"
+                "url": "https://github.com/stern/stern/releases/download/v1.21.0/stern_1.21.0_windows_amd64.tar.gz"
             }
         },
         "hash": {
-            "url": "https://github.com/wercker/stern/releases/tag/$version",
+            "url": "https://github.com/stern/stern/releases/tag/$version",
             "regex": "(?sm)$basename:.*?$sha256"
         }
     }


### PR DESCRIPTION
Stern development has moved from https://github.com/wercker/stern to https://github.com/stern/stern. This PR reflects this change.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3697

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
