### PR TITLE
edgedriver: Use stable version

### DIFF
--- a/bucket/edgedriver.json
+++ b/bucket/edgedriver.json
@@ -19,7 +19,7 @@
     },
     "bin": "msedgedriver.exe",
     "checkver": {
-        "script": "Write-Output $([System.Text.Encoding]::Unicode.GetString((Invoke-WebRequest -URI https://msedgedriver.azureedge.net/LATEST_CANARY).Content))",
+        "script": "Write-Output $([System.Text.Encoding]::Unicode.GetString((Invoke-WebRequest -URI https://msedgedriver.azureedge.net/LATEST_STABLE).Content))",
         "regex": "([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/edgedriver.json
+++ b/bucket/edgedriver.json
@@ -1,5 +1,5 @@
 {
-    "version": "111.0.1661.54",
+    "version": "111.0.1661.62",
     "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
     "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
     "license": {
@@ -9,16 +9,16 @@
     "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
     "architecture": {
         "64bit": {
-            "url": "https://msedgedriver.azureedge.net/111.0.1661.54/edgedriver_win64.zip",
-            "hash": "97bd1acfeb5595218db4694fbbd48605b9112ea191dab499f4ba3a4b258d9d23"
+            "url": "https://msedgedriver.azureedge.net/111.0.1661.62/edgedriver_win64.zip",
+            "hash": "7edcc7f55859a503674ea5f024e715e8ca26fa11d65444d2554cd87cfca1c3a6"
         },
         "32bit": {
-            "url": "https://msedgedriver.azureedge.net/111.0.1661.54/edgedriver_win32.zip",
-            "hash": "a521f161fc14b417fba89d1c85fa30f84a8bc42e59233356d166293147270cf2"
+            "url": "https://msedgedriver.azureedge.net/111.0.1661.62/edgedriver_win32.zip",
+            "hash": "153915913a0c7e456aeb412b36f87deff46af8de2de58272c6cb4293161dbe2d"
         },
         "arm64": {
-            "url": "https://msedgedriver.azureedge.net/111.0.1661.54/edgedriver_arm64.zip",
-            "hash": "bd75b4a1a35e03bad87d34b0adf1e141245a5372ad144388042cd0804724586b"
+            "url": "https://msedgedriver.azureedge.net/111.0.1661.62/edgedriver_arm64.zip",
+            "hash": "b64626b307620f822d60c54b23499a735550ba598771fcca430b2a6f0c41a79d"
         }
     },
     "bin": "msedgedriver.exe",

--- a/bucket/edgedriver.json
+++ b/bucket/edgedriver.json
@@ -1,5 +1,5 @@
 {
-    "version": "113.0.1773.0",
+    "version": "111.0.1661.54",
     "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
     "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
     "license": {
@@ -9,12 +9,16 @@
     "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
     "architecture": {
         "64bit": {
-            "url": "https://msedgedriver.azureedge.net/113.0.1773.0/edgedriver_win64.zip",
-            "hash": "d92f07f0ac307b064e0e4fdc6c93cbecc6c36d69410d03050f055b46766f57ba"
+            "url": "https://msedgedriver.azureedge.net/111.0.1661.54/edgedriver_win64.zip",
+            "hash": "97bd1acfeb5595218db4694fbbd48605b9112ea191dab499f4ba3a4b258d9d23"
         },
         "32bit": {
-            "url": "https://msedgedriver.azureedge.net/113.0.1773.0/edgedriver_win32.zip",
-            "hash": "b1089c29f337cd5501650d5373e9c62b339ba5b69daddffee1f0ee3d0580cf53"
+            "url": "https://msedgedriver.azureedge.net/111.0.1661.54/edgedriver_win32.zip",
+            "hash": "a521f161fc14b417fba89d1c85fa30f84a8bc42e59233356d166293147270cf2"
+        },
+        "arm64": {
+            "url": "https://msedgedriver.azureedge.net/111.0.1661.54/edgedriver_arm64.zip",
+            "hash": "bd75b4a1a35e03bad87d34b0adf1e141245a5372ad144388042cd0804724586b"
         }
     },
     "bin": "msedgedriver.exe",

--- a/bucket/edgedriver.json
+++ b/bucket/edgedriver.json
@@ -29,6 +29,9 @@
             },
             "32bit": {
                 "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+            },
+            "arm64": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_arm64.zip"
             }
         }
     }

--- a/bucket/edgedriver.json
+++ b/bucket/edgedriver.json
@@ -4,7 +4,7 @@
     "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
     "license": {
         "identifier": "Freeware",
-        "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+        "url": "https://msedgedriver.azureedge.net/EULA"
     },
     "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
I noticed checkver was getting the latest canary version instead of stable.
Also added the ARM64 variant and fixed the license link.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
