### PR TITLE
cloud-sql-proxy@2.0.0: autoupdate urls changed

### DIFF
--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -6,28 +6,15 @@
     "depends": "gcloud",
     "architecture": {
         "64bit": {
-            "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x64.exe",
-            "hash": "d83eb69b0f1dc69ec2d8a6da2eb66c90a0cd2ea2002849459a07c6958bb08388",
-            "bin": [
-                "cloud-sql-proxy.x64.exe", 
-                [
-                    "cloud-sql-proxy.x64.exe", 
-                    "cloud-sql-proxy"
-                ]
-            ]
+            "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x64.exe#/cloud-sql-proxy.exe",
+            "hash": "d83eb69b0f1dc69ec2d8a6da2eb66c90a0cd2ea2002849459a07c6958bb08388"
         },
         "32bit": {
-            "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x86.exe",
-            "hash": "8d5252bfc2741b1c32a56e5648f6bcf96cc6169b716cdb032503459bfd8d9b23",
-            "bin": [
-                "cloud-sql-proxy.x86.exe", 
-                [
-                    "cloud-sql-proxy.x86.exe", 
-                    "cloud-sql-proxy"
-                ]
-            ]
+            "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x86.exe#/cloud-sql-proxy.exe",
+            "hash": "8d5252bfc2741b1c32a56e5648f6bcf96cc6169b716cdb032503459bfd8d9b23"
         }
     },
+    "bin": "cloud-sql-proxy.exe",
     "checkver": {
         "github": "https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
     },

--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -8,12 +8,24 @@
         "64bit": {
             "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x64.exe",
             "hash": "d83eb69b0f1dc69ec2d8a6da2eb66c90a0cd2ea2002849459a07c6958bb08388",
-            "bin": ["cloud-sql-proxy.x64.exe", "cloud-sql-proxy.exe"]
+            "bin": [
+                "cloud-sql-proxy.x64.exe", 
+                [
+                    "cloud-sql-proxy.x64.exe", 
+                    "cloud-sql-proxy"
+                ]
+            ]
         },
         "32bit": {
             "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x86.exe",
-            "hash": "8d5252bfc2741b1c32a56e5648f6bcf96cc6169b716cdb032503459bfd8d9b23"
-            "bin": ["cloud-sql-proxy.x86.exe", "cloud-sql-proxy.exe"]
+            "hash": "8d5252bfc2741b1c32a56e5648f6bcf96cc6169b716cdb032503459bfd8d9b23",
+            "bin": [
+                "cloud-sql-proxy.x86.exe", 
+                [
+                    "cloud-sql-proxy.x86.exe", 
+                    "cloud-sql-proxy"
+                ]
+            ]
         }
     },
     "checkver": {

--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -29,7 +29,7 @@
         }
     },
     "checkver": {
-        "github": "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
+        "github": "https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
     },
     "autoupdate": {
         "architecture": {
@@ -41,7 +41,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases/tag/v$version",
+            "url": "https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases/tag/v$version",
             "regex": "(?sm)$basename.*?td>$sha256"
         }
     }

--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -21,10 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://storage.googleapis.com/cloudsql-proxy/v$version/cloud_sql_proxy_x64.exe#/cloud_sql_proxy.exe"
+                "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v$version/cloud-sql-proxy.x64.exe"
             },
             "32bit": {
-                "url": "https://storage.googleapis.com/cloudsql-proxy/v$version/cloud_sql_proxy_x86.exe#/cloud_sql_proxy.exe"
+                "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v$version/cloud-sql-proxy.x86.exe"
             }
         },
         "hash": {

--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.33.1",
+    "version": "2.0.0",
     "description": "Provides secure access to Cloud SQL Second Generation instances without having to add Authorized networks or configure SSL.",
     "homepage": "https://cloud.google.com/sql/docs/mysql/sql-proxy",
     "license": "Apache-2.0",
     "depends": "gcloud",
     "architecture": {
         "64bit": {
-            "url": "https://storage.googleapis.com/cloudsql-proxy/v1.33.1/cloud_sql_proxy_x64.exe#/cloud_sql_proxy.exe",
-            "hash": "2a3177fc089817b6e79a07008c5d6dff9c3faf93a68e0f4198a6b226f680db76"
+            "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x64.exe",
+            "hash": "d83eb69b0f1dc69ec2d8a6da2eb66c90a0cd2ea2002849459a07c6958bb08388"
         },
         "32bit": {
-            "url": "https://storage.googleapis.com/cloudsql-proxy/v1.33.1/cloud_sql_proxy_x86.exe#/cloud_sql_proxy.exe",
-            "hash": "d60d4ddf3a2c5bd337661b1f1ddda947626cd0bb109ab470e14c57b3bb52b68e"
+            "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x86.exe",
+            "hash": "8d5252bfc2741b1c32a56e5648f6bcf96cc6169b716cdb032503459bfd8d9b23"
         }
     },
     "bin": "cloud_sql_proxy.exe",

--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -7,14 +7,15 @@
     "architecture": {
         "64bit": {
             "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x64.exe",
-            "hash": "d83eb69b0f1dc69ec2d8a6da2eb66c90a0cd2ea2002849459a07c6958bb08388"
+            "hash": "d83eb69b0f1dc69ec2d8a6da2eb66c90a0cd2ea2002849459a07c6958bb08388",
+            "bin": ["cloud-sql-proxy.x64.exe", "cloud-sql-proxy.exe"]
         },
         "32bit": {
             "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.0.0/cloud-sql-proxy.x86.exe",
             "hash": "8d5252bfc2741b1c32a56e5648f6bcf96cc6169b716cdb032503459bfd8d9b23"
+            "bin": ["cloud-sql-proxy.x86.exe", "cloud-sql-proxy.exe"]
         }
     },
-    "bin": "cloud_sql_proxy.exe",
     "checkver": {
         "github": "https://github.com/GoogleCloudPlatform/cloudsql-proxy"
     },

--- a/bucket/cloud-sql-proxy.json
+++ b/bucket/cloud-sql-proxy.json
@@ -21,10 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v$version/cloud-sql-proxy.x64.exe"
+                "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v$version/cloud-sql-proxy.x64.exe#/cloud-sql-proxy.exe"
             },
             "32bit": {
-                "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v$version/cloud-sql-proxy.x86.exe"
+                "url": "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v$version/cloud-sql-proxy.x86.exe#/cloud-sql-proxy.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
Google has changed the URLs for the executables resulting in scoop not being able to grab the latest files.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).