### PR TITLE
rizin: Add missing command line tools to PATH

### DIFF
--- a/bucket/rizin.json
+++ b/bucket/rizin.json
@@ -16,13 +16,17 @@
     "innosetup": true,
     "bin": [
         "bin\\rizin.exe",
+        "bin\\rz-agent.exe",
+        "bin\\rz-asm.exe",
         "bin\\rz-ax.exe",
         "bin\\rz-bin.exe",
         "bin\\rz-diff.exe",
         "bin\\rz-find.exe",
         "bin\\rz-gg.exe",
         "bin\\rz-hash.exe",
-        "bin\\rz-run.exe"
+        "bin\\rz-run.exe",
+        "bin\\rz-sign.exe",
+        "bin\\rz-test.exe"
     ],
     "checkver": {
         "github": "https://github.com/rizinorg/rizin"


### PR DESCRIPTION
some of to rizin tools are not created in `shims/`

this PR adds
- `rz-agent.exe`
- `rz-asm.exe`
- `rz-sign.exe`
- `rz-test.exe`

to `bin` field in `bucket/rizin.json`

## Rizin Tools in bin/
```
> dir %userprofile%\scoop\apps\rizin\current\bin\rz-*.exe
  rz-agent.exe
  rz-asm.exe
  rz-ax.exe
  rz-bin.exe
  rz-diff.exe
  rz-find.exe
  rz-gg.exe
  rz-hash.exe
  rz-run.exe
  rz-sign.exe
  rz-test.exe
```

## Rizin Tools in shims/
```
> dir %userprofile%\scoop\shims\rz-*.exe
  rz-ax.exe
  rz-bin.exe
  rz-diff.exe
  rz-find.exe
  rz-gg.exe
  rz-hash.exe
  rz-run.exe    
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
