### PR TITLE
rdiff-backup@2.2.2: release format changed

### DIFF
--- a/bucket/rdiff-backup.json
+++ b/bucket/rdiff-backup.json
@@ -3,18 +3,36 @@
     "description": "Reverse differential backup tool, over a network or locally",
     "homepage": "https://rdiff-backup.net",
     "license": "GPL-2.0-only",
+    "notes": "Please refer to https://rdiff-backup.net/Windows-README.html for (possibly outdated) Windows specific documentation.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v2.2.2/rdiff-backup-2.2.2.win64exe.zip",
+            "hash": "fa37ae6555a6d34a3a1756a2791f0cc67fa4724ccb10deddbcda7a0999bae447",
+            "extract_dir": "rdiff-backup-2.2.2-64"
+        },
+        "32bit": {
+            "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v2.2.2/rdiff-backup-2.2.2.win32exe.zip",
+            "hash": "5ee2d372561f250f500d03483a4e73af2db74eb2f4d38f599da689cd3f74af83",
+            "extract_dir": "rdiff-backup-2.2.2-32"
+        }
+    },
     "suggest": {
         "vcredist2008": "extras/vcredist2008"
     },
-    "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v2.2.2/rdiff-backup-2.2.2.win32exe.zip",
-    "hash": "5ee2d372561f250f500d03483a4e73af2db74eb2f4d38f599da689cd3f74af83",
-    "extract_dir": "rdiff-backup-2.2.2",
     "bin": "rdiff-backup.exe",
     "checkver": {
         "github": "https://github.com/rdiff-backup/rdiff-backup"
     },
     "autoupdate": {
-        "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v$version/rdiff-backup-$version.win32exe.zip",
-        "extract_dir": "rdiff-backup-$version"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v$version/rdiff-backup-$version.win64exe.zip",
+                "extract_dir": "rdiff-backup-$version-64"
+            },
+            "32bit": {
+                "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v$version/rdiff-backup-$version.win32exe.zip",
+                "extract_dir": "rdiff-backup-$version-32"
+            }
+        }
     }
 }


### PR DESCRIPTION
- `architecture`: 64-bit version since [v2.2.0](https://github.com/rdiff-backup/rdiff-backup/releases/tag/v2.2.0). Installing a wrong version can make [ssh undiscoverable](https://github.com/rdiff-backup/rdiff-backup/blob/386732002e8956329421fb6f7c55a3222092e87a/docs/Windows-README.adoc#using-microsofts-openssh-client-on-windows-10).
- `extract_dir`: There's a 64/32 tail now. (e.g. `rdiff-backup-$version` → `rdiff-backup-$version-64`)
- `notes`: Add Windows doc.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #4423

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
  - [x] Test my manifest by installing, uninstalling, checking functionality, persistence etc. (only 64-bit is tested)
  - [x] Confirm that manifest gets updated automatically