### PR TITLE
yt-dlp: Persistant configuration file

### DIFF
--- a/bucket/yt-dlp.json
+++ b/bucket/yt-dlp.json
@@ -17,6 +17,12 @@
         }
     },
     "bin": "yt-dlp.exe",
+    "pre_install": [
+        "$manifest.persist | ForEach-Object {",
+        "    if (-not (Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -ItemType file | Out-Null }",
+        "}"
+    ],
+    "persist": "yt-dlp.conf",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/yt-dlp.json
+++ b/bucket/yt-dlp.json
@@ -4,8 +4,7 @@
     "homepage": "https://github.com/yt-dlp/yt-dlp",
     "license": "Unlicense",
     "suggest": {
-        "ffmpeg": "ffmpeg",
-        "vcredist": "extras/vcredist2010"
+        "ffmpeg": "ffmpeg"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

[Configuration file](https://github.com/yt-dlp/yt-dlp#configuration) for yt-dlp can be placed alongside the executable in addition to [youtube-dl's supported locations](https://github.com/ytdl-org/youtube-dl#configuration). This is especially usefull for portable installs like using Scoop. So this PR adds `yt-dlp.conf` as a persistent file

I have also removed `vcredist2010` from dependencies since yt-dlp no longer uses it. Let me know if you'd rather have this in a separate PR