### PR TITLE
qemu: Update to version 8.0.0-rc2

### DIFF
--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -7,10 +7,6 @@
         "64bit": {
             "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-20221230.exe#/dl.7z_",
             "hash": "sha512:1a8c1764359bad713b3a0b306603adce42e12974d461140fa6378b5cf0a095bd57a4abf986de4210cc431d80e9d5af785b25e571040a2a0efd1ec3dd441a8193"
-        },
-        "32bit": {
-            "url": "https://qemu.weilnetz.de/w32/qemu-w32-setup-20221230.exe#/dl.7z_",
-            "hash": "sha512:e8380fc1f44264a25a6591cee881842220106c7ceee9087dd229dc56fed1415e79afebfdbf243c71853c4b2a946d2591707f06bed429eda21e31a4d9ed7b62ab"
         }
     },
     "pre_install": "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\" -Removal -Switches '-xr!*.exe.nsis -x!$PLUGINSDIR'",
@@ -20,9 +16,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-$matchYear$matchMonth$matchDay.exe#/dl.7z_"
-            },
-            "32bit": {
-                "url": "https://qemu.weilnetz.de/w32/qemu-w32-setup-$matchYear$matchMonth$matchDay.exe#/dl.7z_"
             }
         },
         "hash": {

--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -1,12 +1,12 @@
 {
-    "version": "8.0.0-rc2",
+    "version": "8.0.0-rc3",
     "description": "A generic and open source machine emulator and virtualizer.",
     "homepage": "https://qemu.weilnetz.de/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-20230410.exe#/dl.7z_",
-            "hash": "sha512:eea6aafdbbcb9411ae04c2f804c701b280dbb79dd30d3dff9a1ab77c2789bb1afc2a46f1e6a459de7c8fbdc28221db1ec7a12c03e5548cefb2f3be6dbbee00ae"
+            "url": "https://qemu.weilnetz.de/w64/2023/qemu-w64-setup-20230411.exe#/dl.7z_",
+            "hash": "sha512:93ed66c0af85956a46e8dbb1fe43b7877139fda9ee6446b428dae786aa12b37a5a36160e64ba605fc29bc3e3a3c570180516389c8fdb7a0c5d8f8dd18e326bb8"
         }
     },
     "pre_install": "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\" -Removal -Switches '-xr!*.exe.nsis -x!$PLUGINSDIR'",

--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -11,7 +11,7 @@
     },
     "pre_install": "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\" -Removal -Switches '-xr!*.exe.nsis -x!$PLUGINSDIR'",
     "env_add_path": ".",
-    "checkver": "<strong>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})</strong>: New QEMU installers \\((?<version>[\\d.a-z-]+)\\)",
+    "checkver": "<strong>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})</strong>: New QEMU installer \\((?<version>[\\d.a-z-]+)\\)",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -15,7 +15,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-$matchYear$matchMonth$matchDay.exe#/dl.7z_"
+                "url": "https://qemu.weilnetz.de/w64/$matchYear/qemu-w64-setup-$matchYear$matchMonth$matchDay.exe#/dl.7z_"
             }
         },
         "hash": {

--- a/bucket/qemu.json
+++ b/bucket/qemu.json
@@ -1,12 +1,12 @@
 {
-    "version": "7.2.0",
+    "version": "8.0.0-rc2",
     "description": "A generic and open source machine emulator and virtualizer.",
     "homepage": "https://qemu.weilnetz.de/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-20221230.exe#/dl.7z_",
-            "hash": "sha512:1a8c1764359bad713b3a0b306603adce42e12974d461140fa6378b5cf0a095bd57a4abf986de4210cc431d80e9d5af785b25e571040a2a0efd1ec3dd441a8193"
+            "url": "https://qemu.weilnetz.de/w64/qemu-w64-setup-20230410.exe#/dl.7z_",
+            "hash": "sha512:eea6aafdbbcb9411ae04c2f804c701b280dbb79dd30d3dff9a1ab77c2789bb1afc2a46f1e6a459de7c8fbdc28221db1ec7a12c03e5548cefb2f3be6dbbee00ae"
         }
     },
     "pre_install": "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\" -Removal -Switches '-xr!*.exe.nsis -x!$PLUGINSDIR'",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
32-bit builds were dropped which broke autoupdate: https://qemu.weilnetz.de/
>2023-04-07: New QEMU installers (8.0.0-rc0). Build only 64 bit installer.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #4649

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
