### PR TITLE
cmake: Add arm64 architecture

### DIFF
--- a/bucket/cmake.json
+++ b/bucket/cmake.json
@@ -13,6 +13,11 @@
             "url": "https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-windows-i386.zip",
             "hash": "073ebce128b05716ed07dfa1d62448302c1355013ef4b5e17c3535a2821c4cbc",
             "extract_dir": "cmake-3.26.3-windows-i386"
+        },
+        "arm64": {
+            "url": "https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-windows-arm64.zip",
+            "hash": "fd1d908ea54a081a092bc7f9dad0a6ba90fc5aa2644ee5cef901e3f925fce3d8",
+            "extract_dir": "cmake-3.26.3-windows-arm64"
         }
     },
     "bin": [
@@ -41,6 +46,10 @@
             "32bit": {
                 "url": "https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version-windows-i386.zip",
                 "extract_dir": "cmake-$version-windows-i386"
+            },
+            "arm64": {
+                "url": "https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version-windows-arm64.zip",
+                "extract_dir": "cmake-$version-windows-arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Binaries were added in version 3.24:
https://cmake.org/cmake/help/latest/release/3.24.html#other-changes
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
