### PR TITLE
DevSpace: Add version 6.3.2

### DIFF
--- a/bucket/devspace.json
+++ b/bucket/devspace.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-amd64.exe",
+            "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-amd64.exe#/devspace.exe",
             "hash": "72d89cd7f2c4b59a4ae282293423318eb5cac68a1bb48dcc50ff200f3ce826a6",
             "bin": [
                 "devspace-windows-amd64.exe",
@@ -16,7 +16,7 @@
             ]
         },
         "32bit": {
-            "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-386.exe",
+            "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-386.exe#/devspace.exe",
             "hash": "af143841ae2fa0c0a2e77ffa2ceb3d7a630458f17681d15d0e4fa8e922f259da",
             "bin": [
                 "devspace-windows-386.exe",
@@ -33,10 +33,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-amd64.exe"
+                "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-amd64.exe#/devspace.exe"
             },
             "32bit": {
-                "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-386.exe"
+                "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-386.exe#/devspace.exe"
             }
         },
         "hash": {

--- a/bucket/devspace.json
+++ b/bucket/devspace.json
@@ -1,0 +1,42 @@
+{
+  "version": "6.3.2",
+  "homepage": "https://devspace.sh",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-amd64.exe",
+      "hash": "72d89cd7f2c4b59a4ae282293423318eb5cac68a1bb48dcc50ff200f3ce826a6",
+      "bin": [
+        "devspace-windows-amd64.exe",
+        [
+          "devspace-windows-amd64.exe",
+          "devspace"
+        ]
+      ]
+    },
+    "32bit": {
+      "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-386.exe",
+      "hash": "af143841ae2fa0c0a2e77ffa2ceb3d7a630458f17681d15d0e4fa8e922f259da",
+      "bin": [
+        "devspace-windows-386.exe",
+        [
+          "devspace-windows-386.exe",
+          "devspace"
+        ]
+      ]
+    }
+  },
+  "checkver": {"github": "https://github.com/devspace-sh/devspace"},
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-amd64.exe"
+      },
+      "32bit": {
+        "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-386.exe"
+      },
+      "hash": {
+        "url": "$url.sha256"
+      }
+    }
+  }
+}

--- a/bucket/devspace.json
+++ b/bucket/devspace.json
@@ -6,27 +6,14 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-amd64.exe#/devspace.exe",
-            "hash": "72d89cd7f2c4b59a4ae282293423318eb5cac68a1bb48dcc50ff200f3ce826a6",
-            "bin": [
-                "devspace-windows-amd64.exe",
-                [
-                    "devspace-windows-amd64.exe",
-                    "devspace"
-                ]
-            ]
+            "hash": "72d89cd7f2c4b59a4ae282293423318eb5cac68a1bb48dcc50ff200f3ce826a6"
         },
         "32bit": {
             "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-386.exe#/devspace.exe",
-            "hash": "af143841ae2fa0c0a2e77ffa2ceb3d7a630458f17681d15d0e4fa8e922f259da",
-            "bin": [
-                "devspace-windows-386.exe",
-                [
-                    "devspace-windows-386.exe",
-                    "devspace"
-                ]
-            ]
+            "hash": "af143841ae2fa0c0a2e77ffa2ceb3d7a630458f17681d15d0e4fa8e922f259da"
         }
     },
+    "bin": "devspace.exe",
     "checkver": {
         "github": "https://github.com/devspace-sh/devspace"
     },

--- a/bucket/devspace.json
+++ b/bucket/devspace.json
@@ -37,10 +37,10 @@
             },
             "32bit": {
                 "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-386.exe"
-            },
-            "hash": {
-                "url": "$url.sha256"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/devspace.json
+++ b/bucket/devspace.json
@@ -1,42 +1,46 @@
 {
-  "version": "6.3.2",
-  "homepage": "https://devspace.sh",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-amd64.exe",
-      "hash": "72d89cd7f2c4b59a4ae282293423318eb5cac68a1bb48dcc50ff200f3ce826a6",
-      "bin": [
-        "devspace-windows-amd64.exe",
-        [
-          "devspace-windows-amd64.exe",
-          "devspace"
-        ]
-      ]
-    },
-    "32bit": {
-      "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-386.exe",
-      "hash": "af143841ae2fa0c0a2e77ffa2ceb3d7a630458f17681d15d0e4fa8e922f259da",
-      "bin": [
-        "devspace-windows-386.exe",
-        [
-          "devspace-windows-386.exe",
-          "devspace"
-        ]
-      ]
-    }
-  },
-  "checkver": {"github": "https://github.com/devspace-sh/devspace"},
-  "autoupdate": {
+    "version": "6.3.2",
+    "description": "DevSpace is an open-source developer tool for Kubernetes that lets you develop and deploy cloud-native software faster",
+    "homepage": "https://devspace.sh",
+    "license": "Apache-2.0",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-amd64.exe"
-      },
-      "32bit": {
-        "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-386.exe"
-      },
-      "hash": {
-        "url": "$url.sha256"
-      }
+        "64bit": {
+            "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-amd64.exe",
+            "hash": "72d89cd7f2c4b59a4ae282293423318eb5cac68a1bb48dcc50ff200f3ce826a6",
+            "bin": [
+                "devspace-windows-amd64.exe",
+                [
+                    "devspace-windows-amd64.exe",
+                    "devspace"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/devspace-sh/devspace/releases/download/v6.3.2/devspace-windows-386.exe",
+            "hash": "af143841ae2fa0c0a2e77ffa2ceb3d7a630458f17681d15d0e4fa8e922f259da",
+            "bin": [
+                "devspace-windows-386.exe",
+                [
+                    "devspace-windows-386.exe",
+                    "devspace"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/devspace-sh/devspace"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-amd64.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/devspace-sh/devspace/releases/download/v$version/devspace-windows-386.exe"
+            },
+            "hash": {
+                "url": "$url.sha256"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
Provide a new app manifest for [DevSpace](https://devspace.sh)

Relates to https://github.com/devspace-sh/devspace/issues/2629

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
