### PR TITLE
glab@1.23.0 - move to GitLab and update version

### DIFF
--- a/bucket/glab.json
+++ b/bucket/glab.json
@@ -1,27 +1,30 @@
 {
-    "version": "1.22.0",
+    "version": "1.23.0",
     "description": "GitLab CLI",
-    "homepage": "https://github.com/profclems/glab",
+    "homepage": "https://gitlab.com/gitlab-org/cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "http://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_windows_x86_64.zip",
-            "hash": "1b07931cbd9547fdf33bc5c636a5e70bc01d7ef68768cff13f9655623ce411d8"
+            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Windows_x86_64.zip",
+            "hash": "6d7413f31e6f787bcb0ec4fcdba6143d8fdf1a17669225ff38cacbd00f1a6dde"
         },
         "32bit": {
-            "url": "http://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_windows_i386.zip",
-            "hash": "43e86b78e919ec0a1947157c1eeaf62fa8bc03087f09affb28293af939ac4389"
+            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Windows_i386.zip",
+            "hash": "87cced7408ed7bb7419e789c81432a312ec66b27c59b154bca46b9d747af7090"
         }
     },
     "bin": "bin\\glab.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://gitlab.com/gitlab-org/cli/-/tags?format=atom",
+        "regex": "/tags/v([\\d.]+)<"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://github.com/profclems/glab/releases/download/v$version/glab_$version_windows_x86_64.zip"
+                "url": "https://gitlab.com/gitlab-org/cli/-/releases/v$version/downloads/glab_$version_Windows_x86_64.zip"
             },
             "32bit": {
-                "url": "http://github.com/profclems/glab/releases/download/v$version/glab_$version_windows_i386.zip"
+                "url": "https://gitlab.com/gitlab-org/cli/-/releases/v$version/downloads/glab_$version_Windows_i386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
*I read the `CONTRIBUTING` document, and it seemed that issues are meant for deciding whether a new package gets accepted or for changes to the core. If I misunderstood, please close this MR, and I'll create an issue to discuss this update.*

This PR updates the `glab` Scoop bucket.

- `glab` is updated to version `1.23.0`

Apart from updating the package, this PR also changes the origin (ownership) of the formula

GitLab is now the official maintainer of the `glab` package.

- Archived original repo: https://github.com/profclems/glab
- Announcement issue: https://github.com/profclems/glab/issues/983
- The new home for the project https://gitlab.com/gitlab-org/cli
- Release mentioned in this PR https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0


I've made similar PR for homebrew: https://github.com/Homebrew/homebrew-core/pull/116608

This configuration is inspired by the [`graphviz` bucket configuration.](https://github.com/ScoopInstaller/Main/blob/master/bucket/graphviz.json)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
