### PR TITLE
chkcpu: Update chkcpu to version v2.15

### DIFF
--- a/bucket/chkcpu.json
+++ b/bucket/chkcpu.json
@@ -6,8 +6,8 @@
         "identifier": "Freeware",
         "url": "http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm"
     },
-    "url": "http://web.inter.nl.net/hcc/J.Steunebrink/ckcpu214.zip",
-    "hash": "ce9142e29000f8299750a1880056a8a812c0fef91cac16b843ad947b18114d16",
+    "url": "http://web.inter.nl.net/hcc/J.Steunebrink/ckcpu215.zip",
+    "hash": "f896e42cfef67bbac90c4c51eb9791401455ad9b02edbf65de05f84a96d88897",
     "bin": [
         "chkcpu32.exe",
         [


### PR DESCRIPTION
Add version v2.15 and change download links to correct ones because it looks like urls have changed after looking on chkcpu website download links listed on chkcpu website: [http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm](http://web.inter.nl.net/hcc/J.Steunebrink/chkcpu.htm)

Closes #4437 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).