### PR TITLE
grep: Rename binary before shimming

### DIFF
--- a/bucket/grep.json
+++ b/bucket/grep.json
@@ -23,7 +23,7 @@
             "extract_dir": "tools\\install\\grep-windows-3.7"
         }
     },
-    "pre_install": "Move-Item \"$dir\\grep-$version-x64.exe\" \"$dir\\grep.exe\"",
+    "pre_install": "Rename-Item \"$dir\\grep-$version-x64.exe\" grep.exe",
     "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
     "checkver": {
         "url": "https://community.chocolatey.org/packages/grep",

--- a/bucket/grep.json
+++ b/bucket/grep.json
@@ -20,10 +20,10 @@
                     "-F"
                 ]
             ],
-            "extract_dir": "tools\\install\\grep-windows-3.7",
-            "pre_install": "Move-Item \"$dir\\grep-3.7-x64.exe\" \"$dir\\grep.exe\""
+            "extract_dir": "tools\\install\\grep-windows-3.7"
         }
     },
+    "pre_install": "Move-Item \"$dir\\grep-3.7-x64.exe\" \"$dir\\grep.exe\"",
     "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
     "checkver": {
         "url": "https://community.chocolatey.org/packages/grep",
@@ -37,9 +37,9 @@
                     "url": "https://community.chocolatey.org/packages/grep",
                     "regex": "$sha256.*?$basename"
                 },
-                "extract_dir": "tools\\install\\grep-windows-$version",
-                "pre_install": "Move-Item \"$dir\\grep-$version-x64.exe\" \"$dir\\grep.exe\""
+                "extract_dir": "tools\\install\\grep-windows-$version"
             }
-        }
+        },
+        "pre_install": "Move-Item \"$dir\\grep-$version-x64.exe\" \"$dir\\grep.exe\""
     }
 }

--- a/bucket/grep.json
+++ b/bucket/grep.json
@@ -8,22 +8,20 @@
             "url": "https://packages.chocolatey.org/grep.3.7.nupkg",
             "hash": "ec113135322239cd453a290f48fdb1ce6190cdcde162aa8e576d41ff8c606c94",
             "bin": [
+                "grep.exe",
                 [
-                    "grep-3.7-x64.exe",
-                    "grep"
-                ],
-                [
-                    "grep-3.7-x64.exe",
+                    "grep.exe",
                     "egrep",
                     "-E"
                 ],
                 [
-                    "grep-3.7-x64.exe",
+                    "grep.exe",
                     "fgrep",
                     "-F"
                 ]
             ],
-            "extract_dir": "tools\\install\\grep-windows-3.7"
+            "extract_dir": "tools\\install\\grep-windows-3.7",
+            "pre_install": "Move-Item \"$dir\\grep-3.7-x64.exe\" \"$dir\\grep.exe\""
         }
     },
     "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
@@ -39,23 +37,8 @@
                     "url": "https://community.chocolatey.org/packages/grep",
                     "regex": "$sha256.*?$basename"
                 },
-                "bin": [
-                    [
-                        "grep-$version-x64.exe",
-                        "grep"
-                    ],
-                    [
-                        "grep-$version-x64.exe",
-                        "egrep",
-                        "-E"
-                    ],
-                    [
-                        "grep-$version-x64.exe",
-                        "fgrep",
-                        "-F"
-                    ]
-                ],
-                "extract_dir": "tools\\install\\grep-windows-$version"
+                "extract_dir": "tools\\install\\grep-windows-$version",
+                "pre_install": "Move-Item \"$dir\\grep-$version-x64.exe\" \"$dir\\grep.exe\""
             }
         }
     }

--- a/bucket/grep.json
+++ b/bucket/grep.json
@@ -23,7 +23,7 @@
             "extract_dir": "tools\\install\\grep-windows-3.7"
         }
     },
-    "pre_install": "Move-Item \"$dir\\grep-3.7-x64.exe\" \"$dir\\grep.exe\"",
+    "pre_install": "Move-Item \"$dir\\grep-$version-x64.exe\" \"$dir\\grep.exe\"",
     "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
     "checkver": {
         "url": "https://community.chocolatey.org/packages/grep",
@@ -39,7 +39,6 @@
                 },
                 "extract_dir": "tools\\install\\grep-windows-$version"
             }
-        },
-        "pre_install": "Move-Item \"$dir\\grep-$version-x64.exe\" \"$dir\\grep.exe\""
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Rename binary to `grep.exe` so that the filename that grep shows up is the same as its command.

Before:
![image](https://user-images.githubusercontent.com/56180050/176203379-fda18491-9abc-4888-b0e3-981ea56d01af.png)
After:
![image](https://user-images.githubusercontent.com/56180050/176203267-9a4ecbea-2232-4ee4-b95a-d5372ef5b4f9.png)


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
