### PR TITLE
xxcopy: Use archived links

### DIFF
--- a/bucket/xxcopy.json
+++ b/bucket/xxcopy.json
@@ -1,12 +1,12 @@
 {
     "version": "3.33.3",
     "description": "A versatile file management tool for Microsoft Windows®.",
-    "homepage": "http://www.xxcopy.com",
+    "homepage": "https://web.archive.org/web/20220619093459/http://www.xxcopy.com/",
     "license": {
         "identifier": "Freeware",
-        "url": "http://www.xxcopy.com/xxtb_092.htm"
+        "url": "https://web.archive.org/web/20211021210622/http://xxcopy.com/xxtb_092.htm"
     },
-    "url": "http://www.xxcopy.com/download/xxfw3333.zip",
+    "url": "https://web.archive.org/web/20210710023145if_/http://xxcopy.com/download/xxfw3333.zip",
     "hash": "d5fd9d2446a0d54b564c864310b481c9e160ee487f305af67f584eff5b6bd767",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
`xxcopy.com` appears to be a dead domain, so I switched all links to the Internet Archive. (I'm unsure if I should be adding it to https://github.com/ScoopInstaller/Binary instead)
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
