### PR TITLE
glslang: Restrict to 64-bit

### DIFF
--- a/bucket/glslang.json
+++ b/bucket/glslang.json
@@ -6,8 +6,12 @@
         "identifier": "Freeware,MIT,...",
         "url": "https://github.com/KhronosGroup/glslang/blob/master/LICENSE.txt"
     },
-    "url": "https://github.com/KhronosGroup/glslang/releases/download/8.13.3559/glslang-master-windows-x64-Release.zip",
-    "hash": "e4bffacd4a75e1e150c0cf19d5020cfa6893386a1e6dd14ef6426789859eab88",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/KhronosGroup/glslang/releases/download/8.13.3559/glslang-master-windows-x64-Release.zip",
+            "hash": "e4bffacd4a75e1e150c0cf19d5020cfa6893386a1e6dd14ef6426789859eab88",
+        }
+    },
     "bin": [
         "bin\\glslangValidator.exe",
         "bin\\spirv-remap.exe"

--- a/bucket/glslang.json
+++ b/bucket/glslang.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/KhronosGroup/glslang/releases/download/8.13.3559/glslang-master-windows-x64-Release.zip",
-            "hash": "e4bffacd4a75e1e150c0cf19d5020cfa6893386a1e6dd14ef6426789859eab88",
+            "hash": "e4bffacd4a75e1e150c0cf19d5020cfa6893386a1e6dd14ef6426789859eab88"
         }
     },
     "bin": [


### PR DESCRIPTION
It works only on 64-bit Windows.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
