### PR TITLE
cppcryptfsctl: Add version 1.4.4.1

### DIFF
--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -1,6 +1,7 @@
 {
     "version": "1.4.4.1",
     "license": "MIT",
+	"description": "cppcryptfs is an implementation of the gocryptfs encrypted overlay filesystem in C++ for Windows.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl.exe",

--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -4,14 +4,32 @@
     "description": "cppcryptfs is an implementation of the gocryptfs encrypted overlay filesystem in C++ for Windows.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl.exe",
-            "hash": "30141acf45b5fdbb30208465f3f629d45467211f22950cc3e260e6d61ea02b89",
-            "bin": "cppcryptfsctl.exe"
+            "url": [
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl.exe",
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfs.exe"
+            ],
+            "hash": [
+                "30141acf45b5fdbb30208465f3f629d45467211f22950cc3e260e6d61ea02b89",
+                "2f4af3b75b7341acaec1c4d5b156a1c2e9eb071e0f3d5fc0bae28f336c48fe3a"
+            ],
+            "bin": [
+                "cppcryptfsctl.exe",
+                "cppcryptfs.exe"
+            ]
         },
         "32bit": {
-            "url": "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl32.exe",
-            "hash": "bcd10379d362c15ca78050ca43ef7ce4dd676be349125b0f50b26a0619a4f12a",
-            "bin": "cppcryptfsctl32.exe"
+            "url": [
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl32.exe",
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfs32.exe"
+            ],
+            "hash": [
+                "bcd10379d362c15ca78050ca43ef7ce4dd676be349125b0f50b26a0619a4f12a",
+                "f561c474572ceca71373dd94af80881e09e94f37e50d257f5f0d348d59f97484"
+            ],
+            "bin": [
+                "cppcryptfsctl32.exe",
+                "cppcryptfs32.exe"
+            ]
         }
     },
     "homepage": "https://github.com/bailey27/cppcryptfs",

--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -19,16 +19,16 @@
         },
         "32bit": {
             "url": [
-                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl32.exe",
-                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfs32.exe"
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl32.exe#/cppcryptfsctl.exe",
+                "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfs32.exe#/cppcryptfs.exe"
             ],
             "hash": [
                 "bcd10379d362c15ca78050ca43ef7ce4dd676be349125b0f50b26a0619a4f12a",
                 "f561c474572ceca71373dd94af80881e09e94f37e50d257f5f0d348d59f97484"
             ],
             "bin": [
-                "cppcryptfsctl32.exe",
-                "cppcryptfs32.exe"
+                "cppcryptfsctl.exe",
+                "cppcryptfs.exe"
             ]
         }
     },

--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.4.4.1",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl.exe",
+            "hash": "30141acf45b5fdbb30208465f3f629d45467211f22950cc3e260e6d61ea02b89",
+            "bin": "cppcryptfsctl.exe"
+        },
+        "32bit": {
+            "url": "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl32.exe",
+            "hash": "bcd10379d362c15ca78050ca43ef7ce4dd676be349125b0f50b26a0619a4f12a",
+            "bin": "cppcryptfsctl32.exe"
+        }
+    },
+    "homepage": "https://github.com/bailey27/cppcryptfs",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl32.exe"
+            }
+        }
+    }
+}

--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -40,8 +40,8 @@
             },
             "32bit": {
                 "url": [
-                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl32.exe",
-                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfs32.exe"
+                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl32.exe#/cppcryptfsctl.exe",
+                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfs32.exe#/cppcryptfs.exe"
                 ]
             }
         }

--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -11,10 +11,6 @@
             "hash": [
                 "30141acf45b5fdbb30208465f3f629d45467211f22950cc3e260e6d61ea02b89",
                 "2f4af3b75b7341acaec1c4d5b156a1c2e9eb071e0f3d5fc0bae28f336c48fe3a"
-            ],
-            "bin": [
-                "cppcryptfsctl.exe",
-                "cppcryptfs.exe"
             ]
         },
         "32bit": {
@@ -25,22 +21,28 @@
             "hash": [
                 "bcd10379d362c15ca78050ca43ef7ce4dd676be349125b0f50b26a0619a4f12a",
                 "f561c474572ceca71373dd94af80881e09e94f37e50d257f5f0d348d59f97484"
-            ],
-            "bin": [
-                "cppcryptfsctl.exe",
-                "cppcryptfs.exe"
             ]
         }
     },
+    "bin": [
+        "cppcryptfsctl.exe",
+        "cppcryptfs.exe"
+    ],
     "homepage": "https://github.com/bailey27/cppcryptfs",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl.exe"
+                "url": [
+                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl.exe",
+                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfs.exe"
+                ]
             },
             "32bit": {
-                "url": "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl32.exe"
+                "url": [
+                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfsctl32.exe",
+                    "https://github.com/bailey27/cppcryptfs/releases/download/$version/cppcryptfs32.exe"
+                ]
             }
         }
     }

--- a/bucket/cppcryptfsctl.json
+++ b/bucket/cppcryptfsctl.json
@@ -1,7 +1,7 @@
 {
     "version": "1.4.4.1",
     "license": "MIT",
-	"description": "cppcryptfs is an implementation of the gocryptfs encrypted overlay filesystem in C++ for Windows.",
+    "description": "cppcryptfs is an implementation of the gocryptfs encrypted overlay filesystem in C++ for Windows.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/bailey27/cppcryptfs/releases/download/1.4.4.1/cppcryptfsctl.exe",


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Adding this to Main since it is recommended by gocryptfs