### PR TITLE
doggo: Add version 0.5.4

### DIFF
--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/mr-karan/doggo/releases/download/v0.5.4/doggo_0.5.4_windows_amd64.tar.gz",
             "hash": "0923e035492b8c55b25e6250fe744c5c7559786364d3c758707104a564dd0a16"
+        },
+        "arm64": {
+            "url": "https://github.com/mr-karan/doggo/releases/download/v0.5.4/doggo_0.5.4_windows_arm64.tar.gz",
+            "hash": "efbde34ea7c238461e6d7d57061ff4761021cff2499af8c0634bce5705d0c465"
         }
     },
     "bin": "doggo.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_windows_arm64.tar.gz"
             }
         },
         "hash": {

--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.5.4",
+    "description": "Command-line DNS Client for Humans",
+    "homepage": "https://doggo.mrkaran.dev/",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mr-karan/doggo/releases/download/v0.5.4/doggo_0.5.4_windows_amd64.tar.gz",
+            "hash": "0923e035492b8c55b25e6250fe744c5c7559786364d3c758707104a564dd0a16"
+        }
+    },
+    "bin": "doggo.exe",
+    "checkver": {
+        "github": "https://github.com/mr-karan/doggo"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_windows_amd64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/doggo_$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Add [doggo](https://github.com/mr-karan/doggo/), a command-line DNS client.

Closes #4044.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).