### PR TITLE
alist@3.16.1: Add arm64 architecture

### DIFF
--- a/bucket/alist.json
+++ b/bucket/alist.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/alist-org/alist/releases/download/v3.16.1/alist-windows-386.zip",
             "hash": "md5:2342f5945adc4d0c60dd49910ed27775"
+        },
+        "arm64": {
+            "url": "https://github.com/alist-org/alist/releases/download/v3.16.1/alist-windows-arm64.zip",
+            "hash": "md5:8056d3a13e96533d0ca887df9c1c6375"
         }
     },
     "bin": [
@@ -34,6 +38,9 @@
             },
             "32bit": {
                 "url": "https://github.com/alist-org/alist/releases/download/v$version/alist-windows-386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/alist-org/alist/releases/download/v$version/alist-windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
