### PR TITLE
gsudo: Update to version 1.4.0. Support for x86 and x64 platforms (breaking change)

### DIFF
--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -1,10 +1,18 @@
 {
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "A Sudo for Windows",
     "homepage": "https://github.com/gerardog/gsudo",
     "license": "MIT",
-    "url": "https://github.com/gerardog/gsudo/releases/download/v1.3.0/gsudo.v1.3.0.zip",
-    "hash": "cfd28467bbedf85bb05dc35f59c2e16ba8f19bd7aa555abb37cb2693a9b97855",
+    "url": "https://github.com/gerardog/gsudo/releases/download/v1.4.0/gsudo.v1.4.0.zip",
+    "hash": "FA7EBED253889D2532A0570132F6E470E0E1AE95040D587ABC8AF0F79BFEDD4C",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "x64"
+        },
+        "32bit": {
+            "extract_dir": "x86"
+        }
+    },	
     "bin": [
         [
             "gsudo.exe",

--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -12,7 +12,7 @@
         "32bit": {
             "extract_dir": "x86"
         }
-    },	
+    },
     "bin": [
         [
             "gsudo.exe",


### PR DESCRIPTION
Starting at v1.4.0, gsudo have different builds for x86 and x64, each one on it's separate folder.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
