### PR TITLE
bazel-buildtools: Update to version 6.1.2 and fix autoupdate

### DIFF
--- a/bucket/bazel-buildtools.json
+++ b/bucket/bazel-buildtools.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.1.1",
+    "version": "6.1.2",
     "description": "Developer tools for working with Google's bazel buildtool.",
     "homepage": "https://github.com/bazelbuild/buildtools",
     "license": "Apache-2.0",
@@ -9,14 +9,14 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/bazelbuild/buildtools/releases/download/6.1.1/buildifier-windows-amd64.exe#/buildifier.exe",
-                "https://github.com/bazelbuild/buildtools/releases/download/6.1.1/buildozer-windows-amd64.exe#/buildozer.exe",
-                "https://github.com/bazelbuild/buildtools/releases/download/6.1.1/unused_deps-windows-amd64.exe#/unused_deps.exe"
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-windows-amd64.exe#/buildifier.exe",
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildozer-windows-amd64.exe#/buildozer.exe",
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/unused_deps-windows-amd64.exe#/unused_deps.exe"
             ],
             "hash": [
-                "5a79024cb03058a99c995f062afa74401733b30011b583f0c80507bec2c8fa37",
-                "95b7dbf6e01131450c57c5743935903b246fc44f16aca4c6d92ec03d13400a68",
-                "579450c763f0a192b3612631418a55c5a5667b8713059d7f9f76b5f76895244a"
+                "92bdd284fbc6766fc3e300b434ff9e68ac4d76a06cb29d1bdefe79a102a8d135",
+                "07664d5d08ee099f069cd654070cabf2708efaae9f52dc83921fa400c67a868b",
+                "929dbcd155b05b34f8a088c88358e78aaf3dab3e753a32fdf233a80fda085101"
             ]
         }
     },
@@ -30,9 +30,9 @@
         "architecture": {
             "64bit": {
                 "url": [
-                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildifier-windows-amd64.exe#/buildifier.exe",
-                    "https://github.com/bazelbuild/buildtools/releases/download/$version/buildozer-windows-amd64.exe#/buildozer.exe",
-                    "https://github.com/bazelbuild/buildtools/releases/download/$version/unused_deps-windows-amd64.exe#/unused_deps.exe"
+                    "https://github.com/bazelbuild/buildtools/releases/download/v$version/buildifier-windows-amd64.exe#/buildifier.exe",
+                    "https://github.com/bazelbuild/buildtools/releases/download/v$version/buildozer-windows-amd64.exe#/buildozer.exe",
+                    "https://github.com/bazelbuild/buildtools/releases/download/v$version/unused_deps-windows-amd64.exe#/unused_deps.exe"
                 ]
             }
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

bazel-buildtools: 6.1.2 (scoop version is 6.1.1) autoupdate available
Autoupdating bazel-buildtools
Downloading buildifier-windows-amd64.exe to compute hashes!
VERBOSE: GET with 0-byte payload
VERBOSE: received 6403-byte response of content type application/json
VERBOSE: Content encoding: utf-8
The remote server returned an error: (404) Not Found.
URL https://github.com/bazelbuild/buildtools/releases/download/6.1.2/buildifier-windows-amd64.exe#/buildifier.exe is not valid
ERROR Could not update bazel-buildtools, hash for buildifier-windows-amd64.exe failed!

https://github.com/bazelbuild/buildtools/releases/tag/v6.1.2 Version tag on GitHub now start with v, e.g. v6.1.2 for the current release.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
