### PR TITLE
espanso: Seems like 2.1.8 is a full release

### DIFF
--- a/bucket/espanso.json
+++ b/bucket/espanso.json
@@ -1,39 +1,42 @@
 {
-    "version": "0.7.3",
-    "description": "Text expander",
-    "homepage": "https://espanso.org",
-    "license": "GPL-3.0-only",
-    "suggest": {
-        "Microsoft Visual C++ Redistributables": "extras/vcredist2022"
-    },
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/federico-terzi/espanso/releases/download/v0.7.3/espanso-win-installer.exe",
-            "hash": "5b19d107601f736a072610f926044f5bae537590f47d67bfd358b8652d261c98"
-        }
-    },
-    "innosetup": true,
-    "bin": "espanso.exe",
-    "shortcuts": [
-        [
-            "espanso.exe",
-            "Espanso",
-            "start",
-            "icon.ico"
-        ]
-    ],
-    "persist": ".espanso",
-    "checkver": {
-        "github": "https://github.com/federico-terzi/espanso"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/federico-terzi/espanso/releases/download/v$version/espanso-win-installer.exe",
-                "hash": {
-                    "url": "$baseurl/espanso-win-installer-sha256.txt"
-                }
-            }
-        }
-    }
+  "version": "2.1.8",
+  "description": "Text expander",
+  "homepage": "https://espanso.org",
+  "license": "GPL-3.0-only",
+  "suggest": {
+      "Microsoft Visual C++ Redistributables 2019": "extras/vcredist2019"
+  },
+  "architecture": {
+      "64bit": {
+          "url": "https://github.com/federico-terzi/espanso/releases/download/v2.1.8/Espanso-Win-Portable-x86_64.zip",
+          "hash": "57b64a2c1591345fe92f03a8c6670d97886b60e42c542161eacc8aa79f42f557"
+      }
+  },
+  "extract_dir": "espanso-portable",
+  "bin": [
+      "espansod.exe",
+      "espanso.cmd"
+  ],
+  "shortcuts": [
+      [
+          "espansod.exe",
+          "Espanso",
+          "launcher"
+      ]
+  ],
+  "persist": ".espanso",
+  "checkver": {
+      "url": "https://github.com/federico-terzi/espanso/releases",
+      "regex": "v([\\d.])"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://github.com/federico-terzi/espanso/releases/download/v$version/Espanso-Win-Portable-x86_64.zip",
+              "hash": {
+                  "url": "$url.sha256.txt"
+              }
+          }
+      }
+  }
 }


### PR DESCRIPTION
And now with portable version.

I just took manifest from ``versions`` bucket, so if anything breaks, blame them :D

Also, updating from ``-pre`` version should work (rename the ``persist`` folder, that’s it), but ``v0.7.3`` was pretty different. Is there a protocol about that? Should we need to add a note?

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
