### PR TITLE
gpac: Remove mp4client.exe

### DIFF
--- a/bucket/gpac.json
+++ b/bucket/gpac.json
@@ -22,8 +22,7 @@
     ],
     "bin": [
         "gpac.exe",
-        "mp4box.exe",
-        "mp4client.exe"
+        "mp4box.exe"
     ],
     "persist": [
         "Storage",


### PR DESCRIPTION
MP4Client is being removed from GPAC since 2.2-rev0. See [GPAC 2.2](https://gpac.wp.imt.fr/2022/12/19/gpac-2-2/).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
