### PR TITLE
Update chafa.json

### DIFF
--- a/bucket/chafa.json
+++ b/bucket/chafa.json
@@ -13,7 +13,7 @@
     "bin": "chafa.exe",
     "checkver": {
         "url": "https://hpjansson.org/chafa/download/",
-        "regex": "Get Chafa (\\d+\\.\\d+\\.\\d+) for Windows"
+        "regex": "Get Chafa ([\\d.]+) for Windows"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Change the version regex in Checkver to "[\\d.]+". Though the version regex "\\d+\\.\\d+\\.\\d+" is OK, I realize I should make it concise as most buckets do.
