### PR TITLE
sqlcl: update to 22.3.1.285.1825

### DIFF
--- a/bucket/sqlcl.json
+++ b/bucket/sqlcl.json
@@ -1,5 +1,5 @@
 {
-    "version": "22.2.1.201.1451",
+    "version": "22.3.1.285.1825",
     "description": "Oracle SQL Developer Command Line (SQLcl)",
     "homepage": "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl",
     "license": {
@@ -9,8 +9,8 @@
     "suggest": {
         "JRE": "java/oraclejdk"
     },
-    "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-22.2.1.201.1451.zip",
-    "hash": "b478af0eb8a1bd864d47c06d242bc662ffc030f651781acd88469f5a839c18c7",
+    "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip",
+    "hash": "76c9bfa69a76804b67b5d7ad008bad51508bb3a0cbca9ffb3f1551fe4545127b",
     "extract_dir": "sqlcl",
     "bin": "bin\\sql.exe",
     "checkver": {
@@ -18,6 +18,7 @@
         "regex": ">([\\d.]+)</a>"
     },
     "autoupdate": {
-        "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-$version.zip"
+        "url": "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip"
     }
 }
+


### PR DESCRIPTION

- [ X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Already Verified:
> sql -v
> SQLcl: Release 22.3.1.0 Production Build: 22.3.1.285.1828