### PR TITLE
fix(elixir): make install elixir@1.14.0-otp-25 work

### DIFF
--- a/bucket/elixir.json
+++ b/bucket/elixir.json
@@ -16,7 +16,7 @@
         "url": "https://repo.hex.pm/builds/elixir/v$version.zip",
         "hash": {
             "url": "https://repo.hex.pm/builds/elixir/builds.txt",
-            "regex": "$version ([a-zA-Z0-9]+) (\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z) $sha256"
+            "regex": "$version [a-zA-Z0-9]+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z $sha256"
         }
     }
 }


### PR DESCRIPTION
Relates to #3921 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

It seems that the first match group is taken as sha1? We don't want that.

Tested on a tmp bucket https://github.com/princemaple/tmp-bucket. Manged to install `@1.14.0-otp-25`.