### PR TITLE
python: Add arm64 architecture

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -12,12 +12,21 @@
         "32bit": {
             "url": "https://www.python.org/ftp/python/3.11.0/python-3.11.0.exe#/setup.exe",
             "hash": "2d7b87eacdd5925af4e0db0ec155dd2b765aa27efe609c0684cacc6fbf46f104"
+        },
+        "arm64": {
+            "url": "https://www.python.org/ftp/python/3.11.0/python-3.11.0-arm64.exe#/setup.exe",
+            "hash": "5638e4339eb320cee1fcc7c2722252fc6a6b0855b517a7ea72b01a0c57767091"
         }
     },
     "pre_install": [
         "$py_root = \"$dir\".Replace('\\', '\\\\')",
+        "$py_archLabel = '64-bit'",
         "$bit = '64'",
-        "if ($architecture -eq '32bit') { $bit = '32' }",
+        "if ($architecture -eq '32bit') {",
+        "    $py_archLabel = '32-bit'",
+        "    $bit = '32'",
+        "}",
+        "if ($architecture -eq 'arm64') { $py_archLabel = 'ARM64' }",
         "'install-pep-514.reg', 'uninstall-pep-514.reg' | ForEach-Object {",
         "    $py_version = ($version -split '\\.')[0..1] -join '.'",
         "    $content = Get-Content \"$bucketsdir\\main\\scripts\\python\\$_\"",
@@ -25,6 +34,7 @@
         "    $content = $content.Replace('$py_version', $py_version)",
         "    $content = $content.Replace('$py_fullversion', $version)",
         "    $content = $content.Replace('$py_cleanVersion', $version -replace '\\.')",
+        "    $content = $content.Replace('$py_archLabel', $py_archLabel)",
         "    $content = $content.Replace('$py_arch', \"$bit\")",
         "    if ($global) {",
         "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
@@ -92,6 +102,9 @@
             },
             "32bit": {
                 "url": "https://www.python.org/ftp/python/$version/python-$version.exe#/setup.exe"
+            },
+            "arm64": {
+                "url": "https://www.python.org/ftp/python/$version/python-$version-arm64.exe#/setup.exe"
             }
         },
         "hash": {

--- a/scripts/python/install-pep-514.reg
+++ b/scripts/python/install-pep-514.reg
@@ -5,7 +5,7 @@ Windows Registry Editor Version 5.00
 "SupportUrl"="https://www.python.org/"
 
 [HKEY_CURRENT_USER\Software\Python\PythonCore\$py_version]
-"DisplayName"="Python $py_version ($py_arch-bit)"
+"DisplayName"="Python $py_version ($py_archLabel)"
 "SupportUrl"="https://www.python.org/"
 "Version"="$py_fullversion"
 "SysVersion"="$py_version"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

----

I added a new variable named `$py_archLabel` in `pre_install` script as `$bit` is not enough to distinguish ARM64 from x64.

| `$architecture` | `$py_archLabel` | `$bit` | `DisplayName`[^1]        | `SysArchitecture`[^2] |
|-----------------|-----------------|--------|--------------------------|-----------------------|
| `64bit`         | `64-bit`        | `64`   | `Python 3.11.0 (64-bit)` | `64bit`               |
| `32bit`         | `32-bit`        | `32`   | `Python 3.11.0 (32-bit)` | `32bit`               |
| `arm64`         | `ARM64`         | `64`   | `Python 3.11.0 (ARM64)`  | `64bit`               |

[^1]: Those architecture names in parentheses follow the names used in [Python 3.11.0 release note][1].
[^2]: Those `SysArchitecture` values are intended to be read by [CPython's *PC/layout/support/appxmanifest.py* script][2].

[1]: https://www.python.org/downloads/release/python-3110/
[2]: https://github.com/python/cpython/blob/deaf509e8fc6e0363bd6f26d52ad42f976ec42f2/PC/layout/support/appxmanifest.py#L343-L349