### PR TITLE
avr-gcc: add internal avrdude.exe and make.exe to shims list

### DIFF
--- a/bucket/avr-gcc.json
+++ b/bucket/avr-gcc.json
@@ -44,7 +44,9 @@
         "bin\\avr-run.exe",
         "bin\\avr-size.exe",
         "bin\\avr-strings.exe",
-        "bin\\avr-strip.exe"
+        "bin\\avr-strip.exe",
+        "bin\\avrdude.exe",
+        "bin\\make.exe"
     ],
     "post_install": [
         "# manually shim bin\\avr-gcc-$version.exe",


### PR DESCRIPTION
Just adding the included avrdude.exe and make.exe to shims list.
these executables are already distributed with the package.
this saves the hassle of having to shim them manually or install them separately.