### PR TITLE
doctl@1.96.0: Add arm64 architecture

### DIFF
--- a/bucket/doctl.json
+++ b/bucket/doctl.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.95.0",
+    "version": "1.96.0",
     "description": "A command line tool for DigitalOcean services",
     "homepage": "https://github.com/digitalocean/doctl",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/digitalocean/doctl/releases/download/v1.95.0/doctl-1.95.0-windows-amd64.zip",
-            "hash": "39fc3ac42e841d10f723bb72947132f30b37bae1835ca397fc0bb947a3b32263"
+            "url": "https://github.com/digitalocean/doctl/releases/download/v1.96.0/doctl-1.96.0-windows-amd64.zip",
+            "hash": "5da1cba972b2248b5de50e026ac2c1658ae21393529ebbdacb2f5cf5b0e4ffad"
         },
         "32bit": {
-            "url": "https://github.com/digitalocean/doctl/releases/download/v1.95.0/doctl-1.95.0-windows-386.zip",
-            "hash": "29dcdbfaffa4029e26bf2ea8d496c7b91025c57c4b67408fe6500cc355a32e28"
+            "url": "https://github.com/digitalocean/doctl/releases/download/v1.96.0/doctl-1.96.0-windows-386.zip",
+            "hash": "f621f1141ad3ada1086b6c1659e07a5e157b5b43c5e36583dcf800a56fcc3644"
         },
         "arm64": {
-            "url": "https://github.com/digitalocean/doctl/releases/download/v1.95.0/doctl-1.95.0-windows-arm64.zip",
-            "hash": "6460d81a0201ddcd0a07490884b03dcbd9685f8bb3d11b651a259b7d41923b48"
+            "url": "https://github.com/digitalocean/doctl/releases/download/v1.96.0/doctl-1.96.0-windows-arm64.zip",
+            "hash": "93e887f0ae927ee246330dfcc5bc13a4ed3cc502d12bfd9a4dfde7808a34998a"
         }
     },
     "bin": "doctl.exe",

--- a/bucket/doctl.json
+++ b/bucket/doctl.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/digitalocean/doctl/releases/download/v1.95.0/doctl-1.95.0-windows-386.zip",
             "hash": "29dcdbfaffa4029e26bf2ea8d496c7b91025c57c4b67408fe6500cc355a32e28"
+        },
+        "arm64": {
+            "url": "https://github.com/digitalocean/doctl/releases/download/v1.95.0/doctl-1.95.0-windows-arm64.zip",
+            "hash": "6460d81a0201ddcd0a07490884b03dcbd9685f8bb3d11b651a259b7d41923b48"
         }
     },
     "bin": "doctl.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/digitalocean/doctl/releases/download/v$version/doctl-$version-windows-386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/digitalocean/doctl/releases/download/v$version/doctl-$version-windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
