### PR TITLE
Fixed Hash on shellcheck.json

### DIFF
--- a/bucket/shellcheck.json
+++ b/bucket/shellcheck.json
@@ -4,7 +4,7 @@
     "homepage": "https://shellcheck.net/",
     "license": "GPL-3.0-only",
     "url": "https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.zip",
-    "hash": "ae58191b1ea4ffd9e5b15da9134146e636440302ce3e2f46863e8d71c8be1bbb",
+    "hash": "e79a879103190f1d0065475b8c8172273d8ebb2fe2a5a574772b968d60cc9ad3",
     "pre_install": "Get-ChildItem \"$dir\\shellcheck-*.exe\" | Rename-Item -NewName 'shellcheck.exe'",
     "bin": "shellcheck.exe",
     "checkver": {


### PR DESCRIPTION
When trying to install shellcheck via scoop, I received the following error:

```sh
Wed Feb 22 11:56:24:$ scoop install shellcheck
WARN  Purging previous failed installation of shellcheck.
ERROR 'shellcheck' isn't installed correctly.
Removing older version (0.9.0).
'shellcheck' was uninstalled.
Installing 'shellcheck' (0.9.0) [64bit] from main bucket
Downloading https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.zip (-1 B)...

Checking hash of shellcheck-v0.9.0.zip ... ERROR Hash check failed!
App:         main/shellcheck
URL:         https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.zip
First bytes: 50 4B 03 04 14 00 08 00
Expected:    ae58191b1ea4ffd9e5b15da9134146e636440302ce3e2f46863e8d71c8be1bbb
Actual:      e79a879103190f1d0065475b8c8172273d8ebb2fe2a5a574772b968d60cc9ad3
```

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
