### PR TITLE
fio: change source for checkver/autoupdate to GitHub releases

### DIFF
--- a/bucket/fio.json
+++ b/bucket/fio.json
@@ -1,28 +1,31 @@
 {
-    "version": "3.29",
+    "version": "3.33",
     "description": "Flexible I/O Tester",
-    "homepage": "https://bsdio.com/fio/",
+    "homepage": "https://github.com/axboe/fio",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://bsdio.com/fio/releases/fio-3.29-x64.msi",
-            "hash": "5633f601136678536630e5ab7f277c5df8f112077b203f9b800cc4781090b298"
+            "url": "https://github.com/axboe/fio/releases/download/fio-3.33/fio-3.33-x64.msi",
+            "hash": "9eb156d2bd33fb2233e55ea47743d5d23ccd571ff2fa9255010ce3c8e4d4c350"
         },
         "32bit": {
-            "url": "https://bsdio.com/fio/releases/fio-3.29-x86.msi",
-            "hash": "64c6328d5cd5eb8629bd53e2f5651435aa369503ce186c9aa76416bbead5435e"
+            "url": "https://github.com/axboe/fio/releases/download/fio-3.33/fio-3.33-x86.msi",
+            "hash": "b86c2d06605e9212bd090fa4627610ad869ffb3f79a54e85a56c7c61012dfd61"
         }
     },
     "extract_dir": "fio",
     "bin": "fio.exe",
-    "checkver": "fio-([\\d.]+) released",
+    "checkver": {
+        "github": "https://github.com/axboe/fio",
+        "regex": "fio-(?<version>[\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://bsdio.com/fio/releases/fio-$version-x64.msi"
+                "url": "https://github.com/axboe/fio/releases/download/fio-$version/fio-$version-x64.msi"
             },
             "32bit": {
-                "url": "https://bsdio.com/fio/releases/fio-$version-x86.msi"
+                "url": "https://github.com/axboe/fio/releases/download/fio-$version/fio-$version-x86.msi"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The current `fio` manifest uses https://bsdio.com/fio as its `checkver` distribution source, and this is no longer in sync with latest releases.

The `fio` maintainer started self-publishing releases of its Windows installer via GitHub, as recently as Aug 9 2022 (starting at version 3.31). 

View the maintainer's official GitHub repository here: https://github.com/axboe/fio/releases (mirror of https://git.kernel.dk/cgit/fio)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

1. Closes #4157 
2. Updates `fio` manifest version to `3.33`


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
