### PR TITLE
dart-sass-embedded: Update v1.57.1 => 1.58.3

### DIFF
--- a/bucket/dart-sass-embedded.json
+++ b/bucket/dart-sass-embedded.json
@@ -1,19 +1,20 @@
 {
-    "version": "1.57.1",
+    "version": "1.58.3",
     "description": "A wrapper for Dart Sass that implements the compiler side of the Embedded Sass protocol",
     "homepage": "https://github.com/sass/dart-sass-embedded",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/sass/dart-sass-embedded/releases/download/1.57.1/sass_embedded-1.57.1-windows-ia32.zip",
-            "hash": "729A0C3AE9AD09E1947DC9F19B19E9969797D835B32561BD55AAD964F0C99EB3"
+            "url": "https://github.com/sass/dart-sass-embedded/releases/download/1.58.3/sass_embedded-1.58.3-windows-ia32.zip",
+            "hash": "922CE0B17970A88A9A993047CE3CB9E3B82DD50558D4ADD62D1033E149263D93"
         },
         "64bit": {
-            "url": "https://github.com/sass/dart-sass-embedded/releases/download/1.57.1/sass_embedded-1.57.1-windows-x64.zip",
-            "hash": "133B9FE97EBBBF2E6CA712DF2E250E7C97DF9ED4F42D854048911849C1BDAE0F"
+            "url": "https://github.com/sass/dart-sass-embedded/releases/download/1.58.3/sass_embedded-1.58.3-windows-x64.zip",
+            "hash": "5D34BAEA134D8693E27E2E98E098D48706B345A5F7FB145A97F06A3493B2AD79"
         }
     },
     "bin": "sass_embedded\\dart-sass-embedded.bat",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "32bit": {


### PR DESCRIPTION
Updating dart-sass-embedded from v1.57.1 to 1.58.3

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
