### PR TITLE
chafa: Update license

### DIFF
--- a/bucket/chafa.json
+++ b/bucket/chafa.json
@@ -2,7 +2,7 @@
     "version": "1.12.4",
     "description": "Terminal graphics for the 21st century.",
     "homepage": "https://hpjansson.org/chafa/",
-    "license": "LGPL-3.0-only",
+    "license": "LGPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://hpjansson.org/chafa/releases/static/chafa-1.12.4-1-x86_64-windows.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

License is `LGPL-3.0-or-later` as stated in the [readme](https://github.com/hpjansson/chafa/blob/master/README):
> Both library and frontend tools are covered by the Lesser GPL license, version 3 or later (LGPLv3+).

- [x I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
