### PR TITLE
goreleaser@1.15.2: Add arm64 architecture

### DIFF
--- a/bucket/goreleaser.json
+++ b/bucket/goreleaser.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/goreleaser/goreleaser/releases/download/v1.15.2/goreleaser_Windows_i386.zip",
             "hash": "6db786ce108ea5fde9869a5802f5daf612e69149ef1f77aea667279360c50887"
+        },
+        "arm64": {
+            "url": "https://github.com/goreleaser/goreleaser/releases/download/v1.15.2/goreleaser_Windows_arm64.zip",
+            "hash": "591c8106284c1e16249304c7068d77ef764ccd0b8cd9a3be6c27533c8037c34d"
         }
     },
     "bin": "goreleaser.exe",
@@ -24,6 +28,9 @@
             },
             "32bit": {
                 "url": "https://github.com/goreleaser/goreleaser/releases/download/v$version/goreleaser_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/goreleaser/goreleaser/releases/download/v$version/goreleaser_Windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
