### PR TITLE
cygwin: Fix `installer.args`

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -43,9 +43,12 @@
             "--no-admin",
             "--no-shortcuts",
             "--quiet-mode",
-            "--local-package-dir \"$persist_dir\\packages\"",
-            "--root \"$persist_dir\\root\"",
-            "--site \"https://mirrors.kernel.org/sourceware/cygwin/\""
+            "--local-package-dir",
+            "$persist_dir\\packages",
+            "--root",
+            "$persist_dir\\root",
+            "--site",
+            "https://mirrors.kernel.org/sourceware/cygwin/"
         ],
         "keep": true
     },


### PR DESCRIPTION
Fix #3831.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
