### PR TITLE
tproxy@0.7.0: Add arm64 architecture

### DIFF
--- a/bucket/tproxy.json
+++ b/bucket/tproxy.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/kevwan/tproxy/releases/download/v0.7.0/tproxy-v0.7.0-windows-amd64.zip",
             "hash": "md5:344c7d5d289a692bed32d4722a683a40"
+        },
+        "arm64": {
+            "url": "https://github.com/kevwan/tproxy/releases/download/v0.7.0/tproxy-v0.7.0-windows-arm64.zip",
+            "hash": "md5:5d84dd9e554dbd6d1f1a50bfddc706f2"
         }
     },
     "bin": "tproxy.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/kevwan/tproxy/releases/download/v$version/tproxy-v$version-windows-amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/kevwan/tproxy/releases/download/v$version/tproxy-v$version-windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
