### PR TITLE
flyway: use Maven metadata for checkver

### DIFF
--- a/bucket/flyway.json
+++ b/bucket/flyway.json
@@ -17,8 +17,8 @@
         "jars"
     ],
     "checkver": {
-        "url": "https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html",
-        "regex": "Flyway ([\\d.]+)"
+        "url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/maven-metadata.xml",
+        "regex": "<release>(\\S+)</release>"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Closes #4309

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
