### PR TITLE
resvg: Update to version 0.29.0

### DIFF
--- a/bucket/resvg.json
+++ b/bucket/resvg.json
@@ -5,20 +5,11 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://github.com/RazrFalcon/resvg/releases/download/v0.29.0/resvg-win64.zip",
-                "https://github.com/RazrFalcon/resvg/releases/download/v0.27.0/usvg-win64.zip"
-            ],
-            "hash": [
-                "19a4cb037591692559bca22f32e3bf859ffe9886a7429f4936600f8120b0c77b",
-                "fc30023106bc846ba43713a620b638a04cae761a9fa899b7bd31f4ef9236b96d"
-            ]
+            "url": "https://github.com/RazrFalcon/resvg/releases/download/v0.29.0/resvg-win64.zip",
+            "hash": "19a4cb037591692559bca22f32e3bf859ffe9886a7429f4936600f8120b0c77b"
         }
     },
-    "bin": [
-        "resvg.exe",
-        "usvg.exe"
-    ],
+    "bin": "resvg.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/resvg.json
+++ b/bucket/resvg.json
@@ -24,8 +24,7 @@
         "architecture": {
             "64bit": {
                 "url": [
-                    "https://github.com/RazrFalcon/resvg/releases/download/v$version/resvg-win64.zip",
-                    "https://github.com/RazrFalcon/resvg/releases/download/v$version/usvg-win64.zip"
+                    "https://github.com/RazrFalcon/resvg/releases/download/v$version/resvg-win64.zip"
                 ]
             }
         }

--- a/bucket/resvg.json
+++ b/bucket/resvg.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.27.0",
+    "version": "0.29.0",
     "description": "An SVG rendering library.",
     "homepage": "https://github.com/RazrFalcon/resvg",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/RazrFalcon/resvg/releases/download/v0.27.0/resvg-win64.zip",
+                "https://github.com/RazrFalcon/resvg/releases/download/v0.29.0/resvg-win64.zip",
                 "https://github.com/RazrFalcon/resvg/releases/download/v0.27.0/usvg-win64.zip"
             ],
             "hash": [
-                "2158e8dc480db99bd907e930ae5d98fbb0a0745113380c07843065f4b9f2c469",
+                "19a4cb037591692559bca22f32e3bf859ffe9886a7429f4936600f8120b0c77b",
                 "fc30023106bc846ba43713a620b638a04cae761a9fa899b7bd31f4ef9236b96d"
             ]
         }
@@ -23,9 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": [
-                    "https://github.com/RazrFalcon/resvg/releases/download/v$version/resvg-win64.zip"
-                ]
+                "url": "https://github.com/RazrFalcon/resvg/releases/download/v$version/resvg-win64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Removed usvg from autoupdate as it's no longer provided in releases:
https://github.com/RazrFalcon/resvg/blob/master/CHANGELOG.md#0280---2022-12-03
>Removed
>  - usvg CLI binary. No alternatives for now.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
