### PR TITLE
adb: Fix homepage

### DIFF
--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -1,10 +1,10 @@
 {
     "version": "34.0.1",
     "description": "Android SDK platform-tools includes tools that interface with the Android platform, such as adb and fastboot",
-    "homepage": "https://developer.android.com/studio/releases/platform-tools.html",
+    "homepage": "https://developer.android.com/studio/releases/platform-tools",
     "license": {
         "identifier": "Freeware",
-        "url": "https://developer.android.com/studio/releases/platform-tools.html#downloads"
+        "url": "https://developer.android.com/studio/releases/platform-tools#downloads"
     },
     "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-windows.zip",
     "hash": "5dd9c2be744c224fa3a7cbe30ba02d2cb378c763bd0f797a7e47e9f3156a5daa",


### PR DESCRIPTION
Relates to https://repology.org/repository/scoop/problems

Homepage link https://developer.android.com/studio/releases/platform-tools.html is [dead](https://repology.org/link/https://developer.android.com/studio/releases/platform-tools.html) (HTTP 404) for more than a month and should be replaced by alive link (see other packages for hints, or link to [archive.org](https://archive.org/) as a last resort).

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
