### PR TITLE
gobuster: Fix urls and add arm64 architecture

### DIFF
--- a/bucket/gobuster.json
+++ b/bucket/gobuster.json
@@ -1,18 +1,20 @@
 {
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "A tool to brute-force URIs, DNS subdomains or Virtual Host names",
     "homepage": "https://github.com/OJ/gobuster",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/OJ/gobuster/releases/download/v3.1.0/gobuster-windows-amd64.7z",
-            "hash": "31c0e87ebc91f065554ce031af9783e8b898631b9e32541abee23d14c55a8af1",
-            "extract_dir": "gobuster-windows-amd64"
+            "url": "https://github.com/OJ/gobuster/releases/download/v3.2.0/gobuster_3.2.0_Windows_x86_64.zip",
+            "hash": "fce95296c5f262717ec43b5ebf2b82c88edc042d4dc4bfa793ad4fd014902014"
         },
         "32bit": {
-            "url": "https://github.com/OJ/gobuster/releases/download/v3.1.0/gobuster-windows-386.7z",
-            "hash": "737032176e4affce74c5332879afbc2452c8af05da3ae9c755b1d5eb3930f56a",
-            "extract_dir": "gobuster-windows-386"
+            "url": "https://github.com/OJ/gobuster/releases/download/v3.2.0/gobuster_3.2.0_Windows_i386.zip",
+            "hash": "6f1e43cd25c9b010e1c0e108851ead50a26470a627dc8d1da8c28d718e48c02c"
+        },
+        "arm64": {
+            "url": "https://github.com/OJ/gobuster/releases/download/v3.2.0/gobuster_3.2.0_Windows_arm64.zip",
+            "hash": "2d5e3dc965943d71ce40ebfeb8084f80f9fbc00bf8e285d5bfcf6b9231195240"
         }
     },
     "bin": "gobuster.exe",
@@ -20,17 +22,17 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/OJ/gobuster/releases/download/v$version/gobuster-windows-amd64.7z",
-                "extract_dir": "gobuster-windows-amd64"
+                "url": "https://github.com/OJ/gobuster/releases/download/v$version/gobuster_$version_Windows_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/OJ/gobuster/releases/download/v$version/gobuster-windows-386.7z",
-                "extract_dir": "gobuster-windows-386"
+                "url": "https://github.com/OJ/gobuster/releases/download/v$version/gobuster_$version_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/OJ/gobuster/releases/download/v$version/gobuster_$version_Windows_arm64.zip"
             }
         },
         "hash": {
-            "url": "https://github.com/OJ/gobuster/releases/tag/v$version",
-            "regex": "$sha256.*$basename"
+            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
The structure of the releases has changed with the latest version. Additionally, an arm64 binary is now available.

https://github.com/OJ/gobuster/releases

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
