### PR TITLE
bombardier@1.2.6: Add arm64 architecture

### DIFF
--- a/bucket/bombardier.json
+++ b/bucket/bombardier.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/codesenberg/bombardier/releases/download/v1.2.6/bombardier-windows-386.exe#/bombardier.exe",
             "hash": "3ba02e865b3c82cdd506e486c5fe6b1d4a4464c10658151a838ca95dfe367819"
+        },
+        "arm64": {
+            "url": "https://github.com/codesenberg/bombardier/releases/download/v1.2.6/bombardier-windows-arm64.exe#/bombardier.exe",
+            "hash": "b4fe08f9b341fe7799c34c0a7d1b558b23b9a21f05c547f855e9e8b4172853a0"
         }
     },
     "bin": "bombardier.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/codesenberg/bombardier/releases/download/v$version/bombardier-windows-386.exe#/bombardier.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/codesenberg/bombardier/releases/download/v$version/bombardier-windows-arm64.exe#/bombardier.exe"
             }
         }
     }


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
