### PR TITLE
datree: add version 1.8.37

### DIFF
--- a/bucket/datree.json
+++ b/bucket/datree.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.8.37",
+    "description": "Prevent Kubernetes misconfigurations from reaching production (again 😤 )! From code to cloud, Datree provides an E2E policy enforcement solution to run automatic checks for rule violations.",
+    "homepage": "https://www.datree.io/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/datreeio/datree/releases/download/1.8.37/datree-cli_1.8.37_windows_x86_64.zip",
+            "hash": "f80c161380d95ef03c3bdeb0c3cc12a15dc18f2a716ee22aca1e691528626808"
+        },
+        "32bit": {
+            "url": "https://github.com/datreeio/datree/releases/download/1.8.37/datree-cli_1.8.37_windows_386.zip",
+            "hash": "2275d43c471c600d00ac83a429cd07a1681c647e3c57ecc2ce3e592c68419d8e"
+        }
+    },
+    "bin": "datree.exe",
+    "checkver": {
+        "github": "https://github.com/datreeio/datree"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/datreeio/datree/releases/download/$version/datree-cli_$version_windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/datreeio/datree/releases/download/$version/datree-cli_$version_windows_386.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add datree into scoop as given in this [issue](https://github.com/datreeio/datree/issues/799)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
