### PR TITLE
Update kotlin-native.json

### DIFF
--- a/bucket/kotlin-native.json
+++ b/bucket/kotlin-native.json
@@ -26,7 +26,7 @@
         "bin\\jsinterop.bat",
         "bin\\klib.bat",
         "bin\\konanc.bat",
-        "bin\\kotlinc.bat",
+        "bin\\generate-platform.bat",
         "bin\\kotlinc-native.bat",
         "bin\\run_konan.bat"
     ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
`Can't shim 'bin\kotlinc.bat': File doesn't exist` occurs when installing kotlin-native@1.8.20 on Windows.
There is no `bin\kotlinc.bat` in the unzipped  fold. Instead, there is `bin\generate-platform.bat`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
