### PR TITLE
xxd: Add version 3503723768

### DIFF
--- a/bucket/xxd.json
+++ b/bucket/xxd.json
@@ -1,0 +1,24 @@
+{
+    "version": "3503723768",
+    "description": "A hexdump utility by Juergen Weigert",
+    "homepage": "https://github.com/ckormanyos/xxd",
+    "license": "Vim,GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://nightly.link/ckormanyos/xxd/workflows/xxd/main/xxd-win64-msvc.zip",
+            "hash": "1b91b520d3d98789fb912ffc43eb1de42e37b315f01ed41ad39cefea86152979"
+        }
+    },
+    "bin": "xxd.exe",
+    "checkver": {
+        "url": "https://api.github.com/repositories/475011866/actions/workflows/xxd.yml/runs?branch=main&status=success",
+        "jsonpath": "$.workflow_runs[0].id"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://nightly.link/ckormanyos/xxd/workflows/xxd/main/xxd-win64-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Gives you the option to install the latest xxd version without installing vim, if this manifest is a better fit for the versions bucket, lmk, I wasn't too sure which would be better.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).