### PR TITLE
mdcat: Update links

### DIFF
--- a/bucket/mdcat.json
+++ b/bucket/mdcat.json
@@ -1,24 +1,27 @@
 {
-    "version": "0.25.1",
+    "version": "0.29.0",
     "description": "cat for markdown",
-    "homepage": "https://codeberg.org/flausch/mdcat",
+    "homepage": "https://github.com/lunaryorn/mdcat",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://codeberg.org/attachments/eb3b0e1e-dda9-4133-938e-c3a0bcfa2887#/dl.zip",
-            "hash": "ea5e9abfe9c92e95e7ac411ae68af6e234f0f17a10db597838a0f82e016f58e4"
+            "url": "https://github.com/lunaryorn/mdcat/releases/download/mdcat-0.29.0/mdcat-0.29.0-x86_64-pc-windows-msvc.zip",
+            "hash": "sha512:6ed6e3a24bde4c24c74a09dcc4fcf5b65dd084d87ff465f1682ac7d5e5f75d0716d4b48eba3fc07a884068cb84e5b6a33fafa1f813fde46b35b0d95fd5656e95"
         }
     },
     "bin": "mdcat.exe",
     "checkver": {
-        "url": "https://codeberg.org/flausch/mdcat/releases",
-        "regex": "(?sm)(?<attachmentId>[0-9a-f-]{36})\"\\>\\s+<strong><span[^<]*mdcat-([\\d.]+)-x86_64-pc-windows-msvc\\.zip"
+        "github": "https://github.com/lunaryorn/mdcat",
+        "regex": "mdcat-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://codeberg.org/attachments/$matchAttachmentid#/dl.zip"
+                "url": "https://github.com/lunaryorn/mdcat/releases/download/mdcat-$version/mdcat-$version-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA512SUM.txt"
         }
     }
 }


### PR DESCRIPTION
Since mdcat moved back to github from [codeberg](https://codeberg.org/flausch/mdcat), and binaries release restored.
As per [v0.29.0 release notes](https://github.com/lunaryorn/mdcat/releases/tag/mdcat-0.29.0).

Closes #3914.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).