### PR TITLE
mingw-winlibs: Update to version 13.1.0-16.0.2-11.0.0-r1

### DIFF
--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -24,10 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-x86_64-posix-seh-gcc-$match1-mingw-w64msvcrt-$match3-r$match4.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-x86_64-mcf-seh-gcc-$match1-mingw-w64msvcrt-$match3-r$match4.7z"
             },
             "32bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-i686-posix-dwarf-gcc-$match1-mingw-w64msvcrt-$match3-r$match4.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-i686-mcf-dwarf-gcc-$match1-mingw-w64msvcrt-$match3-r$match4.7z"
             }
         },
         "hash": {

--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -1,17 +1,17 @@
 {
-    "version": "12.2.0-16.0.0-10.0.0-r5",
+    "version": "13.1.0-16.0.2-11.0.0-r1",
     "description": "GNU Compiler Collection (MSVCRT, WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-16.0.0-10.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-12.2.0-mingw-w64msvcrt-10.0.0-r5.7z",
-            "hash": "sha512:ef6e56eb5f3407416969309235620c13feb103351803fe364606f15acf0f1acf7decb8169d1728e9d7c60294a1130b96b982983660db4e515e7066cf0a9b8989",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.1.0-16.0.2-11.0.0-msvcrt-r1/winlibs-x86_64-mcf-seh-gcc-13.1.0-mingw-w64msvcrt-11.0.0-r1.7z",
+            "hash": "sha512:ab7a0c2f6d9fcdfeeb8577c93f045337be6b439a60c95030a9153d92008a36b3ce50ca17948b944ee630fdfd4c7e50c88c13534673302c54a60340e3e9fa36a3",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-16.0.0-10.0.0-msvcrt-r5/winlibs-i686-posix-dwarf-gcc-12.2.0-mingw-w64msvcrt-10.0.0-r5.7z",
-            "hash": "sha512:0fd79581e8fe7d5de205d1f4d91c5ebbfa691c09f307374981e2ceaade2ed04fb3a9563e3d5c40bea7c208de954f6e3a1ac982236a75271aecb3ec7b44c65b7b",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.1.0-16.0.2-11.0.0-msvcrt-r1/winlibs-i686-mcf-dwarf-gcc-13.1.0-mingw-w64msvcrt-11.0.0-r1.7z",
+            "hash": "sha512:7df9675c1fdb11655f2ccc26ba4a7aa615bd9a31a978234986c7a13779a5cb35b648046af42e3a8698ba4c1d17114c77b5ecff7717775c0e123afc444c1aa954",
             "extract_dir": "mingw32"
         }
     },

--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -1,6 +1,6 @@
 {
     "version": "12.2.0-16.0.0-10.0.0-r5",
-    "description": "GNU Compiler Collection (WinLibs build)",
+    "description": "GNU Compiler Collection (MSVCRT, WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The GCC13 builds now have two separate releases:
- MCF https://github.com/brechtsanders/winlibs_mingw/releases/tag/13.1.0-16.0.2-11.0.0-msvcrt-r1
- POSIX https://github.com/brechtsanders/winlibs_mingw/releases/tag/13.1.0posix-16.0.3-11.0.0-msvcrt-r1

I'm assuming the MCF build is intended to be the default since the latest posix build is not listed on the winlibs site.

Side note: Should the LLVM number be dropped from the version number? (like https://github.com/ScoopInstaller/Versions/blob/master/bucket/mingw-winlibs-ucrt.json) Since it's not included in these builds.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
