### PR TITLE
go: Add `GOROOT` env variable

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -38,6 +38,9 @@
         "bin\\go.exe",
         "bin\\gofmt.exe"
     ],
+    "env_set": {
+        "GOROOT": "$dir"
+    },
     "checkver": {
         "url": "https://golang.org/dl/",
         "regex": "go([\\d.]+)\\.windows-"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

goland cannot detect GOROOT's path without this variable.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
