### PR TITLE
ruff: Add version 0.0.251

### DIFF
--- a/bucket/ruff.json
+++ b/bucket/ruff.json
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ducaale/xh/releases/download/v$version/ruff-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-x86_64-pc-windows-msvc.zip"
             }
         },
         "hash": {

--- a/bucket/ruff.json
+++ b/bucket/ruff.json
@@ -1,12 +1,20 @@
 {
-    "version": "0.0.249",
+    "version": "0.0.251",
     "description": "An extremely fast Python linter, written in Rust",
     "homepage": "https://github.com/charliermarsh/ruff",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.0.249/ruff-x86_64-pc-windows-msvc.zip",
-            "hash": "d3e18164a996f81cce0d7962942041ddff35105719becd4085951c12050d5a0b"
+            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.0.251/ruff-x86_64-pc-windows-msvc.zip",
+            "hash": "bba682c431f1ba83ff1b41b5559a38f8a83da7eb97e52d02fa0db7325e7986d0"
+        },
+        "32bit": {
+            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.0.251/ruff-i686-pc-windows-msvc.zip",
+            "hash": "6cd65070f2f9b04e200c216d4e5eca0547fbb3e84bbfe23554930523a89013e6"
+        },
+        "arm64": {
+            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.0.251/ruff-aarch64-pc-windows-msvc.zip",
+            "hash": "b349a4518766e189545658df8264df442fb2d286a2c82f97017273163da0200e"
         }
     },
     "bin": "ruff.exe",
@@ -15,6 +23,12 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-x86_64-pc-windows-msvc.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-i686-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-aarch64-pc-windows-msvc.zip"
             }
         },
         "hash": {

--- a/bucket/ruff.json
+++ b/bucket/ruff.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.0.249",
+    "description": "An extremely fast Python linter, written in Rust",
+    "homepage": "https://github.com/charliermarsh/ruff",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.0.249/ruff-x86_64-pc-windows-msvc.zip",
+            "hash": "d3e18164a996f81cce0d7962942041ddff35105719becd4085951c12050d5a0b"
+        }
+    },
+    "bin": "ruff.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ducaale/xh/releases/download/v$version/ruff-x86_64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Add [ruff](https://github.com/charliermarsh/ruff)

> Ruff is extremely actively developed and used in major open-source projects like:
> * [pandas](https://github.com/pandas-dev/pandas)
> * [FastAPI](https://github.com/tiangolo/fastapi)
> * [Transformers (Hugging Face)](https://github.com/huggingface/transformers)
> * [Apache Airflow](https://github.com/apache/airflow)
> * [SciPy](https://github.com/scipy/scipy)
>
> ...and many more.