### PR TITLE
7zip: Add `7zFM.exe` and `7zG.exe` to bin entry

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -26,7 +26,17 @@
         "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
         "}"
     ],
-    "bin": "7z.exe",
+    "bin": [
+        "7z.exe",
+        [
+            "7zFM.exe",
+            "7zfm"
+        ],
+        [
+            "7zG.exe",
+            "7zg"
+        ]
+    ],
     "shortcuts": [
         [
             "7zFM.exe",

--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -28,14 +28,8 @@
     ],
     "bin": [
         "7z.exe",
-        [
-            "7zFM.exe",
-            "7zfm"
-        ],
-        [
-            "7zG.exe",
-            "7zg"
-        ]
+        "7zFM.exe",
+        "7zG.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- `7zFM.exe`: Useful if you want to open the GUI file manager from the command line.
- `7zG.exe`: This is similar to `7z.exe`, except that it displays the progress in a separate GUI window, instead of the console.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
