### PR TITLE
gopass: Add hash regex, add arm64

### DIFF
--- a/bucket/gopass.json
+++ b/bucket/gopass.json
@@ -20,7 +20,8 @@
             }
         },
         "hash": {
-            "url": "$baseurl/gopass_$version_SHA256SUMS"
+            "url": "$baseurl/gopass_$version_SHA256SUMS",
+            "regex": "$sha256  $basename\\n"
         }
     }
 }

--- a/bucket/gopass.json
+++ b/bucket/gopass.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/gopasspw/gopass/releases/download/v1.15.0/gopass-1.15.0-windows-amd64.zip",
             "hash": "fa914a3dd607bab15cf7d70099b705ce20d95359bd91b6ce03c177bb099ee672"
+        },
+        "arm64": {
+            "url": "https://github.com/gopasspw/gopass/releases/download/v1.15.0/gopass-1.15.0-windows-arm64.zip",
+            "hash": "e2a4b8e3f0b1260df2c72060e23a5b88159fdf80d523969f36e8803fdc35befe"
         }
     },
     "bin": "gopass.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/gopasspw/gopass/releases/download/v$version/gopass-$version-windows-amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/gopasspw/gopass/releases/download/v$version/gopass-$version-windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixes for gopass:
- add hash regex to filter out .sbom files;
- add arm64 architecture.

Prevents grabbing the wrong hash for gopass by using a custom regex in the manifest. The issue is that the default regex is actually grabbing the `*.zip.sbom` hash since it appears first in the `gopass_$version_SHA256SUMS` file:

```
0830842e11b5079d0d31ad6d60374c8b0d6142d2bdc9ce26b3de93316c2701f8  gopass-1.15.0-windows-amd64.zip.sbom
...
fa914a3dd607bab15cf7d70099b705ce20d95359bd91b6ce03c177bb099ee672  gopass-1.15.0-windows-amd64.zip
```
This should prevent repeating hash issues on autoupdate (#3800, #3909, #4105, #4171, #4194).
Relates to #4105.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
