### PR TITLE
sapling: fix checkver.regex and update version

### DIFF
--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -23,8 +23,8 @@
     "checkver": {
         "url": "https://api.github.com/repos/facebook/sapling/releases/latest",
         "jsonpath": "$.tag_name",
-        "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})-(?<hash>[\\da-f]{8}))",
-        "replace": "${ver}.${date}.${time}.${hash}"
+        "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})-r(?<hash>[\\da-f]{8}))",
+        "replace": "${ver}.${date}.${time}.r${hash}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.20221118.210929.cfbb68aa",
+    "version": "0.1.20221213.150011.h9b0acf12",
     "description": "Sapling SCM is a cross-platform, highly scalable, Git-compatible source control system.",
     "homepage": "https://sapling-scm.com/",
     "license": "GPL-2.0-only",
@@ -14,8 +14,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/facebook/sapling/releases/download/0.1.20221118-210929-cfbb68aa/sapling_windows_0.1.20221118-210929-cfbb68aa_amd64.zip",
-            "hash": "e67897614e11fb3d91a9544528069174f312de91406c12bd760cec17b28e16a9"
+            "url": "https://github.com/facebook/sapling/releases/download/0.1.20221213-150011-h9b0acf12/sapling_windows_0.1.20221213-150011-h9b0acf12_amd64.zip",
+            "hash": "abd5f96244db631e060e8eeed6349f227bfec4f0055d83ea8eae3d44322ca3db"
         }
     },
     "extract_dir": "Sapling",

--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -23,8 +23,8 @@
     "checkver": {
         "url": "https://api.github.com/repos/facebook/sapling/releases/latest",
         "jsonpath": "$.tag_name",
-        "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})-r(?<hash>[\\da-f]{8}))",
-        "replace": "${ver}.${date}.${time}.r${hash}"
+        "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})-h(?<hash>[\\da-f]{8}))",
+        "replace": "${ver}.${date}.${time}.h${hash}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
* sapling has changed version schema from `MAJOR.MINOR-%Y%m%d-%H%M%S-HASH` to `MAJOR.MINOR-%Y%m%d-%H%M%S-rHASH`. [360873f](https://github.com/facebook/sapling/commit/360873f1498a5a8fe313f861f273bd2b49eb9940)
* sapling has changed versioning schema from from `MAJOR.MINOR-%Y%m%d-%H%M%S-rHASH` to `MAJOR.MINOR-%Y%m%d-%H%M%S-hHASH`. [388343c](https://github.com/facebook/sapling/commit/388343cc8b14039e12a952a2f56c451ccdd0181e)
* sapling: Update version to 0.1.20221213.150011.h9b0acf12

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
