### PR TITLE
helmfile: updated urls due to repository migration

### DIFF
--- a/bucket/helmfile.json
+++ b/bucket/helmfile.json
@@ -25,7 +25,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/releases/download/v$version/helmfile_$version_checksums.txt"
+            "url": "$baseurl/helmfile_$version_checksums.txt"
         }
     }
 }

--- a/bucket/helmfile.json
+++ b/bucket/helmfile.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.144.0",
+    "version": "0.145.3",
     "description": "Command line interface to deploy Kubernetes Helm Charts.",
-    "homepage": "https://github.com/roboll/helmfile/",
+    "homepage": "https://github.com/helmfile/helmfile",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_windows_amd64.exe#/helmfile.exe",
-            "hash": "97f0e617977c5518cc92d9982c894eccaeb4c64fa9ae9577e606d2780e66f10b"
+            "url": "https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_windows_amd64.tar.gz",
+            "hash": "6401465ec21b7f8e1caa2dc85a02eecb406d8a30276e4cb742265413e8638498"
         },
         "32bit": {
-            "url": "https://github.com/roboll/helmfile/releases/download/v0.144.0/helmfile_windows_386.exe#/helmfile.exe",
-            "hash": "3b30897fb08b49e023b134119aafd9d9777ccd5586b3b565805ec8fbd8cbedf8"
+            "url": "https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_windows_386.tar.gz",
+            "hash": "da5138438d177e6a86fed08b2b7dda716bcfc982b1dc41abc8d5c99e19518381"
         }
     },
     "bin": "helmfile.exe",
@@ -18,11 +18,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/roboll/helmfile/releases/download/v$version/helmfile_windows_amd64.exe#/helmfile.exe"
+                "url": "https://github.com/helmfile/helmfile/releases/download/v$version/helmfile_$version_windows_amd64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/roboll/helmfile/releases/download/v$version/helmfile_windows_386.exe#/helmfile.exe"
+                "url": "https://github.com/helmfile/helmfile/releases/download/v$version/helmfile_$version_windows_386.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/releases/download/v$version/helmfile_$version_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Since Helmfile project repository was moved to another owner, updated with correct urls and releases accordingly 