### PR TITLE
syncthing@1.23.2: Link to actual docs

### DIFF
--- a/bucket/syncthing.json
+++ b/bucket/syncthing.json
@@ -3,7 +3,7 @@
     "description": "Open Source Continuous File Synchronization.",
     "homepage": "https://syncthing.net/",
     "license": "MPL-2.0",
-    "notes": "To start syncthing automatically, use a method described at https://github.com/syncthing/docs/blob/main/users/autostart.rst#windows",
+    "notes": "To start syncthing automatically, use a method described at https://docs.syncthing.net/users/autostart.html#windows",
     "architecture": {
         "64bit": {
             "url": "https://github.com/syncthing/syncthing/releases/download/v1.23.2/syncthing-windows-amd64-v1.23.2.zip",


### PR DESCRIPTION
Syncthing's notes links to their docs website instead of their GitHub template, which is parsed incorrectly.

Closes #4607 

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
