### PR TITLE
nircmd: Add to path instead of shimming

### DIFF
--- a/bucket/nircmd.json
+++ b/bucket/nircmd.json
@@ -13,10 +13,7 @@
             "hash": "5071b54669bb1e88422c6c340204b0b3a0ffd07e2ac1d747ccbd1447abc92948"
         }
     },
-    "bin": [
-        "nircmd.exe",
-        "nircmdc.exe"
-    ],
+    "env_add_path": ".",
     "checkver": "<td>NirCmd v([\\d.]+)",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

`nircmd.exe` creates a brief ghost window on silent commands (such as `execmd`) due to the shim; adding it directly to path fixes the problem.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
