### PR TITLE
rhash: Add version 1.4.3

### DIFF
--- a/bucket/rhash.json
+++ b/bucket/rhash.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.4.3",
+    "description": "A console utility for computing and verifying hash sums of files.",
+    "homepage": "https://rhash.sourceforge.net/",
+    "license": "0BSD",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/rhash/rhash/1.4.3/rhash-1.4.3-win64.zip",
+            "hash": "sha1:d8326b6ab1053ff6c5907892aefc03ccbaf53dce",
+            "extract_dir": "RHash-1.4.3-win64"
+        },
+        "32bit": {
+            "url": "https://downloads.sourceforge.net/project/rhash/rhash/1.4.3/rhash-1.4.3-win32.zip",
+            "hash": "sha1:2abe176fb71b7d56ee4ebb12e24293be1a7bfe56",
+            "extract_dir": "RHash-1.4.3-win32"
+        }
+    },
+    "bin": "rhash.exe",
+    "checkver": {
+        "sourceforge": "rhash/rhash"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/rhash/rhash/$version/rhash-$version-win64.zip",
+                "extract_dir": "RHash-$version-win64"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/rhash/rhash/$version/rhash-$version-win32.zip",
+                "extract_dir": "RHash-$version-win32"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

A console utility for computing and verifying hash sums of files.

Config file is located at `$env:USERPROFILE\rhashrc` or `$env:APPDATA\RHash\rhashrc`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
