### PR TITLE
winget: Update to version 1.3.2091 (Stable)

### DIFF
--- a/bucket/winget.json
+++ b/bucket/winget.json
@@ -1,6 +1,6 @@
 {
-    "version": "1.4.2161",
-    "description": "Windows Package Manager CLI (aka winget)",
+    "version": "1.3.2091",
+    "description": "Windows Package Manager Client (aka winget)",
     "homepage": "https://github.com/microsoft/winget-cli",
     "license": "MIT",
     "notes": [
@@ -10,8 +10,8 @@
     "suggest": {
         "vcredist": "extras/vcredist"
     },
-    "url": "https://github.com/microsoft/winget-cli/releases/download/v1.4.2161-preview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
-    "hash": "eabae888c0664be2c8ffb06d9dc9a53b679232232a48a85490329b3536179753",
+    "url": "https://github.com/microsoft/winget-cli/releases/download/v1.3.2091/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
+    "hash": "42dc2811c98e5dc831a314394e1e4d1571580bb4ffbe645534efb8a3577c154d",
     "architecture": {
         "64bit": {
             "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"
@@ -24,14 +24,11 @@
         "script": "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
     },
     "bin": "winget.exe",
-    "checkver": {
-        "url": "https://github.com/microsoft/winget-cli/tags",
-        "regex": "/archive/refs/tags/v([\\d.]+)(?<pre>-preview)?\\.zip"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/microsoft/winget-cli/releases/download/v$version$matchPre/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
+        "url": "https://github.com/microsoft/winget-cli/releases/download/v$version/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
         "hash": {
-            "url": "https://github.com/microsoft/winget-cli/releases/download/v$version$matchPre/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt"
+            "url": "https://github.com/microsoft/winget-cli/releases/download/v$version/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt"
         }
     }
 }

--- a/bucket/winget.json
+++ b/bucket/winget.json
@@ -1,6 +1,6 @@
 {
     "version": "1.3.2091",
-    "description": "Windows Package Manager Client (aka winget)",
+    "description": "Windows Package Manager CLI (aka winget)",
     "homepage": "https://github.com/microsoft/winget-cli",
     "license": "MIT",
     "notes": [


### PR DESCRIPTION
- Update Url to Stable Release
- use checkver: "github"

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
