### PR TITLE
git@2.39.2.windows.1: Add .reg scripts (#4462)

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -3,7 +3,13 @@
     "description": "Distributed version control system",
     "homepage": "https://gitforwindows.org",
     "license": "GPL-2.0-only",
-    "notes": "Set Git Credential Manager Core by running: \"git config --global credential.helper manager\"",
+    "notes": [
+        "Set Git Credential Manager Core by running: \"git config --global credential.helper manager\"",
+        "",
+        "To add context menu entries, run '$dir\\install-context.reg'",
+        "",
+        "To create file-associations for .git* and .sh files, run '$dir\\install-file-associations.reg'"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/git-for-windows/git/releases/download/v2.39.2.windows.1/PortableGit-2.39.2-64-bit.7z.exe#/dl.7z",
@@ -14,6 +20,21 @@
             "hash": "84ea6be01df896f6d50192ba4cda85c38ab995154f7aa9d3849492a15f21b500"
         }
     },
+    "post_install": [
+        "'install-context', 'uninstall-context', 'install-file-associations', 'uninstall-file-associations' | ForEach-Object {",
+        "    $reg_file_in  = \"$bucketsdir\\main\\scripts\\git\\$_.reg\"",
+        "    $reg_file_out = \"$dir\\$_.reg\"",
+        "    $git_root     = \"$dir\".Replace('\\', '\\\\')",
+        "    if (Test-Path $reg_file_in) {",
+        "        $content = Get-Content $reg_file_in",
+        "        $content = $content.Replace('$git_root', $git_root)",
+        "        if ($global) {",
+        "            $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "        }",
+        "        Set-Content -Path $reg_file_out -Value $content -Encoding Ascii",
+        "    }",
+        "}"
+    ],
     "bin": [
         "bin\\sh.exe",
         "bin\\bash.exe",

--- a/scripts/git/install-context.reg
+++ b/scripts/git/install-context.reg
@@ -1,0 +1,51 @@
+Windows Registry Editor Version 5.00
+
+; -----------------------------------------------------------------------------
+;  context menu entry  'Git GUI Here'
+; -----------------------------------------------------------------------------
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_gui]
+@="Git &GUI Here"
+"Icon"="$git_root\\cmd\\git-gui.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_gui\command]
+@="\"$git_root\\cmd\\git-gui.exe\" \"--working-dir\" \"%v.\""
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_gui]
+@="Git &GUI Here"
+"Icon"="$git_root\\cmd\\git-gui.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_gui\command]
+@="\"$git_root\\cmd\\git-gui.exe\" \"--working-dir\" \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_gui]
+@="Git &GUI Here"
+"Icon"="$git_root\\cmd\\git-gui.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_gui\command]
+@="\"$git_root\\cmd\\git-gui.exe\" \"--working-dir\" \"%v.\""
+
+; -----------------------------------------------------------------------------
+;  context menu entry  'Git Bash Here'
+; -----------------------------------------------------------------------------
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_shell]
+@="Git Ba&sh Here"
+"Icon"="$git_root\\git-bash.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_shell\command]
+@="\"$git_root\\git-bash.exe\" \"--cd=%v.\""
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_shell]
+@="Git Ba&sh Here"
+"Icon"="$git_root\\git-bash.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_shell\command]
+@="\"$git_root\\git-bash.exe\" \"--cd=%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_shell]
+@="Git Ba&sh Here"
+"Icon"="$git_root\\git-bash.exe"
+
+[HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_shell\command]
+@="\"$git_root\\git-bash.exe\" \"--cd=%v.\""

--- a/scripts/git/install-file-associations.reg
+++ b/scripts/git/install-file-associations.reg
@@ -1,0 +1,39 @@
+Windows Registry Editor Version 5.00
+
+; -----------------------------------------------------------------------------
+;  associate .git* configuration files with the default text editor
+; -----------------------------------------------------------------------------
+
+[HKEY_CURRENT_USER\Software\Classes\.gitattributes]
+@="txtfile"
+"Content Type"="text/plain"
+"PerceivedType"="text"
+
+[HKEY_CURRENT_USER\Software\Classes\.gitignore]
+@="txtfile"
+"Content Type"="text/plain"
+"PerceivedType"="text"
+
+[HKEY_CURRENT_USER\Software\Classes\.gitmodules]
+@="txtfile"
+"Content Type"="text/plain"
+"PerceivedType"="text"
+
+; -----------------------------------------------------------------------------
+;  associate '.sh' files to be run with git bash
+; -----------------------------------------------------------------------------
+
+[HKEY_CURRENT_USER\Software\Classes\.sh]
+@="sh_auto_file"
+
+[HKEY_CURRENT_USER\Software\Classes\sh_auto_file]
+@="Shell Script"
+
+[HKEY_CURRENT_USER\Software\Classes\sh_auto_file\DefaultIcon]
+@="%SystemRoot%\\System32\\shell32.dll,-153"
+
+[HKEY_CURRENT_USER\Software\Classes\sh_auto_file\shell\open\command]
+@="\"$git_root\\git-bash.exe\" --no-cd \"%L\" %*"
+
+[HKEY_CURRENT_USER\Software\Classes\sh_auto_file\ShellEx\DropHandler]
+@="{60254CA5-953B-11CF-8C96-00AA00B8708C}"

--- a/scripts/git/uninstall-context.reg
+++ b/scripts/git/uninstall-context.reg
@@ -1,0 +1,23 @@
+Windows Registry Editor Version 5.00
+
+; -----------------------------------------------------------------------------
+;  undo: context menu entry  'Git GUI Here'
+; -----------------------------------------------------------------------------
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_gui]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_gui\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_gui]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_gui\command]
+[-HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_gui]
+[-HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_gui\command]
+
+; -----------------------------------------------------------------------------
+;  undo: context menu entry  'Git Bash Here'
+; -----------------------------------------------------------------------------
+
+[-HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_shell]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\background\shell\git_shell\command]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_shell]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shell\git_shell\command]
+[-HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_shell]
+[-HKEY_CURRENT_USER\Software\Classes\LibraryFolder\background\shell\git_shell\command]

--- a/scripts/git/uninstall-file-associations.reg
+++ b/scripts/git/uninstall-file-associations.reg
@@ -1,0 +1,19 @@
+Windows Registry Editor Version 5.00
+
+; -----------------------------------------------------------------------------
+;  undo: associate .git* configuration files with the default text editor
+; -----------------------------------------------------------------------------
+
+[-HKEY_CURRENT_USER\Software\Classes\.gitattributes]
+[-HKEY_CURRENT_USER\Software\Classes\.gitignore]
+[-HKEY_CURRENT_USER\Software\Classes\.gitmodules]
+
+; -----------------------------------------------------------------------------
+;  undo: associate '.sh' files to be run with git bash
+; -----------------------------------------------------------------------------
+
+[-HKEY_CURRENT_USER\Software\Classes\.sh]
+[-HKEY_CURRENT_USER\Software\Classes\sh_auto_file]
+[-HKEY_CURRENT_USER\Software\Classes\sh_auto_file\DefaultIcon]
+[-HKEY_CURRENT_USER\Software\Classes\sh_auto_file\shell\open\command]
+[-HKEY_CURRENT_USER\Software\Classes\sh_auto_file\ShellEx\DropHandler]


### PR DESCRIPTION
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Changes:
- Adds two .reg scripts:
  1. install-context.reg adds context-menu entries for 'Git GUI Here' and 'Git Bash Here'
  2. install-file-associations.reg associates .git* files as plain-text, and associates .sh with Bash

Notes:
- Closes: #4462
- The file-naming convention and post-install script were based on the `7zip.json`, `vim.json` and `pwsh.json` manifest files.
- The registry keys set by the .reg files are identical to those set by [`install.iss`][1] in the [`git-for-windows/build-extra`][2] repo.

[1]: <https://github.com/git-for-windows/build-extra/blob/main/installer/install.iss>
[2]: <https://github.com/git-for-windows/build-extra>
