### PR TITLE
[update]: Upgrade Perl links to HTTPS

### DIFF
--- a/bucket/perl.json
+++ b/bucket/perl.json
@@ -1,15 +1,15 @@
 {
     "version": "5.32.1.1",
     "description": "A programming language suitable for writing simple scripts as well as complex applications.",
-    "homepage": "http://strawberryperl.com",
+    "homepage": "https://strawberryperl.com",
     "license": "GPL-1.0-or-later|Artistic-1.0-Perl",
     "architecture": {
         "64bit": {
-            "url": "http://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit-portable.zip",
+            "url": "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit-portable.zip",
             "hash": "sha1:fac226b31461f2392702822052a3a5628917f857"
         },
         "32bit": {
-            "url": "http://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-32bit-portable.zip",
+            "url": "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-32bit-portable.zip",
             "hash": "sha1:28bca91cadd6651c2b2463db8587c170bf17f2fa"
         }
     },
@@ -24,20 +24,20 @@
         "perl\\bin"
     ],
     "checkver": {
-        "url": "http://strawberryperl.com/releases.html",
+        "url": "https://strawberryperl.com/releases.html",
         "regex": "strawberry-perl-([\\d.]+)-32bit-portable\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://strawberryperl.com/download/$version/strawberry-perl-$version-64bit-portable.zip"
+                "url": "https://strawberryperl.com/download/$version/strawberry-perl-$version-64bit-portable.zip"
             },
             "32bit": {
-                "url": "http://strawberryperl.com/download/$version/strawberry-perl-$version-32bit-portable.zip"
+                "url": "https://strawberryperl.com/download/$version/strawberry-perl-$version-32bit-portable.zip"
             }
         },
         "hash": {
-            "url": "http://strawberryperl.com/releases.html",
+            "url": "https://strawberryperl.com/releases.html",
             "regex": "(?sm)$basename\" onclick.*?Portable edition.*?$sha1"
         }
     }


### PR DESCRIPTION
This commit changes the URLs for perl to use https, instead of http.

Closes #4379

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
