### PR TITLE
jx: Adds hash regex

### DIFF
--- a/bucket/jx.json
+++ b/bucket/jx.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jenkins-x/jx/releases/download/v3.5.33/jx-windows-amd64.zip",
-            "hash": "66a631587dc1c59b8be25290c245783eeec9a4d1ab5cddbb7247156ea0989c1a"
+            "hash": "c68cc24b23a3f0529cff1d728f2aaa9c38e0a887e3e94ef461e1bdcdb59aae0d"
         }
     },
     "pre_install": "Stop-Process -Name 'jx' -ErrorAction 'Ignore' -Verbose",

--- a/bucket/jx.json
+++ b/bucket/jx.json
@@ -19,7 +19,8 @@
             }
         },
         "hash": {
-            "url": "$baseurl/jx-checksums.txt"
+            "url": "$baseurl/jx-checksums.txt",
+            "regex": "(?m)$checksum[\\x20\\t]+.*$basename(?:[\\x20\\t]+\\d+)?$"
         }
     }
 }


### PR DESCRIPTION
Adds custom regex to filter out .sbom file

Prevents grabbing the wrong hash for jx by providing a custom regex to the manifest. Issue is that the default regex is actually grabbing the `.zip.sbom` hash since it shows up first in the `jx-checksums.txt` file.  

## Before/Default Regex:

![image](https://user-images.githubusercontent.com/101352781/193078779-c137a93d-8136-4ae9-b81d-8760fcf8c073.png)

```sh
Searching hash for jx-windows-amd64.zip in https://github.com/jenkins-x/jx/releases/download/v3.5.33/jx-checksums.txt
DEBUG[1664466355] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> C:\Users\..\scoop\apps\scoop\current\lib\autoupdate.ps1:53:5
Found: 66a631587dc1c59b8be25290c245783eeec9a4d1ab5cddbb7247156ea0989c1a using Extract Mode
```

## With Custom Regex:
![image](https://user-images.githubusercontent.com/101352781/193079241-1c4628e4-bc04-49c5-9579-63b705df6620.png)

```sh
Searching hash for jx-windows-amd64.zip in https://github.com/jenkins-x/jx/releases/download/v3.5.33/jx-checksums.txt
DEBUG[1664466410] $regex = (?m)([a-fA-F0-9]{32,128})[\x20\t]+.*jx-windows-amd64\.zip(?:[\x20\t]+\d+)?$ -> C:\Users\...\scoop\apps\scoop\current\lib\autoupdate.ps1:53:5
Found: c68cc24b23a3f0529cff1d728f2aaa9c38e0a887e3e94ef461e1bdcdb59aae0d using Extract Mode
```
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
