### PR TITLE
vhs: Added version 0.1.1

### DIFF
--- a/ttyd.json
+++ b/ttyd.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.7.2",
+    "homepage": "https://github.com/tsl0922/ttyd",
+    "description": "A cli appication for sharing your terminal all over the web.",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tsl0922/ttyd/releases/download/1.7.2/ttyd.win10.exe#/ttyd.exe",
+            "hash": "178382D13A5FA3294E98D4E0AEE5D1084706E958F01C380BA25CBE2EB784C27D"
+        }
+    },
+    "bin": "ttyd.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tsl0922/ttyd/releases/download/$version/ttyd.win10.exe#/ttyd.exe"
+            }
+        }
+    }
+}

--- a/vhs.json
+++ b/vhs.json
@@ -1,0 +1,36 @@
+{
+    "version": "0.1.1",
+    "homepage": "https://github.com/charmbracelet/vhs",
+    "description": "A cli application that allows you to create terminal GIFs as code for integration testing and demoing your CLI tools (ex. neofetch/winfetch).",
+    "license": "MIT",
+    "depends": "ttyd",
+    "suggest": {
+        "ffmpeg": "main/ffmpeg"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/charmbracelet/vhs/releases/download/v0.1.1/vhs_0.1.1_Windows_x86_64.zip",
+            "hash": "c628a4e2eac78f48036d464d0571295a932dadc76220d6a66daea1a60c599713"
+        },
+        "32bit": {
+            "url": "https://github.com/charmbracelet/vhs/releases/download/v0.1.1/vhs_0.1.1_Windows_i386.zip",
+            "hash": "88c1ab9321e593cf22aa199624db9dbca5954c86f67a48a6e2bb3119e4f9c851"
+        }
+    },
+    "bin": "vhs.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/charmbracelet/vhs/releases/download/v$version/vhs_$version_Windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/charmbracelet/vhs/releases/download/v$version/vhs_$version_Windows_i386.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256\\s+vhs_$version_Windows"
+        }
+    }
+}


### PR DESCRIPTION
Also added ttyd, as vhs depends on it to work.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes https://github.com/ScoopInstaller/Extras/issues/9604

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
