### PR TITLE
clash.meta: Add version 1.11.2

### DIFF
--- a/bucket/clash.meta.json
+++ b/bucket/clash.meta.json
@@ -1,6 +1,6 @@
 {
     "version": "1.11.2",
-    "description": "Fork of Clash, a rule-based tunnel in Go.",
+    "description": "Fork of Clash, a rule-based tunnel.",
     "homepage": "https://github.com/MetaCubeX/Clash.Meta",
     "license": "GPL-3.0-or-later",
     "architecture": {

--- a/bucket/clash.meta.json
+++ b/bucket/clash.meta.json
@@ -1,0 +1,35 @@
+{
+    "version": "1.11.2",
+    "description": "Fork of Clash, a rule-based tunnel in Go.",
+    "homepage": "https://github.com/MetaCubeX/Clash.Meta",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/MetaCubeX/Clash.Meta/releases/download/v1.11.2/Clash.Meta-windows-amd64-v1.11.2.zip",
+            "hash": "9d5013f536011adf573a51a8bec21e021f8ff0964713bf403b1cb4751616379c"
+        },
+        "32bit": {
+            "url": "https://github.com/MetaCubeX/Clash.Meta/releases/download/v1.11.2/Clash.Meta-windows-386-v1.11.2.zip",
+            "hash": "396a7d2295e93700eca433f277b52eb82e797a3426d57b183d6ceb40b9ae66aa"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\\Clash.Meta*.exe\" | Rename-Item -NewName 'Clash.Meta.exe'",
+    "bin": [
+        "Clash.Meta.exe",
+        [
+            "Clash.Meta.exe",
+            "clash"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/MetaCubeX/Clash.Meta/releases/download/v$version/Clash.Meta-windows-amd64-v$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/MetaCubeX/Clash.Meta/releases/download/v$version/Clash.Meta-windows-386-v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
**[Clash.Meta](https://github.com/MetaCubeX/Clash.Meta)** is a fork of Clash ([main/clash](https://github.com/ScoopInstaller/Main/blob/master/bucket/clash.json)), a rule-based tunnel in Go.

**NOTES**:
* Currently the repo has **794 stars** and 4K forks.
* config location: `$Env:UserProfile\.config\clash`.