### PR TITLE
latexindent@3.20:Fix Can't shim 'latexindent.exe': File doesn't exist

### DIFF
--- a/bucket/latexindent.json
+++ b/bucket/latexindent.json
@@ -6,7 +6,7 @@
     "url": "http://mirrors.ctan.org/support/latexindent.zip",
     "hash": "36c967c263ba95a9cb57fa32285fd2e99b9ce55299a0d723521f9bfb38977bdf",
     "extract_dir": "latexindent",
-    "bin": "latexindent.exe",
+    "bin": "bin\\windows\\latexindent.exe",
     "checkver": {
         "url": "https://ctan.org/pkg/latexindent",
         "regex": "Version</td><td>([\\d.]+)"


### PR DESCRIPTION
Signed-off-by: qidi1 <1083369179@qq.com>

Closes https://github.com/ScoopInstaller/Scoop/issues/5315
