### PR TITLE
istioctl: Add version 1.16.1

### DIFF
--- a/bucket/istioctl.json
+++ b/bucket/istioctl.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.16.1",
+    "description": "Configuration command line utility for service operators to debug and diagnose their Istio mesh.",
+    "homepage": "https://istio.io/latest/docs/reference/commands/istioctl/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/istio/istio/releases/download/1.16.1/istioctl-1.16.1-win.zip",
+            "hash": "b4c7dfca4ab8e1caeec5c4480483494b492ccee9f0871d291d429ea56a2dca18"
+        }
+    },
+    "bin": "istioctl.exe",
+    "checkver": {
+        "github": "https://github.com/istio/istio"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/istio/istio/releases/download/$version/istioctl-$version-win.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR adds [istioctl](https://istio.io/latest/docs/reference/commands/istioctl/) to the main bucket.

PR https://github.com/ScoopInstaller/Extras/pull/10233 removes `istio` from the extras bucket in favour of this.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
