### PR TITLE
fzf: Add `arm64` architecture

### DIFF
--- a/bucket/fzf.json
+++ b/bucket/fzf.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/junegunn/fzf/releases/download/0.34.0/fzf-0.34.0-windows_amd64.zip",
             "hash": "8fb01d13587fb1e240129ce11b5814ea2b7e08a9f014b363d3e79cec595b80e5"
+        },
+        "arm64": {
+            "url": "https://github.com/junegunn/fzf/releases/download/0.34.0/fzf-0.34.0-windows_arm64.zip",
+            "hash": "875151b30c39e17f9a74229d73463225dbea1444f414099b624ac1bd38262207"
         }
     },
     "bin": "fzf.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/junegunn/fzf/releases/download/$version/fzf-$version-windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/junegunn/fzf/releases/download/$version/fzf-$version-windows_arm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

So what would the order of architecture be with `arm64`? Something like: `64bit`, `32bit`, `arm64`?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
