### PR TITLE
sapling: updated commands in notes

### DIFF
--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -6,7 +6,7 @@
     "notes": [
         "The name of the Sapling CLI sl.exe conflicts with the sl shell built-in in PowerShell (sl is an alias for Set-Location, which is equivalent to cd).",
         "If you want to use sl to run sl.exe in PowerShell, you must reassign the alias to PowerShell $PROFILE by running:",
-        "Add-Content -Path $Profile -Value \"`nSet-Alias -Name sl -Value '$dir\\sl.exe' -Force -Option Constant,ReadOnly,AllScope\""
+        "Add-Content -Path $Profile -Value \"`nSet-Alias -Name sl -Value `\"`$(scoop prefix sapling)\\sl.exe`\" -Force -Option Constant,ReadOnly,AllScope\""
     ],
     "suggest": {
         "Node JS": "nodejs-lts",


### PR DESCRIPTION
Updated so that commands in notes can be copied and pasted as they are.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
