### PR TITLE
mtn: Restrict to 64-bit

### DIFF
--- a/bucket/mtn.json
+++ b/bucket/mtn.json
@@ -6,15 +6,23 @@
     "suggest": {
         "ffmpeg": "ffmpeg"
     },
-    "url": "https://bitbucket.org/wahibre/mtn/downloads/mtn-3.4.2-win64.zip",
-    "hash": "7f20031f8bd8ef5d943f8cd1f398f96ccf872eb855c1c5ec4efd1699e75c0896",
-    "extract_dir": "mtn-win64",
+    "architecture": {
+        "64bit": {
+            "url": "https://bitbucket.org/wahibre/mtn/downloads/mtn-3.4.2-win64.zip",
+            "hash": "7f20031f8bd8ef5d943f8cd1f398f96ccf872eb855c1c5ec4efd1699e75c0896",
+            "extract_dir": "mtn-win64"
+        }
+    },
     "bin": "bin\\mtn.exe",
     "checkver": {
         "url": "https://bitbucket.org/wahibre/mtn/downloads/?tab=downloads",
         "regex": "(?<filename>mtn-(?<version>(?:\\d+\\.)+\\d+)-win64\\.zip)"
     },
     "autoupdate": {
-        "url": "https://bitbucket.org/wahibre/mtn/downloads/$matchFilename"
+        "architecture": {
+            "64bit": {
+                "url": "https://bitbucket.org/wahibre/mtn/downloads/$matchFilename"
+            }
+        }
     }
 }


### PR DESCRIPTION
It works only on 64-bit Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
