### PR TITLE
Update download URL and file hash for nano

### DIFF
--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -7,8 +7,8 @@
         "Configure nano by editing its configuration file %USERPROFILE%\\.nanorc",
         "NOTE: The config file was named nano.rc in the 2.5.3 release, but is now named .nanorc"
     ],
-    "url": "https://files.lhmouse.com/nano-win/nano-win_10156_v7.1-13-ga4fc06579.7z",
-    "hash": "cacc06d4f97c49f13a06c6281f29b4e76eaf820f5081a78b26acf9d1c647d603",
+    "url": "https://files.lhmouse.com/nano-win/nano-win_10156_v7.1-13-g6e18baad3.7z",
+    "hash": "5514b73c955cf5b89ae0a9ffd993c086d51c8102d6313f87a97782b032c2b7d2",
     "post_install": [
         "if (-not (Test-Path \"$env:USERPROFILE\\.nanorc\")) {",
         "   Copy-Item \"$dir\\.nanorc\" \"$env:USERPROFILE\\.nanorc\"",


### PR DESCRIPTION
Fix nano download URL and file hash

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
