### PR TITLE
v2ray: Remove binary verification step(installer.script)

### DIFF
--- a/bucket/v2ray.json
+++ b/bucket/v2ray.json
@@ -13,20 +13,6 @@
             "hash": "sha512:24757e80b4346493de5a9910dcc55adf4407de1da98a967f5c9310fc311f4b969474b28477292daf60d569aec053fead6435cb36c13de210aa742e13d02719d3"
         }
     },
-    "installer": {
-        "script": [
-            "#v2ray.exe cannot recognize signature file when there are spaces in path. This is a workaround to eliminate spaces.",
-            "Write-Host 'Verifying V2Ray binary...' -f Yellow",
-            "$sig_dir = \"$Env:SystemRoot\\Temp\\v2ray\"",
-            "ensure $sig_dir | Out-Null",
-            "Invoke-WebRequest \"https://github.com/v2fly/v2ray-core/releases/download/v$version/Release\" -OutFile $sig_dir\\Release",
-            "if (!(Invoke-Expression \"&`\"$dir\\v2ray.exe`\" verify --sig=$sig_dir\\Release `\"$dir\\v2ray.exe`\"\" | Select-String 'OK')) {",
-            "    Write-Host 'V2Ray binary is corrupted!' -f Red",
-            "    break",
-            "}",
-            "Remove-Item $sig_dir -Force -Recurse | Out-Null"
-        ]
-    },
     "bin": "v2ray.exe",
     "persist": "config.json",
     "checkver": {


### PR DESCRIPTION
- Scoop already hash-checked the downloaded files
- This step caused some distress for the main users of the app
- Removing the verification will not cause security issue

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #4057

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
