### PR TITLE
imagemagick-lean: fix download urls

### DIFF
--- a/bucket/imagemagick-lean.json
+++ b/bucket/imagemagick-lean.json
@@ -5,12 +5,12 @@
     "license": "ImageMagick",
     "architecture": {
         "64bit": {
-            "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-7.1.0-portable-Q16-HDRI-x64.zip",
-            "hash": "dabffdb5f4fa83b88cbb2c4eb339db4ffecb646cad63870c93d4858ec501feaa"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-portable-Q16-HDRI-x64.zip",
+            "hash": "79eef42ef180c1d6e9ad8e1a3c822410d8aed82231afd3042aebd5d5afebe5a8"
         },
         "32bit": {
-            "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-7.1.0-portable-Q16-HDRI-x86.zip",
-            "hash": "35ca42943cc145d135deaa2b7e3da95ec8521fe39cc43aee0406869217b042bb"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-portable-Q16-HDRI-x86.zip",
+            "hash": "31e11f8b572217eb5abcca8eb2d00337474addf65bb4a79376b0098b97fcd5a0"
         }
     },
     "bin": [
@@ -23,21 +23,21 @@
         "- For appropriate programming DLLs and environment variables, install 'imagemagick' instead."
     ],
     "checkver": {
-        "url": "https://download.imagemagick.org/ImageMagick/download/binaries/?C=N;O=D",
+        "url": "https://imagemagick.org/archive/binaries/?C=N;O=D",
         "regex": "ImageMagick-([\\d.-]+)-portable-Q16-HDRI-x64\\.zip\\.asc"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-$version-portable-Q16-HDRI-x64.zip"
+                "url": "https://imagemagick.org/archive/binaries/ImageMagick-$version-portable-Q16-HDRI-x64.zip"
             },
             "32bit": {
-                "url": "https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-$version-portable-Q16-HDRI-x86.zip"
+                "url": "https://imagemagick.org/archive/binaries/ImageMagick-$version-portable-Q16-HDRI-x86.zip"
             }
         },
         "hash": {
             "mode": "rdf",
-            "url": "https://www.imagemagick.org/download/binaries/digest.rdf"
+            "url": "https://imagemagick.org/archive/binaries/digest.rdf"
         }
     }
 }


### PR DESCRIPTION
Change download links to correct ones because it looks like urls have changed after looking on imagemagick website download links listed on imagemagick website

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
