### PR TITLE
(fix) fix git symlink related error #3471

### DIFF
--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -4,15 +4,14 @@
     "homepage": "https://github.com/newren/git-filter-repo",
     "license": "MIT",
     "suggest": {
+        "Git": "git",
         "Python 3": "python"
     },
     "url": "https://github.com/newren/git-filter-repo/archive/v2.38.0.zip",
     "hash": "b8c76eac0a20a0bac47d0321c5093f4a5d50f6312273c3f3a7d9a60791378212",
     "pre_install": "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
     "post_install": "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null",
-    "bin": [
-            "git-filter-repo"
-    ],
+    "bin": "git-filter-repo",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip"

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -11,10 +11,7 @@
     "pre_install": "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
     "post_install": "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null",
     "bin": [
-        [
-            "git_filter_repo.py",
             "git-filter-repo"
-        ]
     ],
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
As suggested by @goigle in #3471 the simplest way seems to let the app point directly to the git-filter-repo file instead of the symbolic link. This fixes the issue on my windows machine

Closes #3471

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
