### PR TITLE
wakatime-cli: Add version 1.55.2

### DIFF
--- a/bucket/wakatime-cli.json
+++ b/bucket/wakatime-cli.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.55.2",
+    "description": "Command line interface to WakaTime used by all WakaTime text editor plugins.",
+    "homepage": "https://wakatime.com/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wakatime/wakatime-cli/releases/download/v1.55.2/wakatime-cli-windows-amd64.zip",
+            "hash": "ffdbc82fa5ef16ea52083607fa7b07e1803bbe1168388b4b43447c7ca7482f3f"
+        },
+        "32bit": {
+            "url": "https://github.com/wakatime/wakatime-cli/releases/download/v1.55.2/wakatime-cli-windows-386.zip",
+            "hash": "3364116b44bb76a84fdde7e2035dfb2ecea4bca707437d69b7af8741656103e5"
+        }
+    },
+    "pre_install": "Rename-Item \"$dir\\wakatime-cli-windows-*.exe\" 'wakatime-cli.exe'",
+    "bin": "wakatime-cli.exe",
+    "checkver": {
+        "github": "https://github.com/wakatime/wakatime-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wakatime/wakatime-cli/releases/download/v$version/wakatime-cli-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/wakatime/wakatime-cli/releases/download/v$version/wakatime-cli-windows-386.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Adds the wakatime-cli, a command line interface to [WakaTime](http://wakatime.com/) used by all WakaTime [text editor plugins](http://wakatime.com/editors).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
