### PR TITLE
oracle-instant-client-sqlplus: Add version 21.8.0.0.0

### DIFF
--- a/bucket/oracle-instant-client-odbc.json
+++ b/bucket/oracle-instant-client-odbc.json
@@ -29,7 +29,7 @@
         ]
     },
     "checkver": {
-        "url": "https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html",
+        "url": "https://www.oracle.com/database/technologies/instant-client/microsoft-windows-32-downloads.html",
         "regex": "Version ([\\d.]+)",
         "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
     },

--- a/bucket/oracle-instant-client-sqlplus.json
+++ b/bucket/oracle-instant-client-sqlplus.json
@@ -1,6 +1,6 @@
 {
     "version": "21.8.0.0.0",
-    "description": "Additional header files and an example makefile for developing Oracle applications with Instant Client.",
+    "description": "The SQL*Plus command line tool for SQL and PL/SQL queries with Oracle Instant Client.",
     "homepage": "https://www.oracle.com/database/technologies/instant-client.html",
     "license": {
         "identifier": "Freeware",
@@ -9,12 +9,12 @@
     "depends": "oracle-instant-client",
     "architecture": {
         "64bit": {
-            "url": "https://download.oracle.com/otn_software/nt/instantclient/218000/instantclient-sdk-windows.x64-21.8.0.0.0dbru.zip",
-            "hash": "43157068ffca2247937eab15642532c39d4cd15a0c2a211b29edaebfc02b8b0d"
+            "url": "https://download.oracle.com/otn_software/nt/instantclient/218000/instantclient-sqlplus-windows.x64-21.8.0.0.0dbru.zip",
+            "hash": "ff87a267a16cf4811165e74a47e238db8ab679b31b5729c4435ac2cfcf1c8360"
         },
         "32bit": {
-            "url": "https://download.oracle.com/otn_software/nt/instantclient/218000/instantclient-sdk-nt-21.8.0.0.0dbru.zip",
-            "hash": "fc5eaf112e1a1842267b2cf291ef8c52afea5632fb94a29d303277ee625bc0e9"
+            "url": "https://download.oracle.com/otn_software/nt/instantclient/218000/instantclient-sqlplus-nt-21.8.0.0.0dbru.zip",
+            "hash": "f0e2c465e3c36247147bcf083aa4d51f2f01eb743450aff5ef2fffbd13608ba1"
         }
     },
     "extract_dir": "instantclient_21_8",
@@ -36,10 +36,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.oracle.com/otn_software/nt/instantclient/$cleanVersion/instantclient-sdk-windows.x64-$versiondbru.zip"
+                "url": "https://download.oracle.com/otn_software/nt/instantclient/$cleanVersion/instantclient-sqlplus-windows.x64-$versiondbru.zip"
             },
             "32bit": {
-                "url": "https://download.oracle.com/otn_software/nt/instantclient/$cleanVersion/instantclient-sdk-nt-$versiondbru.zip"
+                "url": "https://download.oracle.com/otn_software/nt/instantclient/$cleanVersion/instantclient-sqlplus-nt-$versiondbru.zip"
             }
         },
         "extract_dir": "instantclient_$majorVersion_$minorVersion"

--- a/bucket/oracle-instant-client.json
+++ b/bucket/oracle-instant-client.json
@@ -31,7 +31,7 @@
     "env_add_path": ".",
     "persist": "network\\admin",
     "checkver": {
-        "url": "https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html",
+        "url": "https://www.oracle.com/database/technologies/instant-client/microsoft-windows-32-downloads.html",
         "regex": "Version ([\\d.]+)",
         "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Add SQL*Plus for Oracle Instant Client.

Sadly, OCI's 64bit is 21.9.0.0.0 but 32bit is 21.8.0.0.0, so change OCI's checkver to 32bit page.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
