### PR TITLE
Fix upstream URL for mdcat

### DIFF
--- a/bucket/mdcat.json
+++ b/bucket/mdcat.json
@@ -1,23 +1,23 @@
 {
     "version": "2.0.3",
     "description": "cat for markdown",
-    "homepage": "https://github.com/lunaryorn/mdcat",
+    "homepage": "https://github.com/swsnr/mdcat",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lunaryorn/mdcat/releases/download/mdcat-2.0.3/mdcat-2.0.3-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/swsnr/mdcat/releases/download/mdcat-2.0.3/mdcat-2.0.3-x86_64-pc-windows-msvc.zip",
             "hash": "c93b31c7b55fe6353059d52c75d84dc7d92546d273c539ed6b5507b5b05fa258"
         }
     },
     "bin": "mdcat.exe",
     "checkver": {
-        "github": "https://github.com/lunaryorn/mdcat",
+        "github": "https://github.com/swsnr/mdcat",
         "regex": "mdcat-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lunaryorn/mdcat/releases/download/mdcat-$version/mdcat-$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/swsnr/mdcat/releases/download/mdcat-$version/mdcat-$version-x86_64-pc-windows-msvc.zip"
             }
         },
         "hash": {

--- a/bucket/mdcat.json
+++ b/bucket/mdcat.json
@@ -19,9 +19,6 @@
             "64bit": {
                 "url": "https://github.com/swsnr/mdcat/releases/download/mdcat-$version/mdcat-$version-x86_64-pc-windows-msvc.zip"
             }
-        },
-        "hash": {
-            "url": "$baseurl/SHA512SUM.txt"
         }
     }
 }


### PR DESCRIPTION
I renamed my Github account a while ago, this change updates the URLs accordingly.

Also note that the `autoupdate.hash.url` field is not correct anymore; I no longer have SHA512 hashes in the release pipeline but only b2 under `B2SUMS.txt`.  Haven't updated that field though, because I don't understand what it's for, and whether b2 hashes are okay there.