### PR TITLE
xmlstarlet: *nix compatibility

### DIFF
--- a/bucket/xmlstarlet.json
+++ b/bucket/xmlstarlet.json
@@ -6,7 +6,10 @@
     "url": "https://downloads.sourceforge.net/project/xmlstar/xmlstarlet/1.6.1/xmlstarlet-1.6.1-win32.zip",
     "hash": "sha1:cc5f5cd17a1f81740e5185a70408ffd6fa2f862d",
     "extract_dir": "xmlstarlet-1.6.1",
-    "bin": "xml.exe",
+    "bin": [
+        "xml.exe",
+        ["xml.exe", "xmlstarlet"]
+    ],
     "checkver": {
         "url": "https://sourceforge.net/projects/xmlstar/files/",
         "regex": "xmlstarlet-([\\d.]+)-win"


### PR DESCRIPTION
Xmlstarlet is distributed as `xmlstarlet` binary under *nix systems but on Windows - it is installed as `xml`. This causes issues with scripts portability between the systems. Adding additional `xmlstarlet` alias to the existing `xml` binary solves the issue.