### PR TITLE
gsudo: Fix for artifact renamed on v2.0.6, added arm64.

### DIFF
--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -26,7 +26,6 @@
         }
     },
     "bin": [
-        "gsudo.exe",
         [
             "gsudo.exe",
             "sudo"
@@ -36,6 +35,7 @@
         "name": "gsudoModule"
     },
     "post_install": "try { & \"$dir\\gsudo.exe\" -k 2>&1 | Out-Null } catch { info $_.Exception.Message }",
+    "env_add_path": ".",    
     "checkver": {
         "github": "https://github.com/gerardog/gsudo"
     },

--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/gerardog/gsudo",
     "license": "MIT",
     "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.portable.zip",
-    "hash": "58D88626241C6D3B27F9B060DD99B0CDCD9628ACA8B984066B103FA45A3AB4AD",
+    "hash": "9503E2C59DC4BB9AAD8198D2D8F1A6B0F4115220D92A3A68C454434309BDEC23",
     "architecture": {
         "64bit": {
             "extract_dir": "x64"

--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -1,16 +1,19 @@
 {
-    "version": "2.0.4",
+    "version": "2.0.6",
     "description": "A Sudo for Windows",
     "homepage": "https://github.com/gerardog/gsudo",
     "license": "MIT",
-    "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.4/gsudo.v2.0.4.zip",
-    "hash": "0596a670ae0d3f28ae3ce6b695d47db02096ff4b34fd89d4e6519a1d6df40078",
+    "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.portable.zip",
+    "hash": "58D88626241C6D3B27F9B060DD99B0CDCD9628ACA8B984066B103FA45A3AB4AD",
     "architecture": {
         "64bit": {
             "extract_dir": "x64"
         },
         "32bit": {
             "extract_dir": "x86"
+        },
+        "arm64": {
+            "extract_dir": "arm64"
         }
     },
     "bin": [
@@ -23,6 +26,6 @@
     "env_add_path": ".",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.v$version.zip"
+        "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.portable.zip"
     }
 }

--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -35,7 +35,7 @@
         "name": "gsudoModule"
     },
     "post_install": "try { & \"$dir\\gsudo.exe\" -k 2>&1 | Out-Null } catch { info $_.Exception.Message }",
-    "env_add_path": ".",    
+    "env_add_path": ".",
     "checkver": {
         "github": "https://github.com/gerardog/gsudo"
     },

--- a/bucket/gsudo.json
+++ b/bucket/gsudo.json
@@ -1,31 +1,61 @@
 {
     "version": "2.0.6",
     "description": "A Sudo for Windows",
-    "homepage": "https://github.com/gerardog/gsudo",
+    "homepage": "https://gerardog.github.io/gsudo",
     "license": "MIT",
-    "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.portable.zip",
-    "hash": "9503E2C59DC4BB9AAD8198D2D8F1A6B0F4115220D92A3A68C454434309BDEC23",
+    "notes": [
+        "gsudo has a PowerShell module that adds `gsudo !!` to elevate the last command.",
+        "Use the module by running: 'Import-Module gsudoModule'.",
+        "Add it to your $PROFILE to make it permanent."
+    ],
     "architecture": {
         "64bit": {
-            "extract_dir": "x64"
+            "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.setup.x64.msi",
+            "hash": "739423cf03b6c2b5f96ca74e82b0286652f72fe95b989f91e1952fb620cf77f6",
+            "extract_dir": "PFiles64\\gsudo\\2.0.6"
         },
         "32bit": {
-            "extract_dir": "x86"
+            "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.setup.x86.msi",
+            "hash": "8ec7eef5881e4a1414192b9d40a7572a11898adda92b7d95c5aba5a9628aecb3",
+            "extract_dir": "PFiles\\gsudo\\2.0.6"
         },
         "arm64": {
-            "extract_dir": "arm64"
+            "url": "https://github.com/gerardog/gsudo/releases/download/v2.0.6/gsudo.setup.arm64.msi",
+            "hash": "a9bf868557ac2d7c4fa90302c379c87c78c1a3e014308670c919097a0601854e",
+            "extract_dir": "PFiles64\\gsudo\\2.0.6"
         }
     },
     "bin": [
+        "gsudo.exe",
         [
             "gsudo.exe",
             "sudo"
         ]
     ],
+    "psmodule": {
+        "name": "gsudoModule"
+    },
     "post_install": "try { & \"$dir\\gsudo.exe\" -k 2>&1 | Out-Null } catch { info $_.Exception.Message }",
-    "env_add_path": ".",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/gerardog/gsudo"
+    },
     "autoupdate": {
-        "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.portable.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.setup.x64.msi",
+                "extract_dir": "PFiles64\\gsudo\\$version"
+            },
+            "32bit": {
+                "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.setup.x86.msi",
+                "extract_dir": "PFiles\\gsudo\\$version"
+            },
+            "arm64": {
+                "url": "https://github.com/gerardog/gsudo/releases/download/v$version/gsudo.setup.arm64.msi",
+                "extract_dir": "PFiles64\\gsudo\\$version"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

gsudo v2.0.6 has arm64 binaries and the artifact was renamed, so this fix is needed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
