### PR TITLE
elixir@1.14.0: make Elixir 1.14 work as expected

### DIFF
--- a/bucket/elixir.json
+++ b/bucket/elixir.json
@@ -1,22 +1,22 @@
 {
-    "version": "1.13.4",
+    "version": "1.14.0",
     "description": "A dynamic and functional programming language designed for building scalable and maintainable applications.",
     "homepage": "https://elixir-lang.org/",
     "license": "Apache-2.0",
     "suggest": {
         "Erlang compiler": "erlang"
     },
-    "url": "https://github.com/elixir-lang/elixir/releases/download/v1.13.4/Precompiled.zip",
-    "hash": "sha512:e64c714e80cd9657b8897d725f6d78f251d443082f6af5070caec863c18068c97af6bdda156c3b3390e0a2b84f77c2ad3378a42913f64bb583fb5251fa49e619",
+    "url": "https://repo.hex.pm/builds/elixir/v1.14.0.zip",
+    "hash": "sha256:cfe28e62c152235b948a0a89a833cb2795302604a5c21fe06f85a6f786e67b28",
     "env_add_path": "bin",
     "checkver": {
         "github": "https://github.com/elixir-lang/elixir"
     },
     "autoupdate": {
-        "url": "https://github.com/elixir-lang/elixir/releases/download/v$version/Precompiled.zip",
+        "url": "https://repo.hex.pm/builds/elixir/v$version.zip",
         "hash": {
-            "url": "https://github.com/elixir-lang/elixir/releases/tag/v$version/",
-            "regex": "$basename SHA512: $sha512"
+            "url": "https://repo.hex.pm/builds/elixir/builds.txt",
+            "regex": "$version ([a-zA-Z0-9]+) (\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z) $sha256"
         }
     }
 }


### PR DESCRIPTION
Use Elixir 1.14 from hex.pm instead of from github release page. The package is version that compiled lowest OTP. In this case, it's OTP 23.

Closes #3886 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
