### PR TITLE
nano: Update to 7.2-9-10164, add UTF-8 support, mouse support, etc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'master'
   pull_request:
+  push:
   workflow_dispatch:
 
 jobs:
@@ -17,21 +14,17 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 2
-          path: my_bucket
+          path: 'my_bucket'
       - name: Checkout Scoop
         uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
-          path: scoop_core
-      - name: Init Test Suite
-        uses: potatoqualitee/psmodulecache@v5.1
-        with:
-          modules-to-cache: BuildHelpers
-          shell: powershell
-      - name: Test Bucket
+          path: 'scoop_core'
+      - name: Init and Test
         shell: powershell
         run: |
           $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
+          .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1
   test_pwsh:
     name: PowerShell
@@ -41,19 +34,15 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 2
-          path: my_bucket
+          path: 'my_bucket'
       - name: Checkout Scoop
         uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
-          path: scoop_core
-      - name: Init Test Suite
-        uses: potatoqualitee/psmodulecache@v5.1
-        with:
-          modules-to-cache: BuildHelpers
-          shell: pwsh
-      - name: Test Bucket
+          path: 'scoop_core'
+      - name: Init and Test
         shell: pwsh
         run: |
           $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
+          .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: Tests
 
 on:
-  pull_request:
   push:
+    branches:
+      - 'main'
+      - 'master'
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -14,17 +17,21 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 2
-          path: 'my_bucket'
+          path: my_bucket
       - name: Checkout Scoop
         uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
-          path: 'scoop_core'
-      - name: Init and Test
+          path: scoop_core
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@v5.1
+        with:
+          modules-to-cache: BuildHelpers
+          shell: powershell
+      - name: Test Bucket
         shell: powershell
         run: |
           $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
-          .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1
   test_pwsh:
     name: PowerShell
@@ -34,15 +41,19 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 2
-          path: 'my_bucket'
+          path: my_bucket
       - name: Checkout Scoop
         uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
-          path: 'scoop_core'
-      - name: Init and Test
+          path: scoop_core
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@v5.1
+        with:
+          modules-to-cache: BuildHelpers
+          shell: pwsh
+      - name: Test Bucket
         shell: pwsh
         run: |
           $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
-          .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -3,27 +3,39 @@
     "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
-    "notes": "Configure nano by editing its configuration file with nano ~\\.nanorc",
+    "notes": "Configure nano by editing its configuration file with nano ~/.nanorc",
     "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-6-10161/nano-for-windows_v7.2-6-10161.7z",
     "hash": "426f71933d8a9536f3ceed22bae7bd0a37cf42a458cb4c7d91a0d67ba3d9b1fb",
+    "bin": "nano.exe",
     "architecture": {
         "64bit": {
-            "bin": "pkg_x86_64-w64-mingw32\\bin\\nano.exe"
+            "pre_install": [
+                "if (-not (Test-Path ~/.nanorc)) {",
+                "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
+                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
+                "Move-Item \"$dir/pkg_x86_64-w64-mingw32/bin/*\" \"$dir\"",
+                "Move-Item \"$dir/pkg_x86_64-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
+                "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
+                "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
+                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', '~/scoop/apps/nano/current/syntax' | Set-Content ~/.nanorc"
+            ]
         },
         "32bit": {
-            "bin": "pkg_i686-w64-mingw32\\bin\\nano.exe"
+            "pre_install": [
+                "if (-not (Test-Path ~/.nanorc)) {",
+                "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
+                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
+                "Move-Item \"$dir/pkg_i686-w64-mingw32/bin/*\" \"$dir\"",
+                "Move-Item \"$dir/pkg_i686-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
+                "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
+                "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
+                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', '~/scoop/apps/nano/current/syntax' | Set-Content ~/.nanorc"
+            ]
         }
     },
-    "post_install": [
-        "if (-not (Test-Path \"$env:USERPROFILE\\.nanorc\")) {",
-        "   Copy-Item \"$dir\\.nanorc\" \"$env:USERPROFILE\\.nanorc\"",
-        "   Add-Content \"$env:USERPROFILE\\.nanorc\" 'include \"~/scoop/apps/nano/current/pkg_x86_64-w64-mingw32/share/nano/*.nanorc\"'",
-        "}"
-    ],
     "checkver": {
         "github": "https://api.github.com/repos/okibcn/nano-for-windows",
-        "regex": "v(\\d+).(\\d+)-(\\d+)-(\\d+)\\.7z",
-        "replace": "${1}.${2}-${3}-${4}"
+        "regex": "v([\\d\\.\\-]+)\\.7z"
     },
     "autoupdate": {
         "url": "https://github.com/okibcn/nano-for-windows/releases/download/v$version/nano-for-windows_v$version.7z"

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,11 +1,11 @@
 {
-    "version": "7.2-8-10163",
+    "version": "7.2-8-10163.1",
     "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
     "notes": "Configure nano by editing its configuration file with nano ~/.nanorc",
-    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163/nano-for-windows_v7.2-8-10163.7z",
-    "hash": "c12b44f9ff0b35cc281cef9926216fd2b360ce4e2c663a5ae14d69414e70600a",
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.1/nano-for-windows_v7.2-8-10163.1.7z",
+    "hash": "3c96a9218bda9257e20523ab37e07353104c9703e324e1198cb2c1ad308650ad",
     "bin": "nano.exe",
     "architecture": {
         "64bit": {

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -10,26 +10,32 @@
     "architecture": {
         "64bit": {
             "pre_install": [
+                "$arch='x86_64'",
+                "$scoopdir=$scoopdir -replace '\\\\', '/'",
                 "if (-not (Test-Path ~/.nanorc)) {",
                 "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
-                "Move-Item \"$dir/pkg_x86_64-w64-mingw32/bin/*\" \"$dir\"",
-                "Move-Item \"$dir/pkg_x86_64-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
+                "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
+                "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
+                "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
                 "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
+                "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
                 "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', '~/scoop/apps/nano/current/syntax' | Set-Content ~/.nanorc"
+                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc"
             ]
         },
         "32bit": {
             "pre_install": [
+                "$arch='i686'",
+                "$scoopdir=$scoopdir -replace '\\\\', '/'",
                 "if (-not (Test-Path ~/.nanorc)) {",
                 "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
-                "Move-Item \"$dir/pkg_i686-w64-mingw32/bin/*\" \"$dir\"",
-                "Move-Item \"$dir/pkg_i686-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
+                "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
+                "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
+                "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
                 "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
+                "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
                 "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', '~/scoop/apps/nano/current/syntax' | Set-Content ~/.nanorc"
+                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc"
             ]
         }
     },

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -12,7 +12,7 @@
             "pre_install": [
                 "if (-not (Test-Path ~/.nanorc)) {",
                 "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
+                "    Add-Content ~/.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
                 "Move-Item \"$dir/pkg_x86_64-w64-mingw32/bin/*\" \"$dir\"",
                 "Move-Item \"$dir/pkg_x86_64-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
                 "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
@@ -24,7 +24,7 @@
             "pre_install": [
                 "if (-not (Test-Path ~/.nanorc)) {",
                 "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
+                "    Add-Content ~/.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
                 "Move-Item \"$dir/pkg_i686-w64-mingw32/bin/*\" \"$dir\"",
                 "Move-Item \"$dir/pkg_i686-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
                 "Remove-Item  \"$dir/pkg*\" -Force -Recurse",

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -7,38 +7,19 @@
     "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.1/nano-for-windows_v7.2-8-10163.1.7z",
     "hash": "3c96a9218bda9257e20523ab37e07353104c9703e324e1198cb2c1ad308650ad",
     "bin": "nano.exe",
-    "architecture": {
-        "64bit": {
-            "pre_install": [
-                "$arch='x86_64'",
-                "$scoopdir=$scoopdir -replace '\\\\', '/'",
-                "if (-not (Test-Path ~/.nanorc)) {",
-                "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
-                "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
-                "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
-                "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
-                "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc"
-            ]
-        },
-        "32bit": {
-            "pre_install": [
-                "$arch='i686'",
-                "$scoopdir=$scoopdir -replace '\\\\', '/'",
-                "if (-not (Test-Path ~/.nanorc)) {",
-                "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
-                "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
-                "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
-                "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
-                "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc"
-            ]
-        }
-    },
+    "pre_install": [
+        "$arch=if ($architecture -match 64) {'x86_64'} else {'i686'}",
+        "$scoopdir=$scoopdir -replace '\\\\', '/'",
+        "if (-not (Test-Path ~/.nanorc)) {",
+        "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
+        "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
+        "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
+        "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
+        "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
+        "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
+        "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
+        "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc"
+    ],
     "checkver": {
         "github": "https://api.github.com/repos/okibcn/nano-for-windows",
         "regex": "v([\\d\\.\\-]+)\\.7z"

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,27 +1,30 @@
 {
-    "version": "7.2-8-10163.1",
+    "version": "7.2-8-10163.2",
     "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
     "notes": [
-        "Configure nano by editing its configuration file with nano ~/.nanorc",
+        "Configure nano interface, colors, key assignments and more by typing nano ~/.nanorc",
+        "If you are upgrading nano, a copy of the old config file is available at ~/.nanorc.bak",
         "Visit https://github.com/okibcn/nano-for-windows for more information."
     ],
-    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.1/nano-for-windows_v7.2-8-10163.1.7z",
-    "hash": "3c96a9218bda9257e20523ab37e07353104c9703e324e1198cb2c1ad308650ad",
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.2/nano-for-windows_v7.2-8-10163.2.7z",
+    "hash": "bd5676de5320baa5fbb40df54c7221a12508a95a3886ab294931fb3f3199a21d",
     "bin": "nano.exe",
     "pre_install": [
-        "$arch=if ($architecture -match 64) {'x86_64'} else {'i686'}",
-        "$scoopdir=$scoopdir -replace '\\\\', '/'",
-        "if (-not (Test-Path ~/.nanorc)) {",
+        "$arch=if ($architecture -match '64') {'x86_64'} else {'i686'}",
+        "$scoopdir=$scoopdir -replace '\\\\','/'",
+        "if (-not (Test-Path ~/.nanorc)){",
         "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
         "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
+        "elseif (-not (Test-Path ~/.nanorc.bak)){",
+        "    Copy-Item ~/.nanorc ~/.nanorc.bak}",
         "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
         "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
         "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
         "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
-        "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-        "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc"
+        "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
+        "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc"
     ],
     "checkver": {
         "github": "https://api.github.com/repos/okibcn/nano-for-windows",

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,18 +1,18 @@
 {
-    "version": "7.2-6-10161",
+    "version": "7.2-8-10163",
     "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
     "notes": "Configure nano by editing its configuration file with nano ~/.nanorc",
-    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-6-10161/nano-for-windows_v7.2-6-10161.7z",
-    "hash": "426f71933d8a9536f3ceed22bae7bd0a37cf42a458cb4c7d91a0d67ba3d9b1fb",
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163/nano-for-windows_v7.2-8-10163.7z",
+    "hash": "c12b44f9ff0b35cc281cef9926216fd2b360ce4e2c663a5ae14d69414e70600a",
     "bin": "nano.exe",
     "architecture": {
         "64bit": {
             "pre_install": [
                 "if (-not (Test-Path ~/.nanorc)) {",
                 "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~/.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
+                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
                 "Move-Item \"$dir/pkg_x86_64-w64-mingw32/bin/*\" \"$dir\"",
                 "Move-Item \"$dir/pkg_x86_64-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
                 "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
@@ -24,7 +24,7 @@
             "pre_install": [
                 "if (-not (Test-Path ~/.nanorc)) {",
                 "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~/.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
+                "    Add-Content ~\\.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
                 "Move-Item \"$dir/pkg_i686-w64-mingw32/bin/*\" \"$dir\"",
                 "Move-Item \"$dir/pkg_i686-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
                 "Remove-Item  \"$dir/pkg*\" -Force -Recurse",

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,23 +1,11 @@
 {
-    "version": "7.1-12",
-    "description": "A small and friendly GNU editor, inspired by Pico",
+    "version": "7.2-6-10161",
+    "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
-    "notes": [
-        "Configure nano by editing its configuration file %USERPROFILE%\\.nanorc",
-        "NOTE: The config file was named nano.rc in the 2.5.3 release, but is now named .nanorc"
-    ],
-    "url": "https://files.lhmouse.com/nano-win/nano-win_10155_v7.1-12-g14f292a7c.7z",
-    "hash": "dce659505c33f6def27048d44d5998dcbe70ae4361c55fe32398af33bc83682e",
-    "post_install": [
-        "if (-not (Test-Path \"$env:USERPROFILE\\.nanorc\")) {",
-        "   Copy-Item \"$dir\\.nanorc\" \"$env:USERPROFILE\\.nanorc\"",
-        "}"
-    ],
-    "checkver": {
-        "url": "https://files.lhmouse.com/nano-win/?C=N&O=D",
-        "regex": "nano-win_(?<build>\\d+)_v([\\d.-]+)-(?<commit>\\w+)\\.7z"
-    },
+    "notes": "Configure nano by editing its configuration file with nano ~\\.nanorc",
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-6-10161/nano-for-windows_v7.2-6-10161.7z",
+    "hash": "426f71933d8a9536f3ceed22bae7bd0a37cf42a458cb4c7d91a0d67ba3d9b1fb",
     "architecture": {
         "64bit": {
             "bin": "pkg_x86_64-w64-mingw32\\bin\\nano.exe"
@@ -26,7 +14,18 @@
             "bin": "pkg_i686-w64-mingw32\\bin\\nano.exe"
         }
     },
+    "post_install": [
+        "if (-not (Test-Path \"$env:USERPROFILE\\.nanorc\")) {",
+        "   Copy-Item \"$dir\\.nanorc\" \"$env:USERPROFILE\\.nanorc\"",
+        "   Add-Content \"$env:USERPROFILE\\.nanorc\" 'include \"~/scoop/apps/nano/current/pkg_x86_64-w64-mingw32/share/nano/*.nanorc\"'",
+        "}"
+    ],
+    "checkver": {
+        "github": "https://api.github.com/repos/okibcn/nano-for-windows",
+        "regex": "v(\\d+).(\\d+)-(\\d+)-(\\d+)\\.7z",
+        "replace": "${1}.${2}-${3}-${4}"
+    },
     "autoupdate": {
-        "url": "https://files.lhmouse.com/nano-win/nano-win_$matchBuild_v$version-$matchCommit.7z"
+        "url": "https://github.com/okibcn/nano-for-windows/releases/download/v$version/nano-for-windows_v$version.7z"
     }
 }

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.2-8-10163.2",
+    "version": "7.2-8-10163.3",
     "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
@@ -8,8 +8,8 @@
         "If you are upgrading nano, a copy of the old config file is available at ~/.nanorc.bak",
         "Visit https://github.com/okibcn/nano-for-windows for more information."
     ],
-    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.2/nano-for-windows_v7.2-8-10163.2.7z",
-    "hash": "bd5676de5320baa5fbb40df54c7221a12508a95a3886ab294931fb3f3199a21d",
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.3/nano-for-windows_v7.2-8-10163.3.7z",
+    "hash": "d3f65f5bb401aaa7e2cd26c0e415516b79a44f16d150cf2098cad469f0b29332",
     "bin": "nano.exe",
     "pre_install": [
         "$arch=if ($architecture -match '64') {'x86_64'} else {'i686'}",

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.2-8-10163.3",
+    "version": "7.2-9-10164",
     "description": "The legendary small and friendly GNU editor, UTF-8 and mouse ready for Windows CLI 32/64 bits",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
@@ -9,8 +9,8 @@
         "the old config file at \"$dir\\.nanorc.bak\"",
         "Visit https://github.com/okibcn/nano-for-windows for more information."
     ],
-    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.3/nano-for-windows_v7.2-8-10163.3.7z",
-    "hash": "d3f65f5bb401aaa7e2cd26c0e415516b79a44f16d150cf2098cad469f0b29332",
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-9-10164/nano-for-windows_v7.2-9-10164.7z",
+    "hash": "92ad91f7178edfb343e28984ef591a9b7368dc8ab84a6fa3657e684fec1b2231",
     "bin": "nano.exe",
     "pre_install": [
         "$arch=if ($architecture -match '64') {'x86_64'} else {'i686'}",

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,11 +1,12 @@
 {
     "version": "7.2-8-10163.3",
-    "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
+    "description": "The legendary small and friendly GNU editor, UTF-8 and mouse ready for Windows CLI 32/64 bits",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
     "notes": [
         "Configure nano interface, colors, key assignments and more by typing nano ~/.nanorc",
-        "If you are upgrading nano, a copy of the old config file is available at ~/.nanorc.bak",
+        "Default folders have been updated, no custom setting has been modified. Find a backup of",
+        "the old config file at \"$dir\\.nanorc.bak\"",
         "Visit https://github.com/okibcn/nano-for-windows for more information."
     ],
     "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.3/nano-for-windows_v7.2-8-10163.3.7z",
@@ -17,8 +18,7 @@
         "if (-not (Test-Path ~/.nanorc)){",
         "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
         "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
-        "elseif (-not (Test-Path ~/.nanorc.bak)){",
-        "    Copy-Item ~/.nanorc ~/.nanorc.bak}",
+        "else{Copy-Item ~/.nanorc \"$dir/.nanorc.bak\"}",
         "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
         "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
         "Remove-Item  \"$dir/pkg*\" -Force -Recurse",

--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -3,7 +3,10 @@
     "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
-    "notes": "Configure nano by editing its configuration file with nano ~/.nanorc",
+    "notes": [
+        "Configure nano by editing its configuration file with nano ~/.nanorc",
+        "Visit https://github.com/okibcn/nano-for-windows for more information."
+    ],
     "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.1/nano-for-windows_v7.2-8-10163.1.7z",
     "hash": "3c96a9218bda9257e20523ab37e07353104c9703e324e1198cb2c1ad308650ad",
     "bin": "nano.exe",


### PR DESCRIPTION
The current source points to GNU nano v7.1-12, but the current one is 7.2-6.  This new source fixes the issue and also meets the recommended template.

- added specific installation for 32 and 64 bits removing the other package.
- Improved autoupdate regex to avoid missing new releases.
- Improved configuration, enabling the default nano features that were not activated.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
