### PR TITLE
fission-cli: Add version 1.17.0

### DIFF
--- a/bucket/fission-cli.json
+++ b/bucket/fission-cli.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.17.0",
+    "description": "Fast and Simple Serverless Functions for Kubernetes",
+    "homepage": "https://fission.io/",
+    "license": "Apache License 2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fission/fission/releases/download/v1.17.0/fission-v1.17.0-windows-amd64.exe#/fission.exe",
+            "hash": "613b4e2f5c22419946bee0215d6ea60ef785315c29ca89f2927b8b45cb04986e"
+        }
+    },
+    "bin": "fission.exe",
+    "checkver": {
+        "github": "https://github.com/fission/fission"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fission/fission/releases/download/v$version/fission-v$version-windows-amd64.exe#/fission.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Adds manifest for fission-cli

Closes #4346


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
