### PR TITLE
unison: Update to version 2.53.3 and fix autoupdate

### DIFF
--- a/bucket/unison.json
+++ b/bucket/unison.json
@@ -1,13 +1,17 @@
 {
-    "version": "2.53.0",
+    "version": "2.53.3",
     "description": "A file-synchronization tool.",
     "homepage": "https://www.cis.upenn.edu/~bcpierce/unison",
     "license": "GPL-3.0-only",
     "notes": "Compiled with same OCaml compiler version 4.12.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bcpierce00/unison/releases/download/v2.53.0/unison-v2.53.0+ocaml-4.12.1+x86_64.windows.zip",
-            "hash": "bdf67196b1a5335328317724f044e5d3c16cdff10db836176edb61a8a505cf27"
+            "url": "https://github.com/bcpierce00/unison/releases/download/v2.53.3/unison-2.53.3-windows-x86_64.zip",
+            "hash": "5e8607adb6402fb57b10d5cf2d2cc1a717473698023d3edeb5060ea42d79713c"
+        },
+        "32bit": {
+            "url": "https://github.com/bcpierce00/unison/releases/download/v2.53.3/unison-2.53.3-windows-i386.zip",
+            "hash": "77e3008f98390c2187ebc6ed41807bd0db0a2291ba276cd838c87dd6d5db78b7"
         }
     },
     "bin": [
@@ -20,7 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/bcpierce00/unison/releases/download/v$version/unison-v$version+ocaml-4.12.1+x86_64.windows.zip"
+                "url": "https://github.com/bcpierce00/unison/releases/download/v$version/unison-$version-windows-x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/bcpierce00/unison/releases/download/v$version/unison-$version-windows-i386.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

unison: 2.53.3 (scoop version is 2.53.0) autoupdate available
Autoupdating unison
Downloading unison-v2.53.3 ocaml-4.12.1 x86_64.windows.zip to compute hashes!
VERBOSE: GET with 0-byte payload
VERBOSE: received 5240-byte response of content type application/json
VERBOSE: Content encoding: utf-8
The remote server returned an error: (404) Not Found.
URL https://github.com/bcpierce00/unison/releases/download/v2.53.3/unison-v2.53.3+ocaml-4.12.1+x86_64.windows.zip is not valid
ERROR Could not update unison, hash for unison-v2.53.3+ocaml-4.12.1+x86_64.windows.zip failed!

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
