### PR TITLE
red: Update to version 30apr23 and fix autoupdate

### DIFF
--- a/bucket/red.json
+++ b/bucket/red.json
@@ -1,23 +1,23 @@
 {
-    "version": "0.6.4",
+    "version": "30apr23",
     "description": "Programming language inspired by Rebol.",
     "homepage": "https://www.red-lang.org",
     "license": {
         "identifier": "BSD-3-Clause,BSL-1.0",
         "url": "https://github.com/red/red#license"
     },
-    "url": "https://static.red-lang.org/dl/win/red-064.exe#/red.exe",
-    "hash": "45eb8d089b6e25701e4208ac5d1db0c483752e0abff28f58baff5a39f765db9c",
+    "url": "https://static.red-lang.org/dl/auto/win/red-30apr23-5e25fa6eb.exe#/red.exe",
+    "hash": "6e500403b0ee16a5e58e03113b63249b8ec3a3554d5b92d20dccc0f770bfe607",
     "bin": "red.exe",
     "checkver": {
-        "url": "http://static.red-lang.org/download.html",
-        "regex": "Red\\s+([\\d.]+)\\s+for"
+        "url": "https://static.red-lang.org/dl/auto/win/history.html",
+        "regex": "red-(\\w+)-(?<commit>\\w+).exe"
     },
     "autoupdate": {
-        "url": "https://static.red-lang.org/dl/win/red-$cleanVersion.exe#/red.exe",
+        "url": "https://static.red-lang.org/dl/auto/win/red-$version-$matchCommit.exe#/red.exe",
         "hash": {
             "url": "http://static.red-lang.org/download.html",
-            "regex": "$sha256"
+            "regex": "$basename[\\s\\S]+?$sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

red: couldn't match 'Red\s+([\d.]+)\s+for' in http://static.red-lang.org/download.html

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
