### PR TITLE
tealdeer: Remove TEALDEER_CACHE_DIR environment variable

### DIFF
--- a/bucket/tealdeer.json
+++ b/bucket/tealdeer.json
@@ -15,14 +15,14 @@
         "   Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
         "   $CONT = @(",
         "       '[directories]'",
+        "       \"cache_dir = `\"$persist_dir\\cache`\"\"",
         "       \"custom_pages_dir = `\"$persist_dir\\custom-pages`\"\"",
         "   ) -replace '\\\\', '\\\\'",
         "   Set-Content \"$dir\\$file\" ($CONT -join \"`r`n\") -Encoding ASCII",
         "}"
     ],
     "env_set": {
-        "TEALDEER_CONFIG_DIR": "$dir",
-        "TEALDEER_CACHE_DIR": "$dir\\cache"
+        "TEALDEER_CONFIG_DIR": "$dir"
     },
     "bin": "tldr.exe",
     "persist": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The `TEALDEER_CACHE_DIR` env variable is now deprecated, use the `cache_dir` option in the config file instead.
Changelog:
[https://github.com/dbrgn/tealdeer/blob/main/CHANGELOG.md](https://github.com/dbrgn/tealdeer/blob/main/CHANGELOG.md)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
