### PR TITLE
elvish: Fix hash

### DIFF
--- a/bucket/elvish.json
+++ b/bucket/elvish.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://dl.elv.sh/windows-amd64/elvish-v0.19.2.zip",
-            "hash": "7d13e04cb8e513e307acf889fbd2c97453764992dd7099dedac164d83750e910"
+            "hash": "28c96840fa87e654320e1fdf364589bb9a2c64146364ca10db8ecf09c00a0541"
         },
         "32bit": {
             "url": "https://dl.elv.sh/windows-386/elvish-v0.19.2.zip",
-            "hash": "663e60c7cf5f22b2283b5c3fd7e13c6e112538103d359a1e48dcd4503e48431e"
+            "hash": "ab8cb1fea8e8521533a8de712d7c10423f433f210240dddcb600172d86e85639"
         }
     },
     "pre_install": "Rename-Item \"$dir\\elvish-v$version.exe\" 'elvish.exe'",


### PR DESCRIPTION
It seems that SHA256 checksums of Elvish binary archives have officially changed. See:

- 64-bit: https://dl.elv.sh/windows-amd64/elvish-v0.19.2.zip.sha256sum
- 32-bit: https://dl.elv.sh/windows-386/elvish-v0.19.2.zip.sha256sum

We should update them in the app manifest.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
