### PR TITLE
certigo: add version 1.16.0

### DIFF
--- a/bucket/certigo.json
+++ b/bucket/certigo.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.16.0",
+    "description": "A utility to examine and validate certificates in a variety of formats.",
+    "homepage": "https://github.com/square/certigo",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/square/certigo/releases/download/v1.16.0/certigo-windows-amd64#/certigo.exe",
+            "hash": "5137cb276f64280d38fccb29ff8d359c16a9e720292e546f5abcb8b6561194aa"
+        }
+    },
+    "bin": "certigo.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/square/certigo/releases/download/v$version/certigo-windows-amd64#/certigo.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Extras/pull/10916

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
