### PR TITLE
zig: Fix hash extraction

### DIFF
--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -27,20 +27,16 @@
         "architecture": {
             "64bit": {
                 "url": "https://ziglang.org/download/$version/zig-windows-x86_64-$version.zip",
-                "hash": {
-                    "url": "https://ziglang.org/download/index.json",
-                    "jsonpath": "$.['$version'].x86_64-windows.shasum"
-                },
                 "extract_dir": "zig-windows-x86_64-$version"
             },
             "arm64": {
                 "url": "https://ziglang.org/download/$version/zig-windows-aarch64-$version.zip",
-                "hash": {
-                    "url": "https://ziglang.org/download/index.json",
-                    "jsonpath": "$.['$version'].aarch64-windows.shasum"
-                },
                 "extract_dir": "zig-windows-aarch64-$version"
             }
+        },
+        "hash": {
+            "url": "https://ziglang.org/download/index.json",
+            "regex": "(?s)$basename.*?$sha256"
         }
     }
 }

--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -27,16 +27,20 @@
         "architecture": {
             "64bit": {
                 "url": "https://ziglang.org/download/$version/zig-windows-x86_64-$version.zip",
+                "hash": {
+                    "url": "https://ziglang.org/download/index.json",
+                    "jsonpath": "$.['$version'].x86_64-windows.shasum"
+                },
                 "extract_dir": "zig-windows-x86_64-$version"
             },
             "arm64": {
                 "url": "https://ziglang.org/download/$version/zig-windows-aarch64-$version.zip",
+                "hash": {
+                    "url": "https://ziglang.org/download/index.json",
+                    "jsonpath": "$.['$version'].aarch64-windows.shasum"
+                },
                 "extract_dir": "zig-windows-aarch64-$version"
             }
-        },
-        "hash": {
-            "url": "https://ziglang.org/download/",
-            "regex": "(?sm)$basename.*?$sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Hashes are no longer shown on the download page.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
