### PR TITLE
dart-sass-embedded: Move from extras to main

### DIFF
--- a/bucket/dart-sass-embedded.json
+++ b/bucket/dart-sass-embedded.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.56.1",
+    "description": "A wrapper for Dart Sass that implements the compiler side of the Embedded Sass protocol",
+    "homepage": "https://github.com/sass/dart-sass-embedded",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/sass/dart-sass-embedded/releases/download/1.56.1/sass_embedded-1.56.1-windows-ia32.zip",
+            "hash": "35910C75A091DA52E72D251438BA88142126ADEEBFE35AC64B617A24505083DA"
+        },
+        "64bit": {
+            "url": "https://github.com/sass/dart-sass-embedded/releases/download/1.56.1/sass_embedded-1.56.1-windows-x64.zip",
+            "hash": "C8BF9C009AFD6BBEB1742E010845B84E1021FDBA6EDC80B4DD1FBBEE75354B39"
+        }
+    },
+    "bin": "sass_embedded\\dart-sass-embedded.bat",
+    "checkver": {
+        "github": "https://github.com/sass/dart-sass-embedded"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sass/dart-sass-embedded/releases/download/$version/sass_embedded-$version-windows-ia32.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/sass/dart-sass-embedded/releases/download/$version/sass_embedded-$version-windows-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Move to main to satisfy future dependency requirement from app in main.

Related to https://github.com/ScoopInstaller/Extras/pull/9875, https://github.com/ScoopInstaller/Extras/pull/9857, https://github.com/ScoopInstaller/Extras/issues/9856

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
