### PR TITLE
zstd: Specify `extract_dir`

### DIFF
--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-v1.5.5-win64.zip",
-            "hash": "1ab47163dd8ea8c3ef35311ba77808870347e2f0e3e50acd4e99a21c0d87da2c"
+            "hash": "1ab47163dd8ea8c3ef35311ba77808870347e2f0e3e50acd4e99a21c0d87da2c",
+            "extract_dir": "zstd-v1.5.5-win64"
         }
     },
     "bin": "zstd.exe",
@@ -16,7 +17,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip",
+                "extract_dir": "zstd-v$version-win64"
             }
         }
     }


### PR DESCRIPTION
The internal directory organization of the .zip file has changed since v1.5.5.

- Closes #4630.
- Closes #4631.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
