### PR TITLE
git: add scalar.exe to bin entry

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -20,6 +20,7 @@
         "cmd\\git.exe",
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
+        "cmd\\scalar.exe",
         "usr\\bin\\tig.exe",
         "git-bash.exe"
     ],


### PR DESCRIPTION
The new scalar.exe that is now bundled with git can also be used when installed with scoop.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
