### PR TITLE
nodejs: Add arm64 architecture

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -13,6 +13,11 @@
             "url": "https://nodejs.org/dist/v20.0.0/node-v20.0.0-win-x86.7z",
             "hash": "a147b247e19e1324d8f7edef6c1ae4e24e5bdad9867843a2b4b491a0f3d73dd5",
             "extract_dir": "node-v20.0.0-win-x86"
+        },
+        "arm64": {
+            "url": "https://nodejs.org/dist/v20.0.0/node-v20.0.0-win-arm64.7z",
+            "hash": "d3a68cd41eeb773e20a3033e5b1502844fd392818cb64a6cd5febf3193136ad6",
+            "extract_dir": "node-v20.0.0-win-arm64"
         }
     },
     "persist": [
@@ -40,6 +45,10 @@
             "32bit": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
                 "extract_dir": "node-v$version-win-x86"
+            },
+            "arm64": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",
+                "extract_dir": "node-v$version-win-arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
From the latest release: https://github.com/nodejs/node/releases/tag/v20.0.0

>Official support for ARM64 Windows
>
>Node.js now includes binaries for ARM64 Windows, allowing for native execution on the platform.
>The MSI, zip/7z packages, and executable are available from the Node.js download site along with all other platforms.
>The CI system was updated and all changes are now fully tested on ARM64 Windows, to prevent regressions and ensure compatibility.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
