### PR TITLE
scrcpy: fix shim error

### DIFF
--- a/bucket/scrcpy.json
+++ b/bucket/scrcpy.json
@@ -7,11 +7,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.25/scrcpy-win64-v1.25.zip",
-            "hash": "db65125e9c65acd00359efb7cea9c05f63cc7ccd5833000cd243cc92f5053028"
+            "hash": "db65125e9c65acd00359efb7cea9c05f63cc7ccd5833000cd243cc92f5053028",
+            "extract_dir": "scrcpy-win64-v1.25"
         },
         "32bit": {
             "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.25/scrcpy-win32-v1.25.zip",
-            "hash": "d9422cafecb28d9df9dd8490b492bc2e573f8962854163294ba85b239becc0a3"
+            "hash": "d9422cafecb28d9df9dd8490b492bc2e573f8962854163294ba85b239becc0a3",
+            "extract_dir": "scrcpy-win32-v1.25"
         }
     },
     "pre_install": "if (Test-Path \"$dir\\adb.exe\") { Remove-Item \"$dir\\adb.exe\" }",
@@ -32,10 +34,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Genymobile/scrcpy/releases/download/v$version/scrcpy-win64-v$version.zip"
+                "url": "https://github.com/Genymobile/scrcpy/releases/download/v$version/scrcpy-win64-v$version.zip",
+                "extract_dir": "scrcpy-win64-v$version"
             },
             "32bit": {
-                "url": "https://github.com/Genymobile/scrcpy/releases/download/v$version/scrcpy-win32-v$version.zip"
+                "url": "https://github.com/Genymobile/scrcpy/releases/download/v$version/scrcpy-win32-v$version.zip",
+                "extract_dir": "scrcpy-win32-v$version"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #4268 
<!-- or -->

Seems like in 1.25 scrcpy is packed in a dir in the zip file

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
