### PR TITLE
rust, rustup: Use MSVC by default

### DIFF
--- a/bucket/rust-gnu.json
+++ b/bucket/rust-gnu.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.65.0",
+    "description": "A language empowering everyone to build reliable and efficient software. (GNU toolchain)",
+    "homepage": "https://www.rust-lang.org",
+    "license": "MIT|Apache-2.0",
+	"notes": [
+		"Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases."
+	],
+    "architecture": {
+        "64bit": {
+            "url": "https://static.rust-lang.org/dist/rust-1.65.0-x86_64-pc-windows-gnu.msi",
+            "hash": "598b61d3f432d2a6b54733019fd886f95bdc08d2bedf2fcbcf6b01d09eea208b"
+        },
+        "32bit": {
+            "url": "https://static.rust-lang.org/dist/rust-1.65.0-i686-pc-windows-gnu.msi",
+            "hash": "5e1a7d3f35ec33b4153ffdb3157e5ed45d9b6f3727b6e032bae5f794f2ad7344"
+        }
+    },
+    "extract_dir": "Rust",
+    "bin": [
+        "bin\\rustc.exe",
+        "bin\\rustdoc.exe",
+        "bin\\cargo.exe"
+    ],
+    "checkver": {
+        "url": "https://www.rust-lang.org/",
+        "regex": "Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-x86_64-pc-windows-gnu.msi"
+            },
+            "32bit": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-i686-pc-windows-gnu.msi"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/rust-gnu.json
+++ b/bucket/rust-gnu.json
@@ -3,9 +3,9 @@
     "description": "A language empowering everyone to build reliable and efficient software. (GNU toolchain)",
     "homepage": "https://www.rust-lang.org",
     "license": "MIT|Apache-2.0",
-	"notes": [
-		"Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases."
-	],
+    "notes": [
+        "Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://static.rust-lang.org/dist/rust-1.65.0-x86_64-pc-windows-gnu.msi",

--- a/bucket/rust-gnu.json
+++ b/bucket/rust-gnu.json
@@ -1,19 +1,17 @@
 {
-    "version": "1.65.0",
+    "version": "1.66.1",
     "description": "A language empowering everyone to build reliable and efficient software. (GNU toolchain)",
     "homepage": "https://www.rust-lang.org",
     "license": "MIT|Apache-2.0",
-    "notes": [
-        "Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases."
-    ],
+    "notes": "Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases.",
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.65.0-x86_64-pc-windows-gnu.msi",
-            "hash": "598b61d3f432d2a6b54733019fd886f95bdc08d2bedf2fcbcf6b01d09eea208b"
+            "url": "https://static.rust-lang.org/dist/rust-1.66.1-x86_64-pc-windows-gnu.msi",
+            "hash": "3535f1ed1582847d62dbcfb2a99d58ecce463bbbd1728283f4e01d8ef00ac225"
         },
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.65.0-i686-pc-windows-gnu.msi",
-            "hash": "5e1a7d3f35ec33b4153ffdb3157e5ed45d9b6f3727b6e032bae5f794f2ad7344"
+            "url": "https://static.rust-lang.org/dist/rust-1.66.1-i686-pc-windows-gnu.msi",
+            "hash": "0622d2b7843b8af85077d50c0a587ad0b5ba09d69131a7ed6947dee7d42f3fcc"
         }
     },
     "extract_dir": "Rust",

--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -3,6 +3,14 @@
     "description": "A language empowering everyone to build reliable and efficient software. (MSVC toolchain)",
     "homepage": "https://www.rust-lang.org",
     "license": "MIT|Apache-2.0",
+    "notes": [
+        "Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases.",
+        "According to https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-windows",
+        "Microsoft C++ Build Tools is needed and can be downloaded here: https://visualstudio.microsoft.com/visual-cpp-build-tools/",
+        "When installing build tools, these two components should be selected:",
+        "- MSVC - VS C++ x64/x86 build tools",
+        "- Windows SDK"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://static.rust-lang.org/dist/rust-1.66.1-x86_64-pc-windows-msvc.msi",

--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,16 +1,28 @@
 {
-    "version": "1.66.1",
-    "description": "A language empowering everyone to build reliable and efficient software. (GNU toolchain)",
+    "version": "1.65.0",
+    "description": "A language empowering everyone to build reliable and efficient software. (MSVC toolchain)",
     "homepage": "https://www.rust-lang.org",
     "license": "MIT|Apache-2.0",
+    "notes": [
+        "Use the rustup package instead for easier management of multiple toolchains, including beta/nightly releases.",
+        "According to https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-windows",
+        "Microsoft C++ Build Tools is needed and can be downloaded here: https://visualstudio.microsoft.com/visual-cpp-build-tools/",
+        "When installing build tools, these two components should be selected:",
+        "- MSVC - VS C++ x64/x86 build tools",
+        "- Windows SDK"
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.66.1-x86_64-pc-windows-gnu.msi",
-            "hash": "3535f1ed1582847d62dbcfb2a99d58ecce463bbbd1728283f4e01d8ef00ac225"
+            "url": "https://static.rust-lang.org/dist/rust-1.65.0-x86_64-pc-windows-msvc.msi",
+            "hash": "9425a225c484be4cd68386f6ceab1db8a5a8ffe9992a14d47983607a9766fc24"
         },
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.66.1-i686-pc-windows-gnu.msi",
-            "hash": "0622d2b7843b8af85077d50c0a587ad0b5ba09d69131a7ed6947dee7d42f3fcc"
+            "url": "https://static.rust-lang.org/dist/rust-1.65.0-i686-pc-windows-msvc.msi",
+            "hash": "1776b141ef6ba76aa34290aee6b9816fcd4614e713d852cc3171472faf977463"
+        },
+        "arm64": {
+            "url": "https://static.rust-lang.org/dist/rust-1.65.0-aarch64-pc-windows-msvc.msi",
+            "hash": "a056eb6fea459efaa6ce8dad936b46b7e5242ac034ed0dcc33605d032f661dbd"
         }
     },
     "extract_dir": "Rust",
@@ -26,10 +38,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://static.rust-lang.org/dist/rust-$version-x86_64-pc-windows-gnu.msi"
+                "url": "https://static.rust-lang.org/dist/rust-$version-x86_64-pc-windows-msvc.msi"
             },
             "32bit": {
-                "url": "https://static.rust-lang.org/dist/rust-$version-i686-pc-windows-gnu.msi"
+                "url": "https://static.rust-lang.org/dist/rust-$version-i686-pc-windows-msvc.msi"
+            },
+            "arm64": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-aarch64-pc-windows-msvc.msi"
             }
         },
         "hash": {

--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.65.0",
+    "version": "1.66.1",
     "description": "A language empowering everyone to build reliable and efficient software. (MSVC toolchain)",
     "homepage": "https://www.rust-lang.org",
     "license": "MIT|Apache-2.0",
@@ -13,16 +13,16 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.65.0-x86_64-pc-windows-msvc.msi",
-            "hash": "9425a225c484be4cd68386f6ceab1db8a5a8ffe9992a14d47983607a9766fc24"
+            "url": "https://static.rust-lang.org/dist/rust-1.66.1-x86_64-pc-windows-msvc.msi",
+            "hash": "847cb9fd3e3b62386cbd62be3fec0ab95b367637557437e9481e30d2ec38245b"
         },
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.65.0-i686-pc-windows-msvc.msi",
-            "hash": "1776b141ef6ba76aa34290aee6b9816fcd4614e713d852cc3171472faf977463"
+            "url": "https://static.rust-lang.org/dist/rust-1.66.1-i686-pc-windows-msvc.msi",
+            "hash": "f940015b31570bb2ab48c9839f64d65f2fc87b3d5fc6e806147554ee074c8cb8"
         },
         "arm64": {
-            "url": "https://static.rust-lang.org/dist/rust-1.65.0-aarch64-pc-windows-msvc.msi",
-            "hash": "a056eb6fea459efaa6ce8dad936b46b7e5242ac034ed0dcc33605d032f661dbd"
+            "url": "https://static.rust-lang.org/dist/rust-1.66.1-aarch64-pc-windows-msvc.msi",
+            "hash": "6512b7254efd3abc68915aeffbac57011fad6dfb3b4659eeca9bed6aff675443"
         }
     },
     "extract_dir": "Rust",

--- a/bucket/rustup-gnu.json
+++ b/bucket/rustup-gnu.json
@@ -1,0 +1,51 @@
+{
+    "version": "1.25.1",
+    "description": "Manage multiple rust installations with ease",
+    "homepage": "https://rustup.rs",
+    "license": "MIT|Apache-2.0",
+    "notes": "This package defaults to using the GCC toolchain in new installs; use \"rustup set default-host\" to configure it",
+    "architecture": {
+        "64bit": {
+            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-gnu/rustup-init.exe",
+            "hash": "f7367ca97f4b0e4d1f34181bcb68599099134c608bcf10257b4f64e6770395a6"
+        },
+        "32bit": {
+            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/i686-pc-windows-gnu/rustup-init.exe",
+            "hash": "e463cca92bd26e89c7ef79880e68309482cde3cc62f166a2d3c785ea9a09d7cd"
+        }
+    },
+    "installer": {
+        "script": [
+            "[Environment]::SetEnvironmentVariable('CARGO_HOME', \"$persist_dir\\.cargo\", 'Process')",
+            "[Environment]::SetEnvironmentVariable('RUSTUP_HOME', \"$persist_dir\\.rustup\", 'Process')",
+            "$host_arch = if ($architecture -eq '64bit') {'x86_64'} else {'i686'}",
+            "Invoke-ExternalCommand -Path \"$dir\\rustup-init.exe\" -Args @('-y', '--no-modify-path', '--default-host', \"$host_arch-pc-windows-gnu\") | Out-Null"
+        ]
+    },
+    "env_add_path": ".cargo\\bin",
+    "env_set": {
+        "CARGO_HOME": "$persist_dir\\.cargo",
+        "RUSTUP_HOME": "$persist_dir\\.rustup"
+    },
+    "persist": [
+        ".cargo",
+        ".rustup"
+    ],
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/rust-lang-nursery/rustup.rs/master/Cargo.toml",
+        "regex": "version = \"([\\d.]+)\""
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://static.rust-lang.org/rustup/archive/$version/x86_64-pc-windows-gnu/rustup-init.exe"
+            },
+            "32bit": {
+                "url": "https://static.rust-lang.org/rustup/archive/$version/i686-pc-windows-gnu/rustup-init.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/rustup-gnu.json
+++ b/bucket/rustup-gnu.json
@@ -3,7 +3,7 @@
     "description": "Manage multiple rust installations with ease",
     "homepage": "https://rustup.rs",
     "license": "MIT|Apache-2.0",
-    "notes": "This package defaults to using the GCC toolchain; use \"rustup set default-host\" to configure it",
+    "notes": "This package defaults to using the GCC toolchain on install/update; use \"rustup set default-host\" to configure it",
     "architecture": {
         "64bit": {
             "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-gnu/rustup-init.exe",

--- a/bucket/rustup-gnu.json
+++ b/bucket/rustup-gnu.json
@@ -6,12 +6,12 @@
     "notes": "This package defaults to using the GCC toolchain on install/update; use \"rustup set default-host\" to configure it",
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-gnu/rustup-init.exe",
-            "hash": "f7367ca97f4b0e4d1f34181bcb68599099134c608bcf10257b4f64e6770395a6"
+            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-msvc/rustup-init.exe",
+            "hash": "2220ddb49fea0e0945b1b5913e33d66bd223a67f19fd1c116be0318de7ed9d9c"
         },
         "32bit": {
-            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/i686-pc-windows-gnu/rustup-init.exe",
-            "hash": "e463cca92bd26e89c7ef79880e68309482cde3cc62f166a2d3c785ea9a09d7cd"
+            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/i686-pc-windows-msvc/rustup-init.exe",
+            "hash": "79442f66a969a504febda49ee9158a90ad9e94913209ccdca3c22ef86d635c31"
         }
     },
     "installer": {
@@ -38,10 +38,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://static.rust-lang.org/rustup/archive/$version/x86_64-pc-windows-gnu/rustup-init.exe"
+                "url": "https://static.rust-lang.org/rustup/archive/$version/x86_64-pc-windows-msvc/rustup-init.exe"
             },
             "32bit": {
-                "url": "https://static.rust-lang.org/rustup/archive/$version/i686-pc-windows-gnu/rustup-init.exe"
+                "url": "https://static.rust-lang.org/rustup/archive/$version/i686-pc-windows-msvc/rustup-init.exe"
             }
         },
         "hash": {

--- a/bucket/rustup-gnu.json
+++ b/bucket/rustup-gnu.json
@@ -3,7 +3,7 @@
     "description": "Manage multiple rust installations with ease",
     "homepage": "https://rustup.rs",
     "license": "MIT|Apache-2.0",
-    "notes": "This package defaults to using the GCC toolchain in new installs; use \"rustup set default-host\" to configure it",
+    "notes": "This package defaults to using the GCC toolchain; use \"rustup set default-host\" to configure it",
     "architecture": {
         "64bit": {
             "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-gnu/rustup-init.exe",

--- a/bucket/rustup-msvc.json
+++ b/bucket/rustup-msvc.json
@@ -4,6 +4,8 @@
     "homepage": "https://rustup.rs",
     "license": "MIT|Apache-2.0",
     "notes": [
+        "This package defaults to using the MSVC toolchain in new installs; use \"rustup set default-host\" to configure it",
+        "(now equivalent to the rustup package)",
         "According to https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-windows",
         "Microsoft C++ Build Tools is needed and can be downloaded here: https://visualstudio.microsoft.com/visual-cpp-build-tools/",
         "When installing build tools, these two components should be selected:",
@@ -24,8 +26,7 @@
         "script": [
             "[Environment]::SetEnvironmentVariable('CARGO_HOME', \"$persist_dir\\.cargo\", 'Process')",
             "[Environment]::SetEnvironmentVariable('RUSTUP_HOME', \"$persist_dir\\.rustup\", 'Process')",
-            "$host_arch = if ($architecture -eq '64bit') {'x86_64'} else {'i686'}",
-            "Invoke-ExternalCommand -Path \"$dir\\rustup-init.exe\" -Args @('-y', '--no-modify-path', '--default-host', \"$host_arch-pc-windows-msvc\") | Out-Null"
+            "Invoke-ExternalCommand -Path \"$dir\\rustup-init.exe\" -Args @('-y', '--no-modify-path') | Out-Null"
         ]
     },
     "env_add_path": ".cargo\\bin",

--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -3,22 +3,30 @@
     "description": "Manage multiple rust installations with ease",
     "homepage": "https://rustup.rs",
     "license": "MIT|Apache-2.0",
+    "notes": [
+        "This package defaults to using the MSVC toolchain in new installs; use \"rustup set default-host\" to configure it",
+        "(existing installs may be using the GNU toolchain by default)",
+        "According to https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-windows",
+        "Microsoft C++ Build Tools is needed and can be downloaded here: https://visualstudio.microsoft.com/visual-cpp-build-tools/",
+        "When installing build tools, these two components should be selected:",
+        "- MSVC - VS C++ x64/x86 build tools",
+        "- Windows SDK"
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-gnu/rustup-init.exe",
-            "hash": "f7367ca97f4b0e4d1f34181bcb68599099134c608bcf10257b4f64e6770395a6"
+            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-pc-windows-msvc/rustup-init.exe",
+            "hash": "2220ddb49fea0e0945b1b5913e33d66bd223a67f19fd1c116be0318de7ed9d9c"
         },
         "32bit": {
-            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/i686-pc-windows-gnu/rustup-init.exe",
-            "hash": "e463cca92bd26e89c7ef79880e68309482cde3cc62f166a2d3c785ea9a09d7cd"
+            "url": "https://static.rust-lang.org/rustup/archive/1.25.1/i686-pc-windows-msvc/rustup-init.exe",
+            "hash": "79442f66a969a504febda49ee9158a90ad9e94913209ccdca3c22ef86d635c31"
         }
     },
     "installer": {
         "script": [
             "[Environment]::SetEnvironmentVariable('CARGO_HOME', \"$persist_dir\\.cargo\", 'Process')",
             "[Environment]::SetEnvironmentVariable('RUSTUP_HOME', \"$persist_dir\\.rustup\", 'Process')",
-            "$host_arch = if ($architecture -eq '64bit') {'x86_64'} else {'i686'}",
-            "Invoke-ExternalCommand -Path \"$dir\\rustup-init.exe\" -Args @('-y', '--no-modify-path', '--default-host', \"$host_arch-pc-windows-gnu\") | Out-Null"
+            "Invoke-ExternalCommand -Path \"$dir\\rustup-init.exe\" -Args @('-y', '--no-modify-path') | Out-Null"
         ]
     },
     "env_add_path": ".cargo\\bin",
@@ -37,10 +45,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://static.rust-lang.org/rustup/archive/$version/x86_64-pc-windows-gnu/rustup-init.exe"
+                "url": "https://static.rust-lang.org/rustup/archive/$version/x86_64-pc-windows-msvc/rustup-init.exe"
             },
             "32bit": {
-                "url": "https://static.rust-lang.org/rustup/archive/$version/i686-pc-windows-gnu/rustup-init.exe"
+                "url": "https://static.rust-lang.org/rustup/archive/$version/i686-pc-windows-msvc/rustup-init.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Changes rust and rustup packages to use MSVC toolchain by default, as this is generally the better supported (and default) choice.

In the rustup package, the MSVC version is always used (the GCC build of rustup provides no benefits, and the MSVC version can be used to install GCC toolchains). The --default-host flag has been removed, so new installs will use the rustup default (MSVC) but existing installs will have a configuration file indicating GCC is the default; a note was added to the rustup packages stating how to change this.

The rust-gnu package was added, to allow using the GCC toolchain without rustup, and a note was added to all rust packages indicating that rustup can be used to more easily manage multiple toolchains (and is the primary install method; see https://forge.rust-lang.org/infra/other-installation-methods.html).

Closes #931.