### PR TITLE
ktx-software: Restrict to 64-bit

### DIFF
--- a/bucket/ktx-software.json
+++ b/bucket/ktx-software.json
@@ -4,15 +4,23 @@
     "license": "https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-Cesium-Trademark-Terms.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-ETCSLA.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-HI-Trademark.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-Kodak.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-PNGSuite.txt, Apache-2.0, BSD-1-Clause, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC-BY-3.0, CC-BY-4.0, CC0-1.0, GPL-2.0-or-later, MIT, Zlib",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v$version/KTX-Software-$version-win64.exe#/dl.7z",
-        "hash": {
-            "url": "$url.sha1"
-        },
-        "extract_dir": "$version"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v$version/KTX-Software-$version-win64.exe#/dl.7z",
+                "hash": {
+                    "url": "$url.sha1"
+                },
+                "extract_dir": "$version"
+            }
+        }
     },
     "homepage": "https://github.com/KhronosGroup/KTX-Software",
-    "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v4.0.0/KTX-Software-4.0.0-win64.exe#/dl.7z",
-    "hash": "sha1:e71ed97e994d1389fbe78f16f008a750ed838fb2",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v4.0.0/KTX-Software-4.0.0-win64.exe#/dl.7z",
+            "hash": "sha1:e71ed97e994d1389fbe78f16f008a750ed838fb2"
+        }
+    },
     "bin": [
         "bin/ktx2check.exe",
         "bin/ktx2ktx2.exe",

--- a/bucket/ktx-software.json
+++ b/bucket/ktx-software.json
@@ -1,20 +1,11 @@
 {
     "version": "4.0.0",
     "description": "A collection of tools for creating/validating/supercompressing/converting or information display of ktx files.",
-    "license": "https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-Cesium-Trademark-Terms.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-ETCSLA.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-HI-Trademark.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-Kodak.txt, https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSES/LicenseRef-PNGSuite.txt, Apache-2.0, BSD-1-Clause, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC-BY-3.0, CC-BY-4.0, CC0-1.0, GPL-2.0-or-later, MIT, Zlib",
-    "checkver": "github",
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v$version/KTX-Software-$version-win64.exe#/dl.7z",
-                "hash": {
-                    "url": "$url.sha1"
-                },
-                "extract_dir": "$version"
-            }
-        }
-    },
     "homepage": "https://github.com/KhronosGroup/KTX-Software",
+    "license": {
+        "identifier": "Apache-2.0|Multiple licences",
+        "url": "https://github.com/KhronosGroup/KTX-Software/blob/master/LICENSE.md"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v4.0.0/KTX-Software-4.0.0-win64.exe#/dl.7z",
@@ -27,5 +18,16 @@
         "bin/ktxinfo.exe",
         "bin/ktxsc.exe",
         "bin/toktx.exe"
-    ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/KhronosGroup/KTX-Software/releases/download/v$version/KTX-Software-$version-win64.exe#/dl.7z",
+                "hash": {
+                    "url": "$url.sha1"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
It works only on 64-bit Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
