### PR TITLE
certstrap: Add version 1.3.0

### DIFF
--- a/bucket/certstrap.json
+++ b/bucket/certstrap.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.3.0",
+    "description": "Tools to bootstrap CAs, certificate requests, and signed certificates",
+    "homepage": "https://github.com/square/certstrap",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/square/certstrap/releases/download/v1.3.0/certstrap-windows-amd64#/certstrap.exe",
+            "hash": "52c811ef6b1469542390a2ac3dde24a03ba93ac626c5367b9b913d83f373b8f4"
+        }
+    },
+    "bin": "certstrap.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/square/certstrap/releases/download/v$version/certstrap-windows-amd64#/certstrap.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION


Closes #4181

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
