### PR TITLE
passbolt-cli: adds v0.1.9

### DIFF
--- a/bucket/passbolt-cli.json
+++ b/bucket/passbolt-cli.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/passbolt/go-passbolt-cli/releases/download/v0.1.9/go-passbolt-cli_0.1.9_Windows_x86_64.zip",
             "hash": "f8e662cbdf1c63e91627a271eea63f3552a7ace147219bb5213a89fbb48334b4"
+        },
+        "arm64": {
+            "url": "https://github.com/passbolt/go-passbolt-cli/releases/download/v0.1.9/go-passbolt-cli_0.1.9_Windows_arm64.zip",
+            "hash": "4f225742e2280dcba0c7ba848e3abce4ee678e3d92bc47af02b7031b458b3c6c"
         }
     },
     "bin": "passbolt.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/passbolt/go-passbolt-cli/releases/download/v$version/go-passbolt-cli_$version_Windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/passbolt/go-passbolt-cli/releases/download/v$version/go-passbolt-cli_$version_Windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/passbolt-cli.json
+++ b/bucket/passbolt-cli.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.1.9",
+    "description": "CLI for the open source password manager for teams",
+    "homepage": "https://www.passbolt.com/",
+    "license": "MIT License",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/passbolt/go-passbolt-cli/releases/download/v0.1.9/go-passbolt-cli_0.1.9_Windows_x86_64.zip",
+            "hash": "f8e662cbdf1c63e91627a271eea63f3552a7ace147219bb5213a89fbb48334b4"
+        }
+    },
+    "bin": "passbolt.exe",
+    "checkver": {
+        "github": "https://github.com/passbolt/go-passbolt-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/passbolt/go-passbolt-cli/releases/download/v$version/go-passbolt-cli_$version_Windows_x86_64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksum.txt"
+        }
+    }
+}

--- a/bucket/passbolt-cli.json
+++ b/bucket/passbolt-cli.json
@@ -20,7 +20,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/checksum.txt"
+            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
adds manifest for passbolt-cli starting at v0.1.9

Closes #4221

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
