### PR TITLE
llvm: Add arm64

### DIFF
--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -11,13 +11,18 @@
         "32bit": {
             "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.3/LLVM-16.0.3-win32.exe#/dl.7z",
             "hash": "4f9d41e5de1c59430bb5284a91b2a56c004d2b7ab1b5b2cd075747ae5f008d99"
+        },
+        "arm64": {
+            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.1/LLVM-16.0.1-woa64.exe#/dl.7z",
+            "hash": "0dbd16067cf35c95c07fbc2396f60ef5b44672add7c4bed9dafc9ba8b5d87171"
         }
     },
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe\" -Recurse",
     "env_add_path": "bin",
     "checkver": {
-        "github": "https://github.com/llvm/llvm-project",
-        "regex": "tag/llvmorg-([\\d._]+)"
+        "url": "https://api.github.com/repos/llvm/llvm-project/releases",
+        "jsonpath": "$[?(@.prerelease == false)]..['html_url','browser_download_url']",
+        "regex": "tag/llvmorg-([\\d.]+)[\\S\\s]+?LLVM-(?<arm64>[\\d.]+)-woa64\\.exe"
     },
     "autoupdate": {
         "architecture": {
@@ -26,6 +31,9 @@
             },
             "32bit": {
                 "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/LLVM-$version-win32.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$matchArm64/LLVM-$matchArm64-woa64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The project has binaries for ARM which are not built for every release (or built much later than the other windows binaries) seen here: https://github.com/llvm/llvm-project/releases
So I modified checkver in an attempt to accommodate the irregular release schedule.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
