### PR TITLE
sqldef: Update to version 0.15.15

### DIFF
--- a/bucket/sqldef.json
+++ b/bucket/sqldef.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.13.23",
+    "version": "0.15.15",
     "description": "Idempotent schema management for MySQL, Microsoft SQL Server, and SQLite.",
     "homepage": "https://github.com/k0kubun/sqldef",
     "license": "MIT,Apache-2.0",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/mssqldef_windows_amd64.zip",
-                "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/mysqldef_windows_amd64.zip",
-                "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/sqlite3def_windows_amd64.zip"
+                "https://github.com/k0kubun/sqldef/releases/download/v0.15.15/mssqldef_windows_amd64.zip",
+                "https://github.com/k0kubun/sqldef/releases/download/v0.15.15/mysqldef_windows_amd64.zip",
+                "https://github.com/k0kubun/sqldef/releases/download/v0.15.15/sqlite3def_windows_amd64.zip"
             ],
             "hash": [
-                "e611e55ad4d935e54bc69c7b68bec190ea6f171ba4a2904804be6cced0d212ec",
-                "ca342f9d6c6978818b4f01e4a0251bbd17e7e6aec1e084e2ba965754d04a5c0e",
-                "8ee58d81d0bbe73f3836d70a8d1248648ec8ccc9911528148e9f4c71bc231167"
+                "cc737e4b71aca76de795142a47cd2ca467a222913212c33bcdf2d7388797e35e",
+                "2c422515c0cb7e90acb57278dce59362f21765b7c4c2ddc4e110759ec9322970",
+                "b9cae4f94cf9a1bdb7f91b1fa8a62864a79bb239cc669f56b0efe57a22b06567"
             ]
         },
         "32bit": {
@@ -23,7 +23,7 @@
                 "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/sqlite3def_windows_386.zip"
             ],
             "hash": [
-                "3862541e28a72824461106c2dea25444605f9210b7a6d91ca7cf41aef92d4e76",
+                "",
                 "f06f29dc3e7683f55bdb1adc90224ce9b5bf46b0ae2e9ed23cada8e5f21958b7",
                 "6e24bc4a66075bda5a75158b5318a5e333af876f5f1d3882841d1ac45b1f3c98"
             ]
@@ -42,13 +42,6 @@
                     "https://github.com/k0kubun/sqldef/releases/download/v$version/mssqldef_windows_amd64.zip",
                     "https://github.com/k0kubun/sqldef/releases/download/v$version/mysqldef_windows_amd64.zip",
                     "https://github.com/k0kubun/sqldef/releases/download/v$version/sqlite3def_windows_amd64.zip"
-                ]
-            },
-            "32bit": {
-                "url": [
-                    "https://github.com/k0kubun/sqldef/releases/download/v$version/mssqldef_windows_386.zip",
-                    "https://github.com/k0kubun/sqldef/releases/download/v$version/mysqldef_windows_386.zip",
-                    "https://github.com/k0kubun/sqldef/releases/download/v$version/sqlite3def_windows_386.zip"
                 ]
             }
         }

--- a/bucket/sqldef.json
+++ b/bucket/sqldef.json
@@ -23,7 +23,7 @@
                 "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/sqlite3def_windows_386.zip"
             ],
             "hash": [
-                "",
+                "3862541e28a72824461106c2dea25444605f9210b7a6d91ca7cf41aef92d4e76",
                 "f06f29dc3e7683f55bdb1adc90224ce9b5bf46b0ae2e9ed23cada8e5f21958b7",
                 "6e24bc4a66075bda5a75158b5318a5e333af876f5f1d3882841d1ac45b1f3c98"
             ]


### PR DESCRIPTION
Drop auto-update for 32bit system

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
