### PR TITLE
qrencode: Fix installation for PowerShell 5

### DIFF
--- a/bucket/qrencode.json
+++ b/bucket/qrencode.json
@@ -43,11 +43,11 @@
         "                \"$dir\\share\\licenses\\qrencode\\COPYING\",",
         "                \"$dir\\share\\man\\man1\\qrencode.1.gz\")",
         "",
-        "Get-ChildItem \"$dir\" -Recurse",
-        "    | Select-Object -ExpandProperty FullName",
-        "    | Where-Object {$keep_files -notcontains $_ }",
-        "    | Sort-Object Length -Descending",
-        "    | ForEach-Object { if ((Test-Path $_ -Type Container) -and (Get-ChildItem $_)) { return } Remove-Item $_ }"
+        "Get-ChildItem \"$dir\" -Recurse                 |",
+        "    Select-Object -ExpandProperty FullName      |",
+        "    Where-Object {$keep_files -notcontains $_ } |",
+        "    Sort-Object Length -Descending              |",
+        "    ForEach-Object { if ((Test-Path $_ -Type Container) -and (Get-ChildItem $_)) { return } Remove-Item $_ }"
     ],
     "bin": "bin\\qrencode.exe",
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

PowerShell 5 only supports line breaks after pipe symbols (without a backtick).

Fixes #4263

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
