### PR TITLE
(chore): add gpg2 alias for gpg and gnupg

### DIFF
--- a/bucket/gnupg.json
+++ b/bucket/gnupg.json
@@ -10,6 +10,7 @@
         "script": [
             "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\gnupg-uninstall.exe.nsis\" -Force -Recurse",
             "New-Item \"$dir\\bin\\gpgconf.ctl\" -Force | Out-Null",
+            "Copy-Item \"$dir\\bin\\gpg.exe\" \"$dir\\bin\\gpg2.exe\"",
             "if (!(Test-Path \"$persist_dir\\home\") -and (Test-Path \"$env:Appdata\\gnupg\")) {",
             "    Write-Host -F yellow \"Copying old '$env:Appdata\\gnupg' to '$persist_dir\\home'\"",
             "    New-Item \"$dir\\home\" -ItemType Directory -Force | Out-Null",

--- a/bucket/gpg.json
+++ b/bucket/gpg.json
@@ -10,6 +10,7 @@
         "script": [
             "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\gnupg-uninstall.exe.nsis\" -Force -Recurse",
             "New-Item \"$dir\\bin\\gpgconf.ctl\" -Force | Out-Null",
+            "Copy-Item \"$dir\\bin\\gpg.exe\" \"$dir\\bin\\gpg2.exe\"",
             "if (!(Test-Path \"$persist_dir\\home\") -and (Test-Path \"$env:Appdata\\gnupg\")) {",
             "    Write-Host -F yellow \"Copying old '$env:Appdata\\gnupg' to '$persist_dir\\home'\"",
             "    New-Item \"$dir\\home\" -ItemType Directory -Force | Out-Null",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Adds an alias for `gpg2` in the `gpg` and `gnupg` apps by copying the binary `gpg.exe` into `gpg2.exe` in the install script.
`"Copy-Item \"$dir\\bin\\gpg.exe\" \"$dir\\bin\\gpg2.exe\""`

Closes #4548 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
