### PR TITLE
rust, rust-msvc: Remove rls bin

### DIFF
--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -19,7 +19,6 @@
     },
     "extract_dir": "Rust",
     "bin": [
-        "bin\\rls.exe",
         "bin\\rustc.exe",
         "bin\\rustdoc.exe",
         "bin\\cargo.exe"

--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -15,7 +15,6 @@
     },
     "extract_dir": "Rust",
     "bin": [
-        "bin\\rls.exe",
         "bin\\rustc.exe",
         "bin\\rustdoc.exe",
         "bin\\cargo.exe"


### PR DESCRIPTION
https://blog.rust-lang.org/2022/07/01/RLS-deprecation.html
Fixes:
```
Creating shim for 'rls'.
Can't shim 'bin\rls.exe': File doesn't exist.
```
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).