### PR TITLE
(chore): Add new 'hash-error' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Scoop Community Support
     url: https://github.com/ScoopInstaller/Scoop/discussions

--- a/.github/ISSUE_TEMPLATE/hash-error.yml
+++ b/.github/ISSUE_TEMPLATE/hash-error.yml
@@ -1,0 +1,19 @@
+name: 🔢 Hash Error
+description: Open an issue about a package's hash is incorrect.
+labels: ["bug"]
+body:
+- type: checkboxes
+  attributes:
+    label: Prerequisites
+    options:
+    - label: I have used the predefined issue title. (e.g. "xxx@xxx&#58; hash check failed")
+      required: true
+    - label: I have verified that I am using the latest version of Scoop and corresponding bucket.
+      required: true
+- type: input
+  attributes:
+    label: Package Name and Version
+    description: Name and version of package (install name) which has incorrect hash.
+    placeholder: e.g. 7zip@21.00 (not '7-Zip')
+  validations:
+    required: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Enable blank issues when the new template is not used by default in Scoop Core.

I'll commit to other official buckets when this is merged.

Please see https://github.com/niheaven/scoop-sysinternals/issues/new?template=hash-error.yml&title=process-explorer%4017.02%3a+hash+check+failed for the new template.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
