### PR TITLE
tldr: Download the help pages in post_install

### DIFF
--- a/bucket/tldr.json
+++ b/bucket/tldr.json
@@ -10,6 +10,9 @@
         }
     },
     "bin": "tldr.exe",
+    "post_install": [
+	    "tldr --update"
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
if we don't do that on install it does it on first usage, which can result in a delay. I think an initial download of all the pages at install time is good UX.  I'm open to critique or improvements.
let me know what you think.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
