### PR TITLE
sapling: Fix checkver

### DIFF
--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -23,8 +23,8 @@
     "checkver": {
         "url": "https://api.github.com/repos/facebook/sapling/releases/latest",
         "jsonpath": "$.tag_name",
-        "regex": "(?<tag>(?<ver>[\\d.]+)-(?<date>[\\d]{6})-(?<commit>[\\da-f]{8}))",
-        "replace": "${ver}.${date}.${commit}"
+        "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})-(?<hash>[\\da-f]{8}))",
+        "replace": "${ver}.${date}.${time}.${hash}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Since the version schema is `VERSION.%Y%m%d-%H%M%S-HASH` format, checkver parses version, date, time and hash.
[#208](https://github.com/facebook/sapling/pull/208) shows `VERSION-%Y%m%d-%H%M%S-HASH` but it is actually `VERSION.%Y%m%d-%H%M%S-HASH`  by [tag-name.sh](https://github.com/facebook/sapling/blob/main/ci/tag-name.sh#L10) is parsed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
