### PR TITLE
sed: Rename binary before shimming

### DIFF
--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -7,8 +7,8 @@
     "hash": "ee430b5edc827e1368cf424fb888e997fc05d24e7e90373b8e9c6811a26eec80",
     "extract_dir": "tools\\install\\sed-windows-master",
     "pre_install": [
-        "mkdir \"$dir\\x64\"",
-        "mkdir \"$dir\\x86\"",
+        "mkdir \"$dir\\x64\" | Out-Null",
+        "mkdir \"$dir\\x86\" | Out-Null",
         "Move-Item \"$dir\\sed-4.8-x64.exe\" \"$dir\\x64\\sed.exe\"",
         "Move-Item \"$dir\\sed-4.8-xp.exe\" \"$dir\\x86\\sed.exe\""
     ],

--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -9,8 +9,8 @@
     "pre_install": [
         "mkdir \"$dir\\x64\" | Out-Null",
         "mkdir \"$dir\\x86\" | Out-Null",
-        "Move-Item \"$dir\\sed-4.8-x64.exe\" \"$dir\\x64\\sed.exe\"",
-        "Move-Item \"$dir\\sed-4.8-xp.exe\" \"$dir\\x86\\sed.exe\""
+        "Move-Item \"$dir\\sed-$version-x64.exe\" \"$dir\\x64\\sed.exe\"",
+        "Move-Item \"$dir\\sed-$version-xp.exe\" \"$dir\\x86\\sed.exe\""
     ],
     "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
     "architecture": {
@@ -30,10 +30,6 @@
         "hash": {
             "url": "https://community.chocolatey.org/packages/sed",
             "regex": "$sha256.*?$basename"
-        },
-        "pre_install": [
-            "Move-Item \"$dir\\sed-$version-x64.exe\" \"$dir\\x64\\sed.exe\"",
-            "Move-Item \"$dir\\sed-$version-xp.exe\" \"$dir\\x86\\sed.exe\""
-        ]
+        }
     }
 }

--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -6,21 +6,22 @@
     "url": "https://packages.chocolatey.org/sed.4.8.nupkg",
     "hash": "ee430b5edc827e1368cf424fb888e997fc05d24e7e90373b8e9c6811a26eec80",
     "extract_dir": "tools\\install\\sed-windows-master",
-    "pre_install": [
-        "mkdir \"$dir\\x64\" | Out-Null",
-        "mkdir \"$dir\\x86\" | Out-Null",
-        "Move-Item \"$dir\\sed-$version-x64.exe\" \"$dir\\x64\\sed.exe\"",
-        "Move-Item \"$dir\\sed-$version-xp.exe\" \"$dir\\x86\\sed.exe\""
-    ],
-    "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
     "architecture": {
         "64bit": {
-            "bin": "x64\\sed.exe"
+            "pre_install": [
+                "Rename-Item \"$dir\\sed-$version-x64.exe\" sed.exe",
+                "Remove-Item \"$dir\\sed-$version-xp.exe\""
+            ]
         },
         "32bit": {
-            "bin": "x86\\sed.exe"
+            "pre_install": [
+                "Rename-Item \"$dir\\sed-$version-xp.exe\" sed.exe",
+                "Remove-Item \"$dir\\sed-$version-x64.exe\""
+            ]
         }
     },
+    "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
+    "bin": "sed.exe",
     "checkver": {
         "url": "https://community.chocolatey.org/packages/sed",
         "regex": "GNU sed ([\\d.]+)</title>"

--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -6,23 +6,19 @@
     "url": "https://packages.chocolatey.org/sed.4.8.nupkg",
     "hash": "ee430b5edc827e1368cf424fb888e997fc05d24e7e90373b8e9c6811a26eec80",
     "extract_dir": "tools\\install\\sed-windows-master",
+    "pre_install": [
+        "mkdir \"$dir\\x64\"",
+        "mkdir \"$dir\\x86\"",
+        "Move-Item \"$dir\\sed-4.8-x64.exe\" \"$dir\\x64\\sed.exe\"",
+        "Move-Item \"$dir\\sed-4.8-xp.exe\" \"$dir\\x86\\sed.exe\""
+    ],
     "post_install": "Remove-Item \"$dir\\tools\" -Recurse",
     "architecture": {
         "64bit": {
-            "bin": [
-                [
-                    "sed-4.8-x64.exe",
-                    "sed"
-                ]
-            ]
+            "bin": "x64\\sed.exe"
         },
         "32bit": {
-            "bin": [
-                [
-                    "sed-4.8-xp.exe",
-                    "sed"
-                ]
-            ]
+            "bin": "x86\\sed.exe"
         }
     },
     "checkver": {
@@ -35,23 +31,9 @@
             "url": "https://community.chocolatey.org/packages/sed",
             "regex": "$sha256.*?$basename"
         },
-        "architecture": {
-            "64bit": {
-                "bin": [
-                    [
-                        "sed-$version-x64.exe",
-                        "sed"
-                    ]
-                ]
-            },
-            "32bit": {
-                "bin": [
-                    [
-                        "sed-$version-xp.exe",
-                        "sed"
-                    ]
-                ]
-            }
-        }
+        "pre_install": [
+            "Move-Item \"$dir\\sed-$version-x64.exe\" \"$dir\\x64\\sed.exe\"",
+            "Move-Item \"$dir\\sed-$version-xp.exe\" \"$dir\\x86\\sed.exe\""
+        ]
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Same reason with https://github.com/ScoopInstaller/Main/pull/3717.

For sed, however, I'm not sure why it is showing the full path:
![image](https://user-images.githubusercontent.com/56180050/176214643-999ac7d6-b5b3-4145-87b5-dcad3f55e29c.png)

But I guess it's better than the latter.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
