### PR TITLE
nircmd: Add `nircmd.exe` to `bin`

### DIFF
--- a/bucket/nircmd.json
+++ b/bucket/nircmd.json
@@ -13,7 +13,10 @@
             "hash": "5071b54669bb1e88422c6c340204b0b3a0ffd07e2ac1d747ccbd1447abc92948"
         }
     },
-    "bin": "nircmdc.exe",
+    "bin": [
+        "nircmd.exe",
+        "nircmdc.exe"
+    ],
     "checkver": "<td>NirCmd v([\\d.]+)",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

> It's recommended to copy the executable of NirCmd (nircmd.exe) to your windows directory, or to any other folder listed in your PATH environment variable, so you won't need to type the full path of nircmd in each time that you want to use it.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
