### PR TITLE
genact: Update to version 1.0.0

### DIFF
--- a/bucket/genact.json
+++ b/bucket/genact.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.12.0",
+    "version": "1.0.0",
     "description": "A nonsense activity generator",
     "homepage": "https://github.com/svenstaro/genact/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/svenstaro/genact/releases/download/v0.12.0/genact-v0.12.0-windows-x86_64.exe#/genact.exe",
-            "hash": "589ae386a9908fbc01a7cd19c082b3efc48c06083ba3f28738a4357cd7cd0472"
+            "url": "https://github.com/svenstaro/genact/releases/download/v1.0.0/genact-1.0.0-x86_64-pc-windows-msvc.exe#/genact.exe",
+            "hash": "ad4f79b7a04fd6c690261ac29243bf8be5f2130e7098278704f86e55ed76217a"
         }
     },
     "bin": "genact.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/svenstaro/genact/releases/download/v$version/genact-v$version-windows-x86_64.exe#/genact.exe"
+                "url": "https://github.com/svenstaro/genact/releases/download/v$version/genact-$version-x86_64-pc-windows-msvc.exe#/genact.exe"
             }
         }
     }


### PR DESCRIPTION
genact has been updated to 1.0.0. 

- Github release: https://github.com/svenstaro/genact/releases/tag/v1.0.0

---

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
