### PR TITLE
dotnet-sdk: Update to version 7.0.100 and fix autoupdate

### DIFF
--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.0.403",
+    "version": "7.0.100",
     "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
     "homepage": "https://www.microsoft.com/net/",
     "license": "MIT",
@@ -8,16 +8,16 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.403/dotnet-sdk-6.0.403-win-x64.zip",
-            "hash": "sha512:8f0c99249f34724d99fe2e7b8955098b5f5531dd9c7199453f1a5f066981de58b8324a5dbd92548e665b1c208c241f9603d8a18ea51b27fd4fdf0c17abc7392b"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.100/dotnet-sdk-7.0.100-win-x64.zip",
+            "hash": "sha512:e77fa3501f6945dd5730dbcec7632f070314717c6abfa95f95e13db53bfd55d2f46faa45809f796535749c8d98251828a4b4ab4d5ceb3ee1daa5262c6907f906"
         },
         "32bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.403/dotnet-sdk-6.0.403-win-x86.zip",
-            "hash": "sha512:a37400428f755929bc75a6f8b0aa0aea7f631b1ae3727a38682c7dec312d586d21357c071f3180a0333ed339e7e1b3dbc9f7666a8a3d12c27fdc35f821e5a849"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.100/dotnet-sdk-7.0.100-win-x86.zip",
+            "hash": "sha512:ae586c292334c51eebf5f0e6bcaa7e3a56a06a37d24278bd132f2df62702f79fab3b4a478c2b25a2920e40d34b3b79d89cb1c831eb1d94927f0652842d47a5a2"
         },
         "arm64": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.403/dotnet-sdk-6.0.403-win-arm64.zip",
-            "hash": "sha512:f3213ac5e7551102be48ca5c65fe098714a79a03ed3111d368ad07eb85ac22fea4c05a356fe742feb231e76f4d3e510954d4235631e0686d19bb0cb2f02b7e4a"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/7.0.100/dotnet-sdk-7.0.100-win-arm64.zip",
+            "hash": "sha512:62ecf2bb2466da663117563b8cc8059fc6dc79f3180012039692e693a14bc98daeb7218f83180e8bfa15f1aa419b780af4424b265a9f231bcb3f6feffc9ed921"
         }
     },
     "env_add_path": ".",
@@ -27,7 +27,7 @@
     },
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
-        "regex": "(?s)(?<rtv>[\\d.]+)[^\\d]*?([\\d.]+)[^\\d]*?(?:current|lts)"
+        "regex": "(?s)(?<rtv>[\\d.]+)[^\\d]*?([\\d.]+)[^\\d]*?(?:sts|lts)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Dotnet 7 has been released at the beginning of November. Autoupdate didn't work because Microsoft [renamed the release type current to sts](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#release-types) (Standard Term Support).
This PR also updates dotnet-sdk version to 7.0.100.

I tested these changes on my local install (x64).