### PR TITLE
danser-go: Update for launcher

### DIFF
--- a/bucket/danser-go.json
+++ b/bucket/danser-go.json
@@ -9,7 +9,13 @@
             "hash": "cfd6bdb219cc7fed04b7043776ada20dee2841a307cb0447754fa777d4900bc3"
         }
     },
-    "bin": "danser.exe",
+    "bin": "danser-cli.exe",
+    "shortcuts": [
+        [
+            "danser.exe",
+            "danser-go"
+        ]
+    ],
     "persist": "settings",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
- Changed bin to `danser-cli.exe` (New filename for CLI)
- Add shortcut to `danser.exe` (Launcher)

Closes #3940

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
