### PR TITLE
osv-scanner: Add version 1.0.0

### DIFF
--- a/bucket/osv-scanner.json
+++ b/bucket/osv-scanner.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.0.0",
+    "description": "Find existing vulnerabilities affecting your project's dependencies.",
+    "homepage": "https://github.com/google/osv-scanner",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/google/osv-scanner/releases/download/v1.0.0/osv-scanner_1.0.0_windows_amd64.exe#/osv-scanner.exe",
+            "hash": "d9347ad3cc64a47706ab3bcf261be04d26ef0c34fea2ac69089aca4b971cda52"
+        }
+    },
+    "bin": "osv-scanner.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/google/osv-scanner/releases/download/v$version/osv-scanner_$version_windows_amd64.exe#/osv-scanner.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/osv-scanner_$version_SHA256SUMS"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR adds the new Google [osv-scanner](https://github.com/google/osv-scanner) a tool to enable looking up vulnerabilities from project dependencies.

I'll link an [Article](https://www.theregister.com/2022/12/15/google_debuts_osvscanner_a_gobased/) from [The Register](https://www.theregister.com/) for context.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
