### PR TITLE
unshield: Add version 1.5.1

### DIFF
--- a/bucket/unshield.json
+++ b/bucket/unshield.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.5.1",
+    "description": "Tool and library to extract CAB files from InstallShield installers.",
+    "homepage": "https://github.com/twogood/unshield",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/unshield/unshield-1.5.1.7z",
+            "hash": "dcf6a9f9087b8b7f95d6a1723a04caa564f18c557f3a220be726a82524b36f61"
+        }
+    },
+    "bin": [
+        "unshield.exe",
+        "unshield-deobfuscate.exe"
+    ]
+}


### PR DESCRIPTION
* supersedes https://github.com/ScoopInstaller/Extras/pull/8800

* **[Unshield](https://github.com/twogood/unshield)** is a tool and library to extract CAB files from **InstallShield** installers.

**NOTES**:
* This app is in *Main* because it is an **unpacker**.

* In order to update this app, we need to manually build it. I think it's fine because:
(1) *Unshield* does not update very often (about once a year)
(2) This app can be useful for us to **extract the installer** of other apps.

* I built the binary with the following steps:
(1) Download source code from https://github.com/twogood/unshield/releases and extract the file.
(2) Install [main/openssl](https://github.com/ScoopInstaller/Main/blob/master/bucket/openssl.json) and [extras/zlib](https://github.com/ScoopInstaller/Extras/blob/master/bucket/zlib.json) with *Scoop*.
(3) Open the folder `unshield-1.5.1` with **cmake-gui**, and set build folder to `unshield-1.5.1\win32_msvc`
(4) Click 'Configure' and 'Generate'
(5) Open the generated `unshield.sln` with VS2022. In project `libunshield`'s properties, set <1> configuration type to `Static Library (.lib)`, and  <2> target file extension to `.lib`.
(6) Open VS2022 dev command prompt, and run `msbuild unshield-1.5.1\win32_msvc\unshield.sln /property:Configuration=Release`

* I tried to build with both `x86` and `x64` configurations, but only `x64` succeeded. Not sure if it is caused by *unshield* itself, or there are problems in settings / dependencies.