### PR TITLE
openssl-mingw: Remove autoupdate

### DIFF
--- a/bucket/openssl-mingw.json
+++ b/bucket/openssl-mingw.json
@@ -1,16 +1,16 @@
 {
     "version": "3.0.2_1",
     "description": "A robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.",
-    "homepage": "https://curl.haxx.se/windows/",
+    "homepage": "https://curl.se/windows/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://curl.haxx.se/windows/dl-7.83.1_1/openssl-3.0.2_1-win64-mingw.tar.xz",
+            "url": "https://curl.se/windows/dl-7.83.1_1/openssl-3.0.2_1-win64-mingw.tar.xz",
             "hash": "104d05f2aead0f98639654b02327e6f5552f313121c3c6c98bd3785c5e6af3aa",
             "extract_dir": "openssl-3.0.2-win64-mingw"
         },
         "32bit": {
-            "url": "https://curl.haxx.se/windows/dl-7.83.1_1/openssl-3.0.2_1-win32-mingw.tar.xz",
+            "url": "https://curl.se/windows/dl-7.83.1_1/openssl-3.0.2_1-win32-mingw.tar.xz",
             "hash": "caa7b35e7a76a0f7e5349b90dde9cd705ebb3336795266b5cbd9f6bf4ecaa7ec",
             "extract_dir": "openssl-3.0.2-win32-mingw"
         }

--- a/bucket/openssl-mingw.json
+++ b/bucket/openssl-mingw.json
@@ -18,22 +18,5 @@
     "env_add_path": "bin",
     "env_set": {
         "OPENSSL_CONF": "$dir\\ssl\\openssl.cnf"
-    },
-    "checkver": "dl-(?<curl>[\\d._]+)/openssl-([\\da-z._]+)-win64-mingw",
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://curl.haxx.se/windows/dl-$matchCurl/openssl-$version-win64-mingw.tar.xz",
-                "extract_dir": "openssl-$matchHead-win64-mingw"
-            },
-            "32bit": {
-                "url": "https://curl.haxx.se/windows/dl-$matchCurl/openssl-$version-win32-mingw.tar.xz",
-                "extract_dir": "openssl-$matchHead-win32-mingw"
-            }
-        },
-        "hash": {
-            "url": "$baseurl/hashes.txt",
-            "regex": "SHA256\\($basename\\)=\\s+$sha256"
-        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://github.com/curl/curl-for-win/issues/33
Because upstream [no longer](https://github.com/curl/curl-for-win/commit/893b5f5c806f0cb2f2914ffbb8cde312b87e30af) ship a full OpenSSL distro, only static libs and headers.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
