### PR TITLE
7zip: Add ARM64 arch

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -22,7 +22,7 @@
                 "$7zr = Join-Path $env:TMP '7zr.exe'",
                 "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
                 "Invoke-ExternalCommand $7zr @('x', \"$dir\\$fname\", \"-o$dir\", '-y') | Out-Null",
-                "Remove-Item \"$dir\\Uninstall.exe\", \"$dir\\*-arm64.exe\""
+                "Remove-Item \"$dir\\Uninstall.exe\", \"$dir\\*-arm64.exe\", $7zr"
             ]
         }
     },

--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -21,7 +21,8 @@
             "pre_install": [
                 "$7zr = Join-Path $env:TMP '7zr.exe'",
                 "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
-                "Invoke-ExternalCommand $7zr @('x', \"$dir\\$fname\", \"-o$dir\", '-y') | Out-Null"
+                "Invoke-ExternalCommand $7zr @('x', \"$dir\\$fname\", \"-o$dir\", '-y') | Out-Null",
+                "Remove-Item \"$dir\\Uninstall.exe\", \"$dir\\*-arm64.exe\""
             ]
         }
     },

--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -6,15 +6,25 @@
     "notes": "Add 7-Zip as a context menu option by running: \"$dir\\install-context.reg\"",
     "architecture": {
         "64bit": {
-            "url": "https://7-zip.org/a/7z2201-x64.msi",
-            "hash": "f4afba646166999d6090b5beddde546450262dc595dddeb62132da70f70d14ca"
+            "url": "https://www.7-zip.org/a/7z2201-x64.msi",
+            "hash": "f4afba646166999d6090b5beddde546450262dc595dddeb62132da70f70d14ca",
+            "extract_dir": "Files\\7-Zip"
         },
         "32bit": {
-            "url": "https://7-zip.org/a/7z2201.msi",
-            "hash": "a4913f98821e0da0c58cd3a7f2a59f1834b85b6ca6b3fdefa5454d6c3bbef54c"
+            "url": "https://www.7-zip.org/a/7z2201.msi",
+            "hash": "a4913f98821e0da0c58cd3a7f2a59f1834b85b6ca6b3fdefa5454d6c3bbef54c",
+            "extract_dir": "Files\\7-Zip"
+        },
+        "arm64": {
+            "url": "https://www.7-zip.org/a/7z2201-arm64.exe",
+            "hash": "700dea3e4012319a09ccadfce91cf090334cfe658d0bdc42204e77acbea1ef99",
+            "pre_install": [
+                "$7zr = Join-Path $env:TMP '7zr.exe'",
+                "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
+                "Invoke-ExternalCommand $7zr @('x', \"$dir\\$fname\", \"-o$dir\", '-y') | Out-Null"
+            ]
         }
     },
-    "extract_dir": "Files\\7-Zip",
     "post_install": [
         "$7zip_root = \"$dir\".Replace('\\', '\\\\')",
         "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
@@ -48,10 +58,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://7-zip.org/a/7z$cleanVersion-x64.msi"
+                "url": "https://www.7-zip.org/a/7z$cleanVersion-x64.msi"
             },
             "32bit": {
-                "url": "https://7-zip.org/a/7z$cleanVersion.msi"
+                "url": "https://www.7-zip.org/a/7z$cleanVersion.msi"
+            },
+            "arm64": {
+                "url": "https://www.7-zip.org/a/7z$cleanVersion-arm64.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

7-zip doesn't provides MSI installer for ARM64, so use 7zr as bridge.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
