### PR TITLE
sliksvn: Update to version 1.14.2b and add arm64 architecture

### DIFF
--- a/bucket/sliksvn.json
+++ b/bucket/sliksvn.json
@@ -1,16 +1,20 @@
 {
-    "version": "1.14.2",
+    "version": "1.14.2b",
     "description": "A software versioning and revision control system.",
     "homepage": "https://sliksvn.com/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://sliksvn.com/pub/Slik-Subversion-1.14.2-x64.zip",
-            "hash": "9348c4b28762c9e852429105c20babdb94414524eb03a03e20efd66db5fcabbd"
+            "url": "https://sliksvn.com/pub/Slik-Subversion-1.14.2b-x64.zip",
+            "hash": "1c5b992b0d2b065bdbbea9939980cd5111519f1588de4a853d5e3115d7c1ea9d"
         },
         "32bit": {
-            "url": "https://sliksvn.com/pub/Slik-Subversion-1.14.2-win32.zip",
-            "hash": "d1ea5453db6bfdf6a1886b1f1a5fadbb87d30ee4558cc60356f195e849897f07"
+            "url": "https://sliksvn.com/pub/Slik-Subversion-1.14.2b-win32.zip",
+            "hash": "2774b536a769aa4be5330c68b126b27acbac0b2e08d4b86b0635eb958894ec9a"
+        },
+        "arm64": {
+            "url": "https://sliksvn.com/pub/Slik-Subversion-1.14.2b-ARM64.zip",
+            "hash": "cceb88655824577ff8b956fb0752f5de0d2f07e9a12bba55255227bd89fe5e1f"
         }
     },
     "pre_install": [
@@ -32,7 +36,7 @@
     ],
     "checkver": {
         "url": "https://sliksvn.com/download/",
-        "regex": "<a.*>SVN ([\\d.]+), 64 bit</a>"
+        "regex": "<a.*>SVN ([\\w.]+), 64 bit</a>"
     },
     "autoupdate": {
         "architecture": {
@@ -41,6 +45,9 @@
             },
             "32bit": {
                 "url": "https://sliksvn.com/pub/Slik-Subversion-$version-win32.zip"
+            },
+            "arm64": {
+                "url": "https://sliksvn.com/pub/Slik-Subversion-$version-ARM64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

sliksvn: couldn't match '<a.*>SVN ([\d.]+), 64 bit</a>' in https://sliksvn.com/download/

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
