### PR TITLE
ImageMagick@7.1.0-54: Update since ImageMagick deleted previous version so installation fails

### DIFF
--- a/bucket/imagemagick-lean.json
+++ b/bucket/imagemagick-lean.json
@@ -1,16 +1,16 @@
 {
-    "version": "7.1.0-53",
+    "version": "7.1.0-54",
     "description": "Create, edit, compose, and convert 200+ of bitmap images formats.",
     "homepage": "https://imagemagick.org/",
     "license": "ImageMagick",
     "architecture": {
         "64bit": {
-            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-53-portable-Q16-HDRI-x64.zip",
-            "hash": "2d172187ffad6ecb4bf5a6acae97ff4fc97e6f796077c0c828701e060759e660"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-54-portable-Q16-HDRI-x64.zip",
+            "hash": "54e0a14e34867ef19832fe5da336e7f3737df104de5432e4e86742b7013758fd"
         },
         "32bit": {
-            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-53-portable-Q16-HDRI-x86.zip",
-            "hash": "e072d9b87f8facfa659742c113fd27d07154c0758497300dffa1b829ba933efe"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-54-portable-Q16-HDRI-x86.zip",
+            "hash": "211e16b73777e23a229aa7178b0eb287815936920f9674a27726fd9e4642ae1f"
         }
     },
     "bin": [

--- a/bucket/imagemagick-lean.json
+++ b/bucket/imagemagick-lean.json
@@ -23,8 +23,9 @@
         "- For appropriate programming DLLs and environment variables, install 'imagemagick' instead."
     ],
     "checkver": {
-        "url": "https://imagemagick.org/archive/binaries/?C=N;O=D",
-        "regex": "ImageMagick-([\\d.-]+)-portable-Q16-HDRI-x64\\.zip\\.asc"
+        "url": "https://imagemagick.org/archive/binaries/digest.rdf",
+        "reverse": true,
+        "regex": "ImageMagick-([\\d.-]+)-portable-Q16-HDRI-x64\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -26,8 +26,9 @@
         "- 'convert.exe' is deprecated in v7 (it also conflicts with the builtin Windows 'convert' utility). Use 'magick convert ...' instead."
     ],
     "checkver": {
-        "url": "https://imagemagick.org/archive/binaries/?C=N;O=D",
-        "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe\\.asc"
+        "url": "https://imagemagick.org/archive/binaries/digest.rdf",
+        "reverse": true,
+        "regex": "ImageMagick-([\\d.-]+)-Q16-HDRI-x64-dll\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,16 +1,16 @@
 {
-    "version": "7.1.0-53",
+    "version": "7.1.0-54",
     "description": "Create, edit, compose, and convert 200+ of bitmap images formats.",
     "homepage": "https://imagemagick.org/",
     "license": "ImageMagick",
     "architecture": {
         "64bit": {
-            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-53-Q16-HDRI-x64-dll.exe",
-            "hash": "f11dd8ff1651ff63fe29566eb8b21aaa56cd59da053f03fc78d320cd45a602c4"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-54-Q16-HDRI-x64-dll.exe",
+            "hash": "886cb6b49e0fe5944c21f53038efb8294dc8a1349e8d1b845bd6450965ba3bdb"
         },
         "32bit": {
-            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-53-Q16-HDRI-x86-dll.exe",
-            "hash": "76491d76fad6b369be23d943baa6b06926ff1befa55b87e8af2d389543a46bd0"
+            "url": "https://imagemagick.org/archive/binaries/ImageMagick-7.1.0-54-Q16-HDRI-x86-dll.exe",
+            "hash": "2e2ead9d8bc6758a7ead39a099b10f5a48d357454b0577774925ef82fc49a03b"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes https://github.com/ScoopInstaller/Main/issues/4214  

ImageMagick deleted version 7.1.0-53 so scoop wasn't be able to install it so I did change version number and download URL.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
