### PR TITLE
railway@v3.0.5: update manifest to new binary names

### DIFF
--- a/bucket/railway.json
+++ b/bucket/railway.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.0.3",
+    "version": "3.0.5",
     "description": "The command line interface for Railway. Use it to connect your code to Railways infrastructure.",
     "homepage": "https://github.com/railwayapp/cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/railwayapp/cli/releases/download/v3.0.3/railway-v3.0.3-x86_64-pc-windows-msvc.zip",
-            "hash": "803c329261060033b505434b6e389b3162b3a29ece1cb825ecb851a1f2972b22"
+            "url": "https://github.com/railwayapp/cli/releases/download/v3.0.5/railway-v3.0.5-x86_64-pc-windows-msvc.zip",
+            "hash": "80e5b6f8de21a9ddb0396357e4d1dc86976dd772538b4fe3e2e35ef4586ebeb1"
         },
         "32bit": {
-            "url": "https://github.com/railwayapp/cli/releases/download/v3.0.3/railway-v3.0.3-i686-pc-windows-msvc.zip",
-            "hash": "ACBF310CD4B385E2602FA73944327189226E8EC2F776279EADC235A050B12096"
+            "url": "https://github.com/railwayapp/cli/releases/download/v3.0.5/railway-v3.0.5-i686-pc-windows-msvc.zip",
+            "hash": "ff0a6399c43535947994bd4fab96f574ebc00a687bd1442cd9473a606b99b174"
         }
     },
     "bin": "railway.exe",
@@ -23,9 +23,6 @@
             "32bit": {
                 "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway-v$version-i686-pc-windows-msvc.zip"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/railway.json
+++ b/bucket/railway.json
@@ -13,7 +13,7 @@
             "hash": "ACBF310CD4B385E2602FA73944327189226E8EC2F776279EADC235A050B12096"
         }
     },
-    "bin": ["railway.exe", "rlwy.exe"],
+    "bin": "railway.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/railway.json
+++ b/bucket/railway.json
@@ -1,31 +1,31 @@
 {
-    "version": "2.1.0",
+    "version": "3.0.3",
     "description": "The command line interface for Railway. Use it to connect your code to Railways infrastructure.",
     "homepage": "https://github.com/railwayapp/cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/railwayapp/cli/releases/download/v2.1.0/railway_2.1.0_windows_amd64.tar.gz",
-            "hash": "27ce66957588d0647385e0092127c933b1008d3796049f95dca5e1495a870e90"
+            "url": "https://github.com/railwayapp/cli/releases/download/v3.0.3/railway-v3.0.3-x86_64-pc-windows-msvc.zip",
+            "hash": "803c329261060033b505434b6e389b3162b3a29ece1cb825ecb851a1f2972b22"
         },
         "32bit": {
-            "url": "https://github.com/railwayapp/cli/releases/download/v2.1.0/railway_2.1.0_windows_386.tar.gz",
-            "hash": "b5a31c0b4d4c901de88589f84cfb39116c78f6e00e9b59dca155e8564a18eea8"
+            "url": "https://github.com/railwayapp/cli/releases/download/v3.0.3/railway-v3.0.3-i686-pc-windows-msvc.zip",
+            "hash": "ACBF310CD4B385E2602FA73944327189226E8EC2F776279EADC235A050B12096"
         }
     },
-    "bin": "railway.exe",
+    "bin": ["railway.exe", "rlwy.exe"],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway_$version_windows_amd64.tar.gz"
+                "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway-v$version-x86_64-pc-windows-msvc.zip"
             },
             "32bit": {
-                "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway_$version_windows_386.tar.gz"
+                "url": "https://github.com/railwayapp/cli/releases/download/v$version/railway-v$version-i686-pc-windows-msvc.zip"
             }
         },
         "hash": {
-            "url": "$baseurl/railway_$version_checksums.txt"
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This updates the manifest since a new version of the Railway CLI was released and it uses new executable names.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
