### PR TITLE
win32yank: Update to version 0.1.1

### DIFF
--- a/bucket/win32yank.json
+++ b/bucket/win32yank.json
@@ -1,14 +1,16 @@
 {
-    "version": "0.0.4",
+    "version": "0.1.1",
     "description": "A clipboard tool for Windows",
     "homepage": "https://github.com/equalsraf/win32yank",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/equalsraf/win32yank/releases/download/v0.0.4/win32yank-x64.zip"
+            "url": "https://github.com/equalsraf/win32yank/releases/download/v0.1.1/win32yank-x64.zip",
+            "hash": "247c9a05b94387a884b49d3db13f806b1677dfc38020f955f719be6902260cd6"
         },
         "32bit": {
-            "url": "https://github.com/equalsraf/win32yank/releases/download/v0.0.4/win32yank-x86.zip"
+            "url": "https://github.com/equalsraf/win32yank/releases/download/v0.1.1/win32yank-x86.zip",
+            "hash": "820274883786affd19ec180392e3a32c1acfbe5dbf9daff2f90fad78d56aab86"
         }
     },
     "bin": "win32yank.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
win32yank: 0.1.1 (scoop version is 0.0.4) autoupdate available
Autoupdating win32yank
Downloading win32yank-x86.zip to compute hashes!
VERBOSE: GET with 0-byte payload
VERBOSE: received 5229-byte response of content type application/json
VERBOSE: Content encoding: utf-8
Downloading https://github.com/equalsraf/win32yank/releases/download/v0.1.1/win32yank-x86.zip (356.0 KB)...
Computed hash: 820274883786affd19ec180392e3a32c1acfbe5dbf9daff2f90fad78d56aab86
ERROR You cannot call a method on a null-valued expression.
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
