### PR TITLE
zoxide: Update to version 0.8.2 and fix download url

### DIFF
--- a/bucket/zoxide.json
+++ b/bucket/zoxide.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "A faster way to navigate your filesystem",
     "homepage": "https://github.com/ajeetdsouza/zoxide",
     "license": "MIT",
     "notes": "_ZO_DATA_DIR is located at '$env:LOCALAPPDATA\\zoxide' by default",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.8.1/zoxide-v0.8.1-x86_64-pc-windows-msvc.zip",
-            "hash": "285077162f1710ec8831b392798e3c23b944340f2c2bc59dbf6f3c9732080e9f"
+            "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v0.8.2/zoxide-0.8.2-x86_64-pc-windows-msvc.zip",
+            "hash": "36b05197f465bafa631691df2ffcf2732430172a9729212b304a43f581a39d2d"
         }
     },
     "bin": "zoxide.exe",
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-v$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/ajeetdsouza/zoxide/releases/download/v$version/zoxide-$version-x86_64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
zoxide changed its Windows artifact naming in 0.8.2 release.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
