### PR TITLE
flyctl: Add arm64 architecture

### DIFF
--- a/bucket/flyctl.json
+++ b/bucket/flyctl.json
@@ -22,6 +22,9 @@
             "64bit": {
                 "url": "https://github.com/superfly/flyctl/releases/download/v$version/flyctl_$version_Windows_x86_64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/flyctl.json
+++ b/bucket/flyctl.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/superfly/flyctl/releases/download/v0.0.442/flyctl_0.0.442_Windows_x86_64.zip",
             "hash": "e8fe246e8203da280e934f7c34f2ececde75b98403d2636f3d6d162bc336a307"
+        },
+        "arm64": {
+            "url": "https://github.com/superfly/flyctl/releases/download/v0.0.442/flyctl_0.0.442_Windows_arm64.zip",
+            "hash": "ed66dea704e70889ee2243a868a63a7d0af51d698181b508d3551de92f046435"
         }
     },
     "bin": [
@@ -21,6 +25,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/superfly/flyctl/releases/download/v$version/flyctl_$version_Windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/superfly/flyctl/releases/download/v$version/flyctl_$version_Windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Some updates for flyctl:
- add arm64 architecture;
- add autoupdate hash extraction.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
