### PR TITLE
Update azcopy hash keys for version 10.16.1

### DIFF
--- a/bucket/azcopy.json
+++ b/bucket/azcopy.json
@@ -9,12 +9,12 @@
     "architecture": {
         "64bit": {
             "url": "https://aka.ms/downloadazcopy-v10-windows/#dl.zip",
-            "hash": "5817cae8ca921f0c199a66cd1a98c2a2f81186b83fa8bceb3366af836cc7edd2",
+            "hash": "1d483db659844ee21f50aad3dcb74dc03b03af85b13161982b709ca890532c1f",
             "extract_dir": "azcopy_windows_amd64_10.16.1"
         },
         "32bit": {
             "url": "https://aka.ms/downloadazcopy-v10-windows-32bit#/dl.zip",
-            "hash": "dc042de5a4e55c13dccbd7c35e12701c1e0b8d099879356de97322ccb6f24333",
+            "hash": "24914df83ad9a5a1605bca7abdded47169b123a97dc7c9ed58439c254cf97cd0",
             "extract_dir": "azcopy_windows_386_10.16.1"
         }
     },


### PR DESCRIPTION
azcopy 10.16.1 hash keys updated

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
