### PR TITLE
cheat: Fix install

### DIFF
--- a/bucket/cheat.json
+++ b/bucket/cheat.json
@@ -14,14 +14,18 @@
         "$file = 'conf.yml'",
         "if (!(Test-Path \"$persist_dir\\$file\")) {",
         "   Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
-        "   $CONT = $(& \"$dir\\cheat\" --init) -replace 'editor: vim', 'editor: notepad' -replace 'cheatsheets/', \"$persist_dir/cheatsheets/\"",
-        "   Set-Content \"$dir\\$file\" ($CONT -replace '\\\\', '/') -Encoding ASCII",
+        "   New-Item -ItemType File -Force -Path \"$dir\\$file\" | Out-Null",
         "}",
         "if (!(Test-Path \"$persist_dir\\cheatsheets\")) {",
         "   Write-Host 'Adding community cheatsheets...' -f Yellow",
         "   New-item -ItemType Directory -Force -Path \"$persist_dir\\cheatsheets\\personal\" | Out-Null",
         "   git clone -q 'https://github.com/cheat/cheatsheets.git' \"$persist_dir\\cheatsheets\\community\"",
         "}"
+    ],
+    "post_install": [
+        "$file = 'conf.yml'",
+        "$CONT = $(& \"$dir\\cheat\" --init) -replace 'editor: EDITOR_PATH', 'editor: notepad' -replace 'pager: PAGER_PATH', 'pager: more'",
+        "Set-Content \"$dir\\$file\" $CONT -Encoding ASCII"
     ],
     "env_set": {
         "CHEAT_CONFIG_PATH": "$dir\\conf.yml"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

* For the cheatsheets path to be set correctly, the configuration file should be initialized after the environment variables are set.
* Set `pager` to more, 'more' is recommended on Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
