### PR TITLE
Change Repo of Bitwarden CLI

### DIFF
--- a/bucket/bitwarden-cli.json
+++ b/bucket/bitwarden-cli.json
@@ -1,22 +1,23 @@
 {
-    "version": "1.22.1",
+    "version": "2022.6.2",
     "description": "The powerful command-line tool (CLI) to write and execute scripts on your Bitwarden vault.",
     "homepage": "https://bitwarden.com/",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bitwarden/cli/releases/download/v1.22.1/bw-windows-1.22.1.zip",
-            "hash": "0902a867d82c96fb93d087eefaaa78867f6ecc48d2ce249f1de231f5f3efad1d"
+            "url": "https://github.com/bitwarden/clients/releases/download/cli-v2022.6.2/bw-windows-2022.6.2.zip",
+            "hash": "c924bffce67274e736e9324b29cef176d407d3e93145ce515daff34f79ff2883"
         }
     },
     "bin": "bw.exe",
     "checkver": {
-        "github": "https://github.com/bitwarden/cli"
+        "url": "https://github.com/bitwarden/clients/releases.atom",
+        "regex": "\\/cli-v([\\d.]+)<\\/id>"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/bitwarden/cli/releases/download/v$version/bw-windows-$version.zip",
+                "url": "https://github.com/bitwarden/clients/releases/download/cli-v$version/bw-windows-$version.zip",
                 "hash": {
                     "url": "$baseurl/bw-windows-sha256-$version.txt"
                 }


### PR DESCRIPTION
Bitwarden consolidated all of their clients (except the mobile application) into a single repository, https://github.com/bitwarden/clients.  All current and future releases of bitwarden-cli will be released there.  As we can no longer assume that a new release on that repo is for the CLI, checkver logic was updated to parse the releases.atom feed. This updated manifest allows scoop to offer current versions of the Bitwarden CLI.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3793

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
