### PR TITLE
imagemagick@7.1.0-39 Update and fix download urls

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,16 +1,16 @@
 {
-    "version": "7.1.0-37",
+    "version": "7.1.0-39",
     "description": "Create, edit, compose, and convert 200+ of bitmap images formats.",
     "homepage": "https://imagemagick.org/",
     "license": "ImageMagick",
     "architecture": {
         "64bit": {
-            "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-7.1.0-37-Q16-HDRI-x64-dll.exe",
-            "hash": "374a55ea9d3b5fea17058bacb917322f66a45281282d6eeab6e9c5d5989b4e7b"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-39-Q16-HDRI-x64-dll.exe",
+            "hash": "1cc4ee2f612f6c26e340aa1a34b010042c154ef81c810337791c84451eec5a8c"
         },
         "32bit": {
-            "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-7.1.0-37-Q16-HDRI-x86-dll.exe",
-            "hash": "a6a5bf7ae4064ab832c80159c14e93998a5c0d7ed7d5b74f8aa3ee095bbe4b77"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-39-Q16-HDRI-x86-dll.exe",
+            "hash": "b1e8d25bd7dac8b04f34bdb6dcea404b81e46473d50e18510af891f1e02f3d85"
         }
     },
     "innosetup": true,
@@ -26,16 +26,16 @@
         "- 'convert.exe' is deprecated in v7 (it also conflicts with the builtin Windows 'convert' utility). Use 'magick convert ...' instead."
     ],
     "checkver": {
-        "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
+        "url": "https://imagemagick.org/archive/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x64-dll.exe"
+                "url": "https://imagemagick.org/archive/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x64-dll.exe"
             },
             "32bit": {
-                "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x86-dll.exe"
+                "url": "https://imagemagick.org/archive/binaries/ImageMagick-$matchHead$matchTail-Q16-HDRI-x86-dll.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Add version 7.1.0-39 and change download links to correct ones because it looks like urls have changed after looking on imagemagick website download links listed on imagemagick website.

This is new link for download archive with all versions of imagemagick: https://imagemagick.org/archive/binaries/

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #3699 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
