### PR TITLE
gosec: Add version 2.13.1

### DIFF
--- a/bucket/gosec.json
+++ b/bucket/gosec.json
@@ -1,0 +1,24 @@
+{
+    "version": "2.13.1",
+    "description": "Inspects source code for security problems by scanning the Go AST.",
+    "homepage": "https://github.com/securego/gosec",
+    "license": "Apache2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/securego/gosec/releases/download/v2.13.1/gosec_2.13.1_windows_amd64.tar.gz",
+            "hash": "e55d44c241c7830a3881829cb1601781d270fc709f371e82ee3cf704587b33ec"
+        }
+    },
+    "bin": "gosec.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/securego/gosec/releases/download/v$version/gosec_$version_windows_amd64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/securego/gosec/releases/download/v$version/gosec_$version_checksums.txt"
+        }
+    }
+}

--- a/bucket/gosec.json
+++ b/bucket/gosec.json
@@ -18,7 +18,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/securego/gosec/releases/download/v$version/gosec_$version_checksums.txt"
+            "url": "$baseurl/gosec_$version_checksums.txt"
         }
     }
 }

--- a/bucket/gosec.json
+++ b/bucket/gosec.json
@@ -2,7 +2,7 @@
     "version": "2.13.1",
     "description": "Inspects source code for security problems by scanning the Go AST.",
     "homepage": "https://github.com/securego/gosec",
-    "license": "Apache2.0",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/securego/gosec/releases/download/v2.13.1/gosec_2.13.1_windows_amd64.tar.gz",


### PR DESCRIPTION
Added gosec.json in the bucket

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
