### PR TITLE
chore: Add arm64 architecture for some apps

### DIFF
--- a/bucket/ddosify.json
+++ b/bucket/ddosify.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/ddosify/ddosify/releases/download/v0.9.0/ddosify_0.9.0_windows_386.zip",
             "hash": "04eb03d486354a257ba8b583070efd60fc838cf8209869cc6a5a87bb43223fdb"
+        },
+        "arm64": {
+            "url": "https://github.com/ddosify/ddosify/releases/download/v0.9.0/ddosify_0.9.0_windows_arm64.zip",
+            "hash": "6c51b876196b7194740a95ffcc493bd0d01013d0bdbdc85181e2af72ddd3fec8"
         }
     },
     "bin": "ddosify.exe",
@@ -24,6 +28,9 @@
             },
             "32bit": {
                 "url": "https://github.com/ddosify/ddosify/releases/download/v$version/ddosify_$version_windows_386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/ddosify/ddosify/releases/download/v$version/ddosify_$version_windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/duf.json
+++ b/bucket/duf.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/muesli/duf/releases/download/v0.8.1/duf_0.8.1_Windows_i386.zip",
             "hash": "1d8829b7f93dfe532bf29015b8826d6d384d6f25c751e9118a12b9ff63ae881a"
+        },
+        "arm64": {
+            "url": "https://github.com/muesli/duf/releases/download/v0.8.1/duf_0.8.1_Windows_arm64.zip",
+            "hash": "f56dae76498f543d7c6335ce77fae5661e3c6e085d5423f1d7af8be2f2bf96f1"
         }
     },
     "bin": "duf.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/muesli/duf/releases/download/v$version/duf_$version_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/muesli/duf/releases/download/v$version/duf_$version_Windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/fx.json
+++ b/bucket/fx.json
@@ -5,17 +5,23 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/antonmedv/fx/releases/download/24.0.0/fx_windows_amd64.exe",
+            "url": "https://github.com/antonmedv/fx/releases/download/24.0.0/fx_windows_amd64.exe#/fx.exe",
             "hash": "e663e5fae64f2b14ffdff837289fccb8f5b5f2156cb6012d9269ad87e38d9867"
+        },
+        "arm64": {
+            "url": "https://github.com/antonmedv/fx/releases/download/24.0.0/fx_windows_arm64.exe#/fx.exe",
+            "hash": "6ce7ca591c621161debd982cce10240699c6a3d9c76fa4287442db6158b1ceaa"
         }
     },
-    "pre_install": "Rename-Item \"$dir\\fx_windows_amd64.exe\" 'fx.exe'",
     "bin": "fx.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/antonmedv/fx/releases/download/$version/fx_windows_amd64.exe"
+                "url": "https://github.com/antonmedv/fx/releases/download/$version/fx_windows_amd64.exe#/fx.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/antonmedv/fx/releases/download/$version/fx_windows_arm64.exe#/fx.exe"
             }
         }
     }

--- a/bucket/gron.json
+++ b/bucket/gron.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/tomnomnom/gron/releases/download/v0.7.1/gron-windows-386-0.7.1.zip",
             "hash": "a532d5aa29395592f3725c336640f2cf9eb670c8ce25115aaee0082d5cdf5a0e"
+        },
+        "arm64": {
+            "url": "https://github.com/tomnomnom/gron/releases/download/v0.7.1/gron-windows-arm64-0.7.1.zip",
+            "hash": "9bd38a241f1afdbd3c8f952b92b7090e7a446cac5251bfed3fdf28f219c9dda8"
         }
     },
     "bin": "gron.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-386-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-arm64-$version.zip"
             }
         }
     }

--- a/bucket/gron.json
+++ b/bucket/gron.json
@@ -13,5 +13,16 @@
             "hash": "a532d5aa29395592f3725c336640f2cf9eb670c8ce25115aaee0082d5cdf5a0e"
         }
     },
-    "bin": "gron.exe"
+    "bin": "gron.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-amd64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/tomnomnom/gron/releases/download/v$version/gron-windows-386-$version.zip"
+            }
+        }
+    }
 }

--- a/bucket/hopp-cli.json
+++ b/bucket/hopp-cli.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v0.0.8/hopp-cli_0.0.8_windows_x86_64.tar.gz",
             "hash": "17307a8d0fa1b38174807a10218d23dffc0c58c46449912fe472595cc23acfef"
+        },
+        "arm64": {
+            "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v0.0.8/hopp-cli_0.0.8_windows_arm64.tar.gz",
+            "hash": "accc78843c9755796b18aa568df184c8942f4a40833c28a0719a1fe1907be830"
         }
     },
     "bin": "hopp-cli.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v$version/hopp-cli_$version_windows_x86_64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/hoppscotch/hopp-cli/releases/download/v$version/hopp-cli_$version_windows_arm64.tar.gz"
             }
         },
         "hash": {

--- a/bucket/octosql.json
+++ b/bucket/octosql.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/cube2222/octosql/releases/download/v0.12.0/octosql_0.12.0_windows_amd64.tar.gz",
             "hash": "485417bd673f467142e02e64eaf96b9e87958b555379e6d38208b8dcee7ad2de"
+        },
+        "arm64": {
+            "url": "https://github.com/cube2222/octosql/releases/download/v0.12.0/octosql_0.12.0_windows_arm64.tar.gz",
+            "hash": "49d63e35f76d041e1f37d87958626ca6e48361f3b600c18515a00892d7293a4a"
         }
     },
     "bin": "octosql.exe",
@@ -14,11 +18,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/cube2222/octosql/releases/download/v$version/octosql_$version_windows_amd64.tar.gz",
-                "hash": {
-                    "url": "$baseurl/octosql_$version_checksums.txt"
-                }
+                "url": "https://github.com/cube2222/octosql/releases/download/v$version/octosql_$version_windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/cube2222/octosql/releases/download/v$version/octosql_$version_windows_arm64.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/octosql_$version_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Add arm64 architecture for some apps.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
