### PR TITLE
fix(#3836): change maven download URL to archive.apache.org

### DIFF
--- a/bucket/maven.json
+++ b/bucket/maven.json
@@ -6,7 +6,7 @@
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://www.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip",
+    "url": "https://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip",
     "hash": "sha512:f92dbd90060c5fd422349f844ea904a0918c9c9392f3277543ce2bfb0aab941950bb4174d9b6e2ea84cd48d2940111b83ffcc2e3acf5a5b2004277105fd22be9",
     "extract_dir": "apache-maven-3.8.6",
     "env_add_path": "bin",
@@ -19,7 +19,7 @@
         "regex": "<b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.apache.org/dist/maven/maven-$majorVersion/$version/binaries/apache-maven-$version-bin.zip",
+        "url": "https://archive.apache.org/dist/maven/maven-$majorVersion/$version/binaries/apache-maven-$version-bin.zip",
         "hash": {
             "url": "$url.sha512"
         },


### PR DESCRIPTION
…f www.apache.org so that older versions of maven can be installed easily.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #3836
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
