### PR TITLE
zig: update to version 0.10.0

### DIFF
--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.1",
+    "version": "0.10.0",
     "description": "General-purpose programming language designed for robustness, optimality, and maintainability.",
     "homepage": "https://ziglang.org/",
     "license": "MIT",
@@ -8,14 +8,9 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://ziglang.org/download/0.9.1/zig-windows-x86_64-0.9.1.zip",
-            "hash": "443da53387d6ae8ba6bac4b3b90e9fef4ecbe545e1c5fa3a89485c36f5c0e3a2",
-            "extract_dir": "zig-windows-x86_64-0.9.1"
-        },
-        "32bit": {
-            "url": "https://ziglang.org/download/0.9.1/zig-windows-i386-0.9.1.zip",
-            "hash": "74a640ed459914b96bcc572183a8db687bed0af08c30d2ea2f8eba03ae930f69",
-            "extract_dir": "zig-windows-i386-0.9.1"
+            "url": "https://ziglang.org/download/0.10.0/zig-windows-x86_64-0.10.0.zip",
+            "hash": "a66e2ff555c6e48781de1bcb0662ef28ee4b88af3af2a577f7b1950e430897ee",
+            "extract_dir": "zig-windows-x86_64-0.10.0"
         }
     },
     "bin": "zig.exe",
@@ -28,10 +23,6 @@
             "64bit": {
                 "url": "https://ziglang.org/download/$version/zig-windows-x86_64-$version.zip",
                 "extract_dir": "zig-windows-x86_64-$version"
-            },
-            "32bit": {
-                "url": "https://ziglang.org/download/$version/zig-windows-i386-$version.zip",
-                "extract_dir": "zig-windows-i386-$version"
             }
         },
         "hash": {

--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -31,7 +31,7 @@
             },
             "arm64": {
                 "url": "https://ziglang.org/download/$version/zig-windows-aarch64-$version.zip",
-                "extract_dir": "zig-windows-aarch64-$version"               
+                "extract_dir": "zig-windows-aarch64-$version"
             }
         },
         "hash": {

--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -11,6 +11,11 @@
             "url": "https://ziglang.org/download/0.10.0/zig-windows-x86_64-0.10.0.zip",
             "hash": "a66e2ff555c6e48781de1bcb0662ef28ee4b88af3af2a577f7b1950e430897ee",
             "extract_dir": "zig-windows-x86_64-0.10.0"
+        },
+        "arm64": {
+            "url": "https://ziglang.org/download/0.10.0/zig-windows-aarch64-0.10.0.zip",
+            "hash": "1bbda8d123d44f3ae4fa90d0da04b1e9093c3f9ddae3429a4abece1e1c0bf19a",
+            "extract_dir": "zig-windows-aarch64-0.10.0"            
         }
     },
     "bin": "zig.exe",
@@ -23,6 +28,10 @@
             "64bit": {
                 "url": "https://ziglang.org/download/$version/zig-windows-x86_64-$version.zip",
                 "extract_dir": "zig-windows-x86_64-$version"
+            },
+            "arm64": {
+                "url": "https://ziglang.org/download/$version/zig-windows-aarch64-$version.zip",
+                "extract_dir": "zig-windows-aarch64-$version"               
             }
         },
         "hash": {

--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -15,7 +15,7 @@
         "arm64": {
             "url": "https://ziglang.org/download/0.10.0/zig-windows-aarch64-0.10.0.zip",
             "hash": "1bbda8d123d44f3ae4fa90d0da04b1e9093c3f9ddae3429a4abece1e1c0bf19a",
-            "extract_dir": "zig-windows-aarch64-0.10.0"            
+            "extract_dir": "zig-windows-aarch64-0.10.0"
         }
     },
     "bin": "zig.exe",


### PR DESCRIPTION
Update zig to version 0.10.0

The [official download](https://ziglang.org/download/) page doesn't have a 32 bit build for Windows platform anymore (nor the [official Github repo](https://github.com/ziglang/zig/releases)) so I removed that from the manifest.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
