### PR TITLE
erdtree: Add version 2.0.0

### DIFF
--- a/bucket/erdtree.json
+++ b/bucket/erdtree.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.8.1",
+    "version": "2.0.0",
     "description": "A multi-threaded file-tree visualizer and disk usage analyzer.",
     "homepage": "https://github.com/solidiquis/erdtree",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/solidiquis/erdtree/releases/download/v1.8.1/et-v1.8.1-x86_64-pc-windows-msvc.exe#/et.exe",
-            "hash": "fa3476c45f3943cf69870395d267ae4f193e8356ffae146320f862a7ce48afea"
+            "url": "https://github.com/solidiquis/erdtree/releases/download/v2.0.0/erd-v2.0.0-x86_64-pc-windows-msvc.exe#/erd.exe",
+            "hash": "70e5dda5836a020c0778bcbf1c8005d53e4cca9a5a93916b5eefce5ddd51f70a"
         }
     },
-    "bin": "et.exe",
+    "bin": "erd.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/solidiquis/erdtree/releases/download/v$version/et-v$version-x86_64-pc-windows-msvc.exe#/et.exe"
+                "url": "https://github.com/solidiquis/erdtree/releases/download/v$version/erd-v$version-x86_64-pc-windows-msvc.exe#/erd.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
As of version `2.0.0` erdtree now uses bin name `erd` instead of `et`. See [here](https://github.com/solidiquis/erdtree/blob/v2.0.0/Cargo.toml#L22).

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
