### PR TITLE
Biber: Add Version 2.18

### DIFF
--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -16,9 +16,9 @@
       "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
       "hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
       "extract_dir": "biber-$version-MSWIN32"
-    },
-  "bin": "biber.exe",
+    }
   },
+  "bin": "biber.exe",
   "checkver": {
       "github": "https://github.com/plk/biber",
       "regex": "Biber ([\\d.]+)-"

--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -1,37 +1,30 @@
 {
   "version": "2.18",
   "description": "Biber is a BibTeX replacement for users of biblatex, with full Unicode support.",
-  "license": "Artistic License 2.0",
-  "homepage": "https://sourceforge.net/projects/biblatex-biber/files/",
+  "license": "Artistic-2.0",
+  "homepage": "https://biblatex-biber.sourceforge.net/",
   "suggest": {
     "tectonic": "tectonic"
   },
   "architecture": {
     "64bit": {
-      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip",
-      "hash": "02ee3a8b6838b7ff1e9aea1a5342686981b9364067a7b8e7131c3b3201cf387c",
-      "extract_dir": "biber-MSWIN64"
+      "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip",
+      "hash": "02ee3a8b6838b7ff1e9aea1a5342686981b9364067a7b8e7131c3b3201cf387c"
     },
     "32bit": {
-      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
-      "hash": "7328c7e6346b6776fcc5e01162d90312817851fb44171d7145d179a143567fb8",
-      "extract_dir": "biber-$version-MSWIN32"
+      "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
+      "hash": "7328c7e6346b6776fcc5e01162d90312817851fb44171d7145d179a143567fb8"
     }
   },
   "bin": "biber.exe",
-  "checkver": {
-      "github": "https://github.com/plk/biber",
-      "regex": "Biber ([\\d.]+)-"
-  },
+  "checkver": "Biber ([\\d.]+) is now ",
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN64.zip",
-        "extract_dir": "biber-$version-MSWIN64"
+        "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip"
       },
       "32bit": {
-        "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN32.zip",
-        "extract_dir": "biber-$version-MSWIN32"
+        "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip"
       }
     }
   }

--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -16,7 +16,7 @@
       "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
       "hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
       "extract_dir": "biber-$version-MSWIN32"
-    }
+    },
   "bin": "biber.exe",
   },
   "checkver": {

--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -1,35 +1,34 @@
 {
-  "bin": "biber.exe",
-  "license": "Artistic License 2.0",
-  "depends": "",
   "version": "2.17",
+  "description": "Biber is a BibTeX replacement for users of biblatex, with full Unicode support.",
+  "license": "Artistic License 2.0",
   "homepage": "https://sourceforge.net/projects/biblatex-biber/files/",
   "suggest": {
-	  "tectonic": "tectonic"
+    "tectonic": "tectonic"
   },
-  "architecture":{
-	  "64bit": {
-		  "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN64.zip",
-		  "hash": "8e7a4c98626511bcf1c89a1847242cdd0e0113927137577eedaa13c72ce84b4b",
-		  "extract_dir": "biber-MSWIN64"
+  "architecture": {
+    "64bit": {
+      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN64.zip",
+      "hash": "8e7a4c98626511bcf1c89a1847242cdd0e0113927137577eedaa13c72ce84b4b",
+      "extract_dir": "biber-MSWIN64"
+    },
+    "32bit": {
+      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN32.zip",
+      "hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
+      "extract_dir": "biber-$version-MSWIN32"
+    }
+  "bin": "biber.exe",
   },
-          "32bit": {
-		"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN32.zip",
-		"hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
-		"extract_dir": "biber-$version-MSWIN32"
-	  }
-},
-"checkver": "sourceforge",
-"autoupdate":{
-	"architecture": {
-		"64bit": {
-			"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN64.zip",
-			"extract_dir": "biber-$version-MSWIN64"
-},
-		"32bit": {
-			"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN32.zip",
-			"extract_dir": "biber-$version-MSWIN32"
-		}
-	}
-	}
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN64.zip",
+        "extract_dir": "biber-$version-MSWIN64"
+      },
+      "32bit": {
+        "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN32.zip",
+        "extract_dir": "biber-$version-MSWIN32"
+      }
+    }
+  }
 }

--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.17",
+  "version": "2.18",
   "description": "Biber is a BibTeX replacement for users of biblatex, with full Unicode support.",
   "license": "Artistic License 2.0",
   "homepage": "https://sourceforge.net/projects/biblatex-biber/files/",
@@ -8,16 +8,20 @@
   },
   "architecture": {
     "64bit": {
-      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN64.zip",
+      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip",
       "hash": "8e7a4c98626511bcf1c89a1847242cdd0e0113927137577eedaa13c72ce84b4b",
       "extract_dir": "biber-MSWIN64"
     },
     "32bit": {
-      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN32.zip",
+      "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
       "hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
       "extract_dir": "biber-$version-MSWIN32"
     }
   "bin": "biber.exe",
+  },
+  "checkver": {
+      "github": "https://github.com/plk/biber",
+      "regex": "Biber ([\\d.]+)-"
   },
   "autoupdate": {
     "architecture": {

--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -1,0 +1,35 @@
+{
+  "bin": "biber.exe",
+  "license": "Artistic License 2.0",
+  "depends": "",
+  "version": "2.17",
+  "homepage": "https://sourceforge.net/projects/biblatex-biber/files/",
+  "suggest": {
+	  "tectonic": "tectonic"
+  },
+  "architecture":{
+	  "64bit": {
+		  "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN64.zip",
+		  "hash": "8e7a4c98626511bcf1c89a1847242cdd0e0113927137577eedaa13c72ce84b4b",
+		  "extract_dir": "biber-MSWIN64"
+  },
+          "32bit": {
+		"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.17/binaries/Windows/biber-MSWIN32.zip",
+		"hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
+		"extract_dir": "biber-$version-MSWIN32"
+	  }
+},
+"checkver": "sourceforge",
+"autoupdate":{
+	"architecture": {
+		"64bit": {
+			"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN64.zip",
+			"extract_dir": "biber-$version-MSWIN64"
+},
+		"32bit": {
+			"url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/$version/binaries/Windows/biber-MSWIN32.zip",
+			"extract_dir": "biber-$version-MSWIN32"
+		}
+	}
+	}
+}

--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -9,12 +9,12 @@
   "architecture": {
     "64bit": {
       "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip",
-      "hash": "8e7a4c98626511bcf1c89a1847242cdd0e0113927137577eedaa13c72ce84b4b",
+      "hash": "02ee3a8b6838b7ff1e9aea1a5342686981b9364067a7b8e7131c3b3201cf387c",
       "extract_dir": "biber-MSWIN64"
     },
     "32bit": {
       "url": "https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
-      "hash": "61e893fc72e9eb965c19e69c63e6b2c7ad3830b9f70bd92bb470d7d651a9a2ff",
+      "hash": "7328c7e6346b6776fcc5e01162d90312817851fb44171d7145d179a143567fb8",
       "extract_dir": "biber-$version-MSWIN32"
     }
   },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds the biber binary for use with latex installations. Does not require perl as it is already compiled with MSVC. 
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
