### PR TITLE
Add git-credential-manager-core to shims

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -21,6 +21,7 @@
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
         "cmd\\scalar.exe",
+        "mingw64\\bin\\git-credential-manager-core.exe",
         "usr\\bin\\tig.exe",
         "git-bash.exe"
     ],


### PR DESCRIPTION
When you select "Git Credential Manager" in the UI popup asking for where credentials should be stored,
Git adds the following to `~/.gitconfig`:
```properties
[credential]
        helper = !\":/Users/mmauch/scoop/apps/git/2.37.3.windows.1/mingw64/bin/git-credential-manager-core.exe"
```
Now, whenever the Git version is updated, one manually has to change this path to the new version.
By providing a shim, one can instead point to `~/scoop/shims/git-credential-manager-core.exe` and be version-independent.