### PR TITLE
uutils-coreutils@0.0.17: Add shims for dir, uname, vdir

### DIFF
--- a/bucket/uutils-coreutils.json
+++ b/bucket/uutils-coreutils.json
@@ -103,6 +103,11 @@
         ],
         [
             "coreutils.exe",
+            "dir",
+            "dir"
+        ],
+        [
+            "coreutils.exe",
             "dircolors",
             "dircolors"
         ],
@@ -438,6 +443,11 @@
         ],
         [
             "coreutils.exe",
+            "uname",
+            "uname"
+        ],
+        [
+            "coreutils.exe",
             "unexpand",
             "unexpand"
         ],
@@ -450,6 +460,11 @@
             "coreutils.exe",
             "unlink",
             "unlink"
+        ],
+        [
+            "coreutils.exe",
+            "vdir",
+            "vdir"
         ],
         [
             "coreutils.exe",


### PR DESCRIPTION
- [v0.0.14][]: The `dir` and `vdir` utilities where added as aliases for `ls` and `ls -l`, respectively.
- [v0.0.17][]: `uname` is now available for all supported platforms, instead of Unix-like platforms only.

[v0.0.17]: https://github.com/uutils/coreutils/releases/tag/0.0.17
[v0.0.14]: https://github.com/uutils/coreutils/releases/tag/0.0.14

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes: #4414

Relates-to: #3482

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
  - [x] Test my manifest by installing, uninstalling, checking functionality, persistence etc.
  - [x] Confirm that manifest gets updated automatically [^auto-update]

[^auto-update]: It can't update shim list automatically either. However I think it's OK, as it won't change frequently.
