### PR TITLE
Fix "FATAL: role "postgres" does not exist"

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -22,7 +22,7 @@
     ],
     "post_install": [
         "if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) {",
-        "   Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList \"--username=postgres --encoding=UTF8 --locale=en --lc-collate=C\" | Out-Null",
+        "   Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList @('--username=postgres', '--encoding=UTF8', '--locale=en', '--lc-collate=C') | Out-Null",
         "}"
     ],
     "shortcuts": [


### PR DESCRIPTION
A problem, caused by using the old line `Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList \"--username=postgres --encoding=UTF8 --locale=en --lc-collate=C\" | Out-Null`, occurs in Windows so that people could not login by the default superuser Id "postgres"

By migration to the new line `Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList @('--username=postgres', '--encoding=UTF8', '--locale=en', '--lc-collate=C') | Out-Null`, the issue is eliminated.

Relates to #3832

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

