### PR TITLE
ect @ 0.9.3: Fix broken ect download.

### DIFF
--- a/bucket/ect.json
+++ b/bucket/ect.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fhanau/Efficient-Compression-Tool/releases/download/v0.9.3/ect-0.9.3-win64.zip",
+            "url": "https://github.com/fhanau/Efficient-Compression-Tool/releases/download/v0.9.3/ect-0.9.3-fix-win64.zip",
             "hash": "d3893fe5117a66e0cc8ff6f8d4d5fdc0e77931f54fbef11cb1faac83bedf8c1c"
         }
     },


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

No idea why they decided to break the naming convention, and only for 0.9.3 and 0.9.2. Might be a good idea to raise this up in the ect issue tracker.