### PR TITLE
jo: Fix bin

### DIFF
--- a/bucket/jo.json
+++ b/bucket/jo.json
@@ -3,11 +3,11 @@
     "description": "A tool for creating JSON objects from CLI",
     "homepage": "https://github.com/jpmens/jo",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/jpmens/jo/releases/download/1.9/jo-1.9.exe",
+    "url": "https://github.com/jpmens/jo/releases/download/1.9/jo-1.9.exe#/jo.exe",
     "hash": "1c038153946ad7611166d36a5f6ce57e7704d8b89c51a4864c4fc821116521b6",
     "bin": "jo.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/jpmens/jo/releases/download/$version/jo-$version.exe"
+        "url": "https://github.com/jpmens/jo/releases/download/$version/jo-$version.exe#/jo.exe"
     }
 }


### PR DESCRIPTION
Fixes:
```
Can't shim 'jo.exe': File doesn't exist.
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).