### PR TITLE
Add arm64 version to pwsh

### DIFF
--- a/bucket/pwsh.json
+++ b/bucket/pwsh.json
@@ -18,6 +18,10 @@
         "32bit": {
             "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.2.7/PowerShell-7.2.7-win-x86.zip",
             "hash": "c82c042e05ba7fc66dd84d43fa46b33131acfc7028b8af724ac149171d2d24b5"
+        },
+        "arm64": {
+            "url": "https://github.com/PowerShell/PowerShell/releases/download/v7.2.7/PowerShell-7.2.7-win-arm64.zip",
+            "hash": "626aed993f6f7906920a0fed1645ee988a86af9700607a04ed219122dd7f4851"
         }
     },
     "pre_install": [
@@ -57,6 +61,9 @@
             },
             "32bit": {
                 "url": "https://github.com/PowerShell/PowerShell/releases/download/v$version/PowerShell-$version-win-x86.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/PowerShell/PowerShell/releases/download/v$version/PowerShell-$version-win-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
This allows installing native arm64 binaries on arm64 systems.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
