### PR TITLE
marksman: Add version 2022-12-28

### DIFF
--- a/bucket/marksman.json
+++ b/bucket/marksman.json
@@ -3,8 +3,12 @@
     "homepage": "https://github.com/artempyanykh/marksman",
     "description": "Write Markdown with code assist and intelligence in the comfort of your favourite editor.",
     "license": "MIT",
-    "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-28/marksman.exe",
-    "hash": "dd9c4a5ab5336bf9925d3aa508b4327aede8631e95f6edb70affb75407d69231",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-28/marksman.exe",
+            "hash": "dd9c4a5ab5336bf9925d3aa508b4327aede8631e95f6edb70affb75407d69231"
+        }
+    },
     "bin": "marksman.exe",
     "checkver": {
         "github": "https://github.com/artempyanykh/marksman",

--- a/bucket/marksman.json
+++ b/bucket/marksman.json
@@ -1,13 +1,13 @@
 {
-    "version": "2022-12-23",
+    "version": "2022-12-28",
     "homepage": "https://github.com/artempyanykh/marksman",
     "description": "Write Markdown with code assist and intelligence in the comfort of your favourite editor.",
     "license": {
         "identifier": "MIT",
         "url": "https://github.com/artempyanykh/marksman/blob/main/LICENSE"
     },
-    "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-23/marksman.exe",
-    "hash": "4e50b23f4ea980ea2c71c33f141d3ee8e5e15d34c08d38596d40c0271c76f5ce",
+    "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-28/marksman.exe",
+    "hash": "dd9c4a5ab5336bf9925d3aa508b4327aede8631e95f6edb70affb75407d69231",
     "bin": "marksman.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/marksman.json
+++ b/bucket/marksman.json
@@ -1,0 +1,16 @@
+{
+    "version": "2022-12-23",
+    "homepage": "https://github.com/artempyanykh/marksman",
+    "description": "Write Markdown with code assist and intelligence in the comfort of your favourite editor.",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/artempyanykh/marksman/blob/main/LICENSE"
+    },
+    "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-23/marksman.exe",
+    "hash": "4e50b23f4ea980ea2c71c33f141d3ee8e5e15d34c08d38596d40c0271c76f5ce",
+    "bin": "marksman.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/artempyanykh/marksman/releases/download/$version/marksman.exe"
+    }
+}

--- a/bucket/marksman.json
+++ b/bucket/marksman.json
@@ -15,6 +15,10 @@
         "regex": "/releases/tag/([\\d-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/artempyanykh/marksman/releases/download/$version/marksman.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/artempyanykh/marksman/releases/download/$version/marksman.exe",
+            }
+        }
     }
 }

--- a/bucket/marksman.json
+++ b/bucket/marksman.json
@@ -9,7 +9,10 @@
     "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-28/marksman.exe",
     "hash": "dd9c4a5ab5336bf9925d3aa508b4327aede8631e95f6edb70affb75407d69231",
     "bin": "marksman.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/artempyanykh/marksman",
+        "regex": "/releases/tag/([\\d-]+)"
+    },
     "autoupdate": {
         "url": "https://github.com/artempyanykh/marksman/releases/download/$version/marksman.exe"
     }

--- a/bucket/marksman.json
+++ b/bucket/marksman.json
@@ -2,10 +2,7 @@
     "version": "2022-12-28",
     "homepage": "https://github.com/artempyanykh/marksman",
     "description": "Write Markdown with code assist and intelligence in the comfort of your favourite editor.",
-    "license": {
-        "identifier": "MIT",
-        "url": "https://github.com/artempyanykh/marksman/blob/main/LICENSE"
-    },
+    "license": "MIT",
     "url": "https://github.com/artempyanykh/marksman/releases/download/2022-12-28/marksman.exe",
     "hash": "dd9c4a5ab5336bf9925d3aa508b4327aede8631e95f6edb70affb75407d69231",
     "bin": "marksman.exe",


### PR DESCRIPTION
Adds manifest for marksman, a language server for Markdown documents.

Closes #4286

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
