### PR TITLE
kubescape: Update url and binary naming

### DIFF
--- a/bucket/kubescape.json
+++ b/bucket/kubescape.json
@@ -1,11 +1,11 @@
 {
     "version": "2.3.1",
     "description": "Scans K8s clusters, YAML files, and HELM charts, and detect misconfigurations and software vulnerabilities at early stages of the CI/CD pipeline and provides a risk score instantly and risk trends over time.",
-    "homepage": "https://github.com/armosec/kubescape/",
+    "homepage": "https://github.com/kubescape/kubescape/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/armosec/kubescape/releases/download/v2.3.1/kubescape-windows-latest#/kubescape.exe",
+            "url": "https://github.com/kubescape/kubescape/releases/download/v2.3.1/kubescape.exe",
             "hash": "8f902712e4ea38a1758491449d68ad499b93a22a96c3cd1708ca6d50014ee6c5"
         }
     },
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/armosec/kubescape/releases/download/v$version/kubescape-windows-latest#/kubescape.exe"
+                "url": "https://github.com/kubescape/kubescape/releases/download/v$version/kubescape.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
- `kubescape` has got moved into `kubescape` org.
- `kubescape-windows-latest` is getting deprecated: https://github.com/kubescape/kubescape/issues/1168

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
