### PR TITLE
pyenv@3.1.1: Improve manifest according to pyenv setup instruction

### DIFF
--- a/bucket/pyenv.json
+++ b/bucket/pyenv.json
@@ -15,7 +15,9 @@
     "bin": "pyenv-win\\bin\\pyenv.bat",
     "env_add_path": "pyenv-win\\shims",
     "env_set": {
-        "PYENV": "$dir\\pyenv-win"
+        "PYENV": "$dir\\pyenv-win",
+        "PYENV_ROOT": "$dir\\pyenv-win",
+        "PYENV_HOME": "$dir\\pyenv-win"
     },
     "persist": [
         "pyenv-win\\version",

--- a/bucket/pyenv.json
+++ b/bucket/pyenv.json
@@ -12,7 +12,10 @@
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\pyenv-win\\version\")) { New-Item \"$dir\\pyenv-win\\version\" | Out-Null }",
-    "env_add_path": ["pyenv-win\\bin", "pyenv-win\\shims"],
+    "env_add_path": [
+        "pyenv-win\\bin",
+        "pyenv-win\\shims"
+    ],
     "env_set": {
         "PYENV": "$dir\\pyenv-win",
         "PYENV_ROOT": "$dir\\pyenv-win",

--- a/bucket/pyenv.json
+++ b/bucket/pyenv.json
@@ -12,8 +12,7 @@
         }
     },
     "pre_install": "if (!(Test-Path \"$persist_dir\\pyenv-win\\version\")) { New-Item \"$dir\\pyenv-win\\version\" | Out-Null }",
-    "bin": "pyenv-win\\bin\\pyenv.bat",
-    "env_add_path": "pyenv-win\\shims",
+    "env_add_path": ["pyenv-win\\bin", "pyenv-win\\shims"],
     "env_set": {
         "PYENV": "$dir\\pyenv-win",
         "PYENV_ROOT": "$dir\\pyenv-win",


### PR DESCRIPTION
When trying to use pyenv with another tool called pyenv-win, I found out it was not working because `PYENV_HOME` env var was missing. 

This led me to look at the setup instruction (https://github.com/pyenv-win/pyenv-win#add-system-settings), I found the following: 

* `PYENV_ROOT` and `PYENV_HOME` are expected to be set
* `pyenv-win/bin` should be in PATH because it contains already all the necessary script for powershell, CMD and Git bash. 

Regarding the second point, I don't think there should be any `bin` in the manifest, as no shims are required. 

This seem to be the way to handle such tools (see my question https://github.com/ScoopInstaller/Scoop/discussions/5156 for details)

With this updated manifest, I can correctly use [pyenv-win-venv](https://github.com/pyenv-win/pyenv-win-venv) now 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
