### PR TITLE
nodejs: Add 32bit support back

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -8,7 +8,13 @@
             "url": "https://nodejs.org/dist/v18.7.0/node-v18.7.0-win-x64.7z",
             "hash": "8af2dd97c0250287960cca4604337ed2e0e0a3b1d414cef5f68056a84f5966ee",
             "extract_dir": "node-v18.7.0-win-x64"
+        },
+        "32bit": {
+            "url": "https://nodejs.org/dist/v18.7.0/node-v18.7.0-win-x86.7z",
+            "hash": "ef934a8315044b7588fe6762e73d3175a08c9ef4f1288b97f11520b1fc3ef172",
+            "extract_dir": "node-v18.7.0-win-x86"
         }
+    
     },
     "persist": [
         "bin",
@@ -31,6 +37,10 @@
             "64bit": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x64.7z",
                 "extract_dir": "node-v$version-win-x64"
+            },
+            "32bit": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
+                "extract_dir": "node-v$version-win-x86"
             }
         },
         "hash": {

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -14,7 +14,6 @@
             "hash": "ef934a8315044b7588fe6762e73d3175a08c9ef4f1288b97f11520b1fc3ef172",
             "extract_dir": "node-v18.7.0-win-x86"
         }
-    
     },
     "persist": [
         "bin",


### PR DESCRIPTION
See https://github.com/ScoopInstaller/Main/commit/c4135181190af27ccc1acb02925a1e9d4450fd99#commitcomment-81309371

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
