### PR TITLE
pwsh: Removed shim because it does not work properly with Task Scheduler

### DIFF
--- a/bucket/pwsh.json
+++ b/bucket/pwsh.json
@@ -41,7 +41,6 @@
         "    }",
         "}"
     ],
-    "bin": "pwsh.exe",
     "shortcuts": [
         [
             "pwsh.exe",
@@ -49,6 +48,7 @@
             "-WorkingDirectory ~"
         ]
     ],
+    "env_add_path": ".",
     "persist": [
         "Microsoft.VSCode_profile.ps1",
         "Microsoft.PowerShell_profile.ps1",


### PR DESCRIPTION
Instead, let's add the folder of `pwsh\current` to the PATH variable.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes this issue,
![(mmc)D21139_05-05-2023](https://user-images.githubusercontent.com/101912712/236574129-bffccbcc-163e-4a69-9040-2116c2bdb8b6.jpg)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
