### PR TITLE
hexed: Update to version 1.1 and fix autoupdate

### DIFF
--- a/bucket/hexed.json
+++ b/bucket/hexed.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.0.32",
+    "version": "1.1",
     "description": "Console-based hex editor",
     "homepage": "https://github.com/samizzo/hexed",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/samizzo/hexed/releases/download/1.0.32/hexed.exe",
-            "hash": "4b512fcd1d3b4026befac8b348d7d539ddbfb4df6656b71c8c2da4a9b3cca7bb"
+            "url": "https://github.com/samizzo/hexed/releases/download/v1.1/hexed.exe",
+            "hash": "ff6532f73248f4b0a0e6240c0b9dbf4ccfc1144006cba7c3f76be3f3ad71daff"
         }
     },
     "bin": "hexed.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/samizzo/hexed/releases/download/$version/hexed.exe"
+                "url": "https://github.com/samizzo/hexed/releases/download/v$version/hexed.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

hexed: 1.1 (scoop version is 1.0.32) autoupdate available
Autoupdating hexed
Downloading hexed.exe to compute hashes!
VERBOSE: GET with 0-byte payload
VERBOSE: received 5096-byte response of content type application/json
VERBOSE: Content encoding: utf-8
The remote server returned an error: (404) Not Found.
URL https://github.com/samizzo/hexed/releases/download/1.1/hexed.exe is not valid
ERROR Could not update hexed, hash for hexed.exe failed!

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
