### PR TITLE
biber: Add version 2.17

### DIFF
--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -1,0 +1,35 @@
+{
+  "bin": "biber.exe",
+  "license": "Artistic License 2.0",
+  "depends": "",
+  "version": "2.17",
+  "homepage": "https://sourceforge.net/projects/biblatex-biber/files/",
+  "suggest": {
+	  "tectonic": "tectonic"
+  },
+  "architecture":{
+	  "64bit": {
+		  "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN64.zip",
+		  "hash": "8e7a4c98626511bcf1c89a1847242cdd0e0113927137577eedaa13c72ce84b4b",
+		  "extract_dir": "biber-MSWIN64"
+  },
+          "32bit": {
+		"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN32.zip",
+		"hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
+		"extract_dir": "biber-$version-MSWIN32"
+	  }
+},
+"checkver": "sourceforge",
+"autoupdate":{
+	"architecture": {
+		"64bit": {
+			"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN64.zip",
+			"extract_dir": "biber-$version-MSWIN64"
+},
+		"32bit": {
+			"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN32.zip",
+			"extract_dir": "biber-$version-MSWIN32"
+		}
+	}
+	}
+}

--- a/bucket/dolt.json
+++ b/bucket/dolt.json
@@ -2,11 +2,11 @@
     "homepage": "https://github.com/dolthub/dolt",
     "license": "Apache-2.0",
     "description": "Dolt is a SQL database that you can fork, clone, branch, merge, push and pull just like a git repository.",
-    "version": "0.50.1",
+    "version": "0.50.2",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dolthub/dolt/releases/download/v0.50.1/dolt-windows-amd64.zip",
-            "hash": "195f4a5509c1f7084b9329fe6406c88f607b94b7b4eec45afc6ea848260d856b"
+            "url": "https://github.com/dolthub/dolt/releases/download/v0.50.2/dolt-windows-amd64.zip",
+            "hash": "bb5689090ce7b891078d817f7dac88656885958b7f6ecd71c6dfaaffe061cdbb"
         }
     },
     "extract_dir": "dolt-windows-amd64",

--- a/bucket/dynamorio.json
+++ b/bucket/dynamorio.json
@@ -1,11 +1,11 @@
 {
-    "version": "9.0.19265",
+    "version": "9.0.19272",
     "description": "DynamoRIO is a runtime code manipulation system that supports code transformations on any part of a program, while it executes.",
     "homepage": "https://dynamorio.org",
     "license": "BSD-3-Clause-Clear",
-    "url": "https://github.com/DynamoRIO/dynamorio/releases/download/cronbuild-9.0.19265/DynamoRIO-Windows-9.0.19265.zip",
-    "hash": "22d331c0e5b461d6ba324d2944dc1145bb810f29284fc11b9848b10cd58fbd5f",
-    "extract_dir": "DynamoRIO-Windows-9.0.19265",
+    "url": "https://github.com/DynamoRIO/dynamorio/releases/download/cronbuild-9.0.19272/DynamoRIO-Windows-9.0.19272.zip",
+    "hash": "fdcacfb7299611b13653a0b54d1fcdb9f9a1bcb62edb69c58df9fdf54448a7a3",
+    "extract_dir": "DynamoRIO-Windows-9.0.19272",
     "architecture": {
         "64bit": {
             "bin": [

--- a/bucket/edgedriver.json
+++ b/bucket/edgedriver.json
@@ -1,5 +1,5 @@
 {
-    "version": "107.0.1417.0",
+    "version": "107.0.1418.3",
     "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
     "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
     "license": {
@@ -9,12 +9,12 @@
     "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
     "architecture": {
         "64bit": {
-            "url": "https://msedgedriver.azureedge.net/107.0.1417.0/edgedriver_win64.zip",
-            "hash": "ff9a84b604d831cd39833788d48bf3e2c7f88425ab80b990529078f8f284fe1e"
+            "url": "https://msedgedriver.azureedge.net/107.0.1418.3/edgedriver_win64.zip",
+            "hash": "bfad346092f74ca7922fcf470b3854a3ee514749bbf4438118df47035050a9f3"
         },
         "32bit": {
-            "url": "https://msedgedriver.azureedge.net/107.0.1417.0/edgedriver_win32.zip",
-            "hash": "50ca5563bf819e856ab38e93cefd59bd6a9022bc6e4852292c0c4012b81a5cea"
+            "url": "https://msedgedriver.azureedge.net/107.0.1418.3/edgedriver_win32.zip",
+            "hash": "bd1c6557be9cc1e6e9856df4894444385df8a7e51f1fb67900900baf39e3de72"
         }
     },
     "bin": "msedgedriver.exe",

--- a/bucket/flyctl.json
+++ b/bucket/flyctl.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.0.404",
+    "version": "0.0.406",
     "description": "Command line deployment/management client for fly.io services",
     "homepage": "https://github.com/superfly/flyctl",
     "license": " Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/superfly/flyctl/releases/download/v0.0.404/flyctl_0.0.404_Windows_x86_64.zip",
-            "hash": "ba653330f5499a950e404ffb793a50e52895fb2085855496c724821602017862"
+            "url": "https://github.com/superfly/flyctl/releases/download/v0.0.406/flyctl_0.0.406_Windows_x86_64.zip",
+            "hash": "2306c1b47b0ed48d0c00b4c80c8be6894c2980e57d65202b041bbdf12af63c4a"
         }
     },
     "bin": [

--- a/bucket/gum.json
+++ b/bucket/gum.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.11.0",
+    "version": "0.12.0",
     "description": "Gradle/Maven wrapper",
     "homepage": "https://github.com/kordamp/gm",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kordamp/gm/releases/download/v0.11.0/gm_Windows_x86_64.zip",
-            "hash": "sha512:3682ef3ef063f327a9ff6699e5b4098cc26faca34487d41de56d978e0564e6761693d548e34976114234668c87cf086cac641d027b39339080ade662a1721234"
+            "url": "https://github.com/kordamp/gm/releases/download/v0.12.0/gm_Windows_x86_64.zip",
+            "hash": "sha512:5f0e51eebdb782bdc92941fc5071bf656bbe59ec9611c4ffd7bb7e0bcbce652725e65df93e8d1e9f1c2ca6d6dfcc1517a3fba96ef9f6fa12c68d03ad1b235a46"
         },
         "32bit": {
-            "url": "https://github.com/kordamp/gm/releases/download/v0.11.0/gm_Windows_i386.zip",
-            "hash": "sha512:16e5b7a6091d408f71b187a2d498a96d013123d1f031ebdcb591038b06fbd8e1996dba3acb72e46718b6c0701421c22d26bd77477a82207a8d3b09094dc10004"
+            "url": "https://github.com/kordamp/gm/releases/download/v0.12.0/gm_Windows_i386.zip",
+            "hash": "sha512:bd939cdf8582eee248de5819a5d09f862242e2197b5109328389cb1d0b549ea38251a328ebee6679afa0ba3a987c7c137bc9ff3836c125825147d3f434771ec3"
         }
     },
     "bin": [

--- a/bucket/k3sup.json
+++ b/bucket/k3sup.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.12.7",
+    "version": "0.12.8",
     "description": "Utility to get from zero to KUBECONFIG with k3s on any local or remote VM",
     "homepage": "https://k3sup.dev",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/alexellis/k3sup/releases/download/0.12.7/k3sup.exe",
-            "hash": "a1fc40b44ef49be4d9966f4110c46e670d4e5ff9511b9d48f560cda7e2616ed0"
+            "url": "https://github.com/alexellis/k3sup/releases/download/0.12.8/k3sup.exe",
+            "hash": "146ab99cb860d0f1fad02609b006ab13a6673457c5f4eee6b2281743c9fbfcae"
         }
     },
     "bin": "k3sup.exe",

--- a/bucket/minikube.json
+++ b/bucket/minikube.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.27.0",
+    "version": "1.27.1",
     "description": "Runs a single-node Kubernetes cluster inside a Virtual Machine to try out Kubernetes.",
     "homepage": "https://kubernetes.io/docs/getting-started-guides/minikube/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://storage.googleapis.com/minikube/releases/v1.27.0/minikube-windows-amd64.exe#/minikube.exe",
-            "hash": "ebecc7633b3a91b652a81fb17faa4d1bb35fecff94e6309533e95933c9224ef7"
+            "url": "https://storage.googleapis.com/minikube/releases/v1.27.1/minikube-windows-amd64.exe#/minikube.exe",
+            "hash": "d5957435f3a94a43ce0c764ecaf3b9c4f7c6f8bcafdc4ef7b2b86937ec5c311c"
         }
     },
     "bin": "minikube.exe",

--- a/bucket/tectonic.json
+++ b/bucket/tectonic.json
@@ -3,6 +3,7 @@
     "description": "Tectonic is a modernized, complete, self-contained TeX/LaTeX engine, powered by XeTeX and TeXLive.",
     "homepage": "https://tectonic-typesetting.github.io/en-US/",
     "license": "MIT",
+    "suggest": "biber",
     "architecture": {
         "64bit": {
             "url": "https://github.com/tectonic-typesetting/tectonic/releases/download/tectonic%400.11.0/tectonic-0.11.0-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Adds the biber tool for Latex and similar languages using TeX for ease of use to reference content. This tool was chosen over biblatex due to the more recent updates and support for UTF encoding.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
