### PR TITLE
7zip@22.01: Add drag-drop context menu entries (#4539)

### DIFF
--- a/scripts/7-zip/install-context.reg
+++ b/scripts/7-zip/install-context.reg
@@ -16,6 +16,12 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Classes\Folder\shellex\ContextMenuHandlers\7-Zip]
 @="{23170F69-40C1-278A-1000-000100020000}"
 
+[HKEY_CURRENT_USER\Software\Classes\Directory\shellex\DragDropHandlers\7-Zip]
+@="{23170F69-40C1-278A-1000-000100020000}"
+
+[HKEY_CURRENT_USER\Software\Classes\Drive\shellex\DragDropHandlers\7-Zip]
+@="{23170F69-40C1-278A-1000-000100020000}"
+
 [HKEY_CURRENT_USER\SOFTWARE\7-Zip\Options]
 "MenuIcons"=dword:00000001
 "CascadedMenu"=dword:00000001

--- a/scripts/7-zip/uninstall-context.reg
+++ b/scripts/7-zip/uninstall-context.reg
@@ -5,4 +5,6 @@ Windows Registry Editor Version 5.00
 [-HKEY_CURRENT_USER\Software\Classes\*\shellex\ContextMenuHandlers\7-Zip]
 [-HKEY_CURRENT_USER\Software\Classes\Directory\shellex\ContextMenuHandlers\7-Zip]
 [-HKEY_CURRENT_USER\Software\Classes\Folder\shellex\ContextMenuHandlers\7-Zip]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shellex\DragDropHandlers\7-Zip]
+[-HKEY_CURRENT_USER\Software\Classes\Drive\shellex\DragDropHandlers\7-Zip]
 [-HKEY_CURRENT_USER\SOFTWARE\7-Zip\Options]


### PR DESCRIPTION
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Changes:
- Adds registry keys required to add 7zip to the drag and drop context menu

Notes:
- Closes #4539
