### PR TITLE
gnuplot: One-time URL update for v5.4.6

### DIFF
--- a/bucket/gnuplot.json
+++ b/bucket/gnuplot.json
@@ -5,8 +5,8 @@
     "license": "gnuplot",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.4.6/gp546-win64-mingw.7z",
-            "hash": "sha1:e7005ff7ca886fb53238a2b95ae96fb72e35e513"
+            "url": "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.4.6/gp546-win64-mingw-2.7z",
+            "hash": "sha1:9d1208cd236d5f8dcac646792765bb73312f7c74"
         }
     },
     "extract_dir": "gnuplot",


### PR DESCRIPTION
Gnuplot 5.4.6 released some bugfix version with "-2" appended to 7z file name. There is no good way to construct the filename for the "autoupdate" feature, so I left it as-is. The filename will most likely go back to its original naming scheme with the next release.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #4586

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
