### PR TITLE
clipboard: Fix bin

### DIFF
--- a/bucket/clipboard.json
+++ b/bucket/clipboard.json
@@ -14,13 +14,7 @@
         }
     },
     "extract_dir": "bin",
-    "bin": [
-        "clipboard.exe",
-        [
-            "clipboard.exe",
-            "cb"
-        ]
-    ],
+    "bin": "cb.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Can't shim 'clipboard.exe': File doesn't exist.
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).