### PR TITLE
procs@0.13.3: Remove extract_dir

### DIFF
--- a/bucket/procs.json
+++ b/bucket/procs.json
@@ -6,8 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/dalance/procs/releases/download/v0.13.3/procs-v0.13.3-x86_64-windows.zip",
-            "hash": "9e3dee1f7f20dca5e70de74e2b9dff7571227984450a3c7279dd51289af17e96",
-            "extract_dir": "target\\x86_64-pc-windows-msvc\\release"
+            "hash": "9e3dee1f7f20dca5e70de74e2b9dff7571227984450a3c7279dd51289af17e96"
         }
     },
     "bin": "procs.exe",


### PR DESCRIPTION
Fix procs manifes by removing `extract_dir` ([since v0.13.3](https://github.com/dalance/procs/blob/master/CHANGELOG.md) release zip for Windows has the exe at toplevel).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
