### PR TITLE
heroku-cli: Fix arguments in `pre_install` script

### DIFF
--- a/bucket/heroku-cli.json
+++ b/bucket/heroku-cli.json
@@ -17,7 +17,7 @@
         "Invoke-ExternalCommand (Get-HelperPath '7zip') -ArgumentList @(",
         "    'x'",
         "    \"$dir\\dl\"",
-        "    \"-o`\"$dir\\dlo`\"\"",
+        "    \"-o$dir\\dlo\"",
         "    '-bso0'",
         "    '-bd'",
         "    '-bse0'",


### PR DESCRIPTION
Closes #3869.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
