### PR TITLE
typst: Add version 22-03-21-2

### DIFF
--- a/bucket/typst.json
+++ b/bucket/typst.json
@@ -1,0 +1,15 @@
+{
+  "extract_dir": "typst-x86_64-pc-windows-msvc",
+  "url": "https://github.com/typst/typst/releases/download/22-03-21/typst-x86_64-pc-windows-msvc.zip",
+  "bin": "typst.exe",
+  "license": "Apache-2.0",
+  "hash": "7a8daa7afcc300198d364221b768bbac797b7409420d054688337ea192baccbd",
+  "version": "22-03-21",
+  "description": "A markup-based typesetting system for the sciences."
+  "homepage": "https://typst.app",
+  "autoupdate": "https://github.com/typst/typst/releases/download/$version/typst-x86_64-pc-windows-msvc.zip",
+  "checkver": {
+    "github": "https://github.com/typst/typst",
+    "regex": "tag/([\\d.-)"
+  }
+}

--- a/bucket/typst.json
+++ b/bucket/typst.json
@@ -7,24 +7,17 @@
         "64bit": {
             "url": "https://github.com/typst/typst/releases/download/22-03-21-2/typst-x86_64-pc-windows-msvc.zip",
             "hash": "b78907ccc296fb18ac9a4dbe36273e50e2ec69efdc3d1abdda91aa7f6c4f00b1"
-        },
-        "32bit": {
-            "url": "https://github.com/typst/typst/releases/download/22-03-21-2/typst-x86_64-pc-windows-msvc.zip",
-            "hash": "b78907ccc296fb18ac9a4dbe36273e50e2ec69efdc3d1abdda91aa7f6c4f00b1"
         }
     },
     "extract_dir": "typst-x86_64-pc-windows-msvc",
     "bin": "typst.exe",
     "checkver": {
-        "github": "https://github.com/typst/typst",
+        "url": "https://github.com/typst/typst/releases",
         "regex": "tag/([\\d.-]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/typst/typst/releases/download/$version/typst-x86_64-pc-windows-msvc.zip"
-            },
-            "32bit": {
                 "url": "https://github.com/typst/typst/releases/download/$version/typst-x86_64-pc-windows-msvc.zip"
             }
         }

--- a/bucket/typst.json
+++ b/bucket/typst.json
@@ -1,23 +1,23 @@
 {
-    "version": "22-03-21",
+    "version": "22-03-21-2",
     "description": "A markup-based typesetting system for the sciences.",
     "homepage": "https://typst.app",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/typst/typst/releases/download/22-03-21/typst-x86_64-pc-windows-msvc.zip",
-            "hash": "7a8daa7afcc300198d364221b768bbac797b7409420d054688337ea192baccbd",
+            "url": "https://github.com/typst/typst/releases/download/22-03-21-2/typst-x86_64-pc-windows-msvc.zip",
+            "hash": "b78907ccc296fb18ac9a4dbe36273e50e2ec69efdc3d1abdda91aa7f6c4f00b1"
         },
         "32bit": {
-            "url": "https://github.com/typst/typst/releases/download/22-03-21/typst-x86_64-pc-windows-msvc.zip",
-            "hash": "7a8daa7afcc300198d364221b768bbac797b7409420d054688337ea192baccbd",
+            "url": "https://github.com/typst/typst/releases/download/22-03-21-2/typst-x86_64-pc-windows-msvc.zip",
+            "hash": "b78907ccc296fb18ac9a4dbe36273e50e2ec69efdc3d1abdda91aa7f6c4f00b1"
         }
     },
     "extract_dir": "typst-x86_64-pc-windows-msvc",
     "bin": "typst.exe",
     "checkver": {
         "github": "https://github.com/typst/typst",
-        "regex": "tag/([\\d.-)"
+        "regex": "tag/([\\d.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/typst.json
+++ b/bucket/typst.json
@@ -1,15 +1,32 @@
 {
-  "extract_dir": "typst-x86_64-pc-windows-msvc",
-  "url": "https://github.com/typst/typst/releases/download/22-03-21/typst-x86_64-pc-windows-msvc.zip",
-  "bin": "typst.exe",
-  "license": "Apache-2.0",
-  "hash": "7a8daa7afcc300198d364221b768bbac797b7409420d054688337ea192baccbd",
-  "version": "22-03-21",
-  "description": "A markup-based typesetting system for the sciences."
-  "homepage": "https://typst.app",
-  "autoupdate": "https://github.com/typst/typst/releases/download/$version/typst-x86_64-pc-windows-msvc.zip",
-  "checkver": {
-    "github": "https://github.com/typst/typst",
-    "regex": "tag/([\\d.-)"
-  }
+    "version": "22-03-21",
+    "description": "A markup-based typesetting system for the sciences.",
+    "homepage": "https://typst.app",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/typst/typst/releases/download/22-03-21/typst-x86_64-pc-windows-msvc.zip",
+            "hash": "7a8daa7afcc300198d364221b768bbac797b7409420d054688337ea192baccbd",
+        },
+        "32bit": {
+            "url": "https://github.com/typst/typst/releases/download/22-03-21/typst-x86_64-pc-windows-msvc.zip",
+            "hash": "7a8daa7afcc300198d364221b768bbac797b7409420d054688337ea192baccbd",
+        }
+    },
+    "extract_dir": "typst-x86_64-pc-windows-msvc",
+    "bin": "typst.exe",
+    "checkver": {
+        "github": "https://github.com/typst/typst",
+        "regex": "tag/([\\d.-)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/typst/typst/releases/download/$version/typst-x86_64-pc-windows-msvc.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/typst/typst/releases/download/$version/typst-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds typst, a markup-based typesetter that was open-sourced on March 21, 2023.  
See https://typst.app

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
