### PR TITLE
ijhttp: Fix extract directory

### DIFF
--- a/bucket/ijhttp.json
+++ b/bucket/ijhttp.json
@@ -10,6 +10,7 @@
     },
     "url": "https://download.jetbrains.com/resources/intellij/http-client/231.8770.17/intellij-http-client.zip",
     "hash": "eb0090f87b6a28172ced9e8a34cc14a9a3b2aae142752f1e31392f58b102db06",
+    "extract_dir": "ijhttp",
     "bin": "ijhttp.bat",
     "checkver": {
         "script": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The bin shim points to `%SCOOP_INSTALLATION_PATH%/apps/ijhttp/current/ijhttp.bat`, but the dist file is unzipped in `%SCOOP_INSTALLATION_PATH%/apps/ijhttp/current/ijhttp`. So `ijhttp.bat` could not be found.

This PR fixes the problem.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


<!-- or -->
Relates to #4724

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
