### PR TITLE
xxcopy: Use ScoopInstaller/Binary

### DIFF
--- a/bucket/xxcopy.json
+++ b/bucket/xxcopy.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://web.archive.org/web/20211021210622/http://xxcopy.com/xxtb_092.htm"
     },
-    "url": "https://web.archive.org/web/20210710023145if_/http://xxcopy.com/download/xxfw3333.zip",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/xxcopy/xxfw3333.zip",
     "hash": "d5fd9d2446a0d54b564c864310b481c9e160ee487f305af67f584eff5b6bd767",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Avoids the use of the internet archive for the binary url.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Binary/pull/18

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
