### PR TITLE
vhs: Update to version 0.5.0

### DIFF
--- a/bucket/vhs.json
+++ b/bucket/vhs.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.4.0",
+    "version": "0.5.0",
     "homepage": "https://github.com/charmbracelet/vhs",
     "description": "A cli application that allows you to create terminal GIFs as code for integration testing and demoing your CLI tools (ex. neofetch/winfetch).",
     "license": "MIT",
@@ -9,12 +9,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/charmbracelet/vhs/releases/download/v0.4.0/vhs_0.4.0_Windows_x86_64.zip",
-            "hash": "0f2a4f4a5b3596f43895257e81067f9c7998c3f04856e4fc9f165c5d06f735bd"
+            "url": "https://github.com/charmbracelet/vhs/releases/download/v0.5.0/vhs_Windows_x86_64.zip",
+            "hash": "ddf272cdf91631c2b1c365a50b1ff35430fa19e6c17c20349a0ce7a1bf5b56b8"
         },
         "32bit": {
-            "url": "https://github.com/charmbracelet/vhs/releases/download/v0.4.0/vhs_0.4.0_Windows_i386.zip",
-            "hash": "bb8256de18be69f68ed84b4323eecc03ae4bd3e753128d1254306a7ca4e15811"
+            "url": "https://github.com/charmbracelet/vhs/releases/download/v0.4.0/vhs_Windows_i386.zip",
+            "hash": "5e72e974e4af26eb2b22741539fb3a4dace7cc2a6f74827c2f3822d10a6cdbc3"
         }
     },
     "bin": "vhs.exe",
@@ -22,10 +22,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/charmbracelet/vhs/releases/download/v$version/vhs_$version_Windows_x86_64.zip"
+                "url": "https://github.com/charmbracelet/vhs/releases/download/v$version/vhs_Windows_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/charmbracelet/vhs/releases/download/v$version/vhs_$version_Windows_i386.zip"
+                "url": "https://github.com/charmbracelet/vhs/releases/download/v$version/vhs_Windows_i386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Updates VHS to v0.5.0.

On v0.5, the archive names changed, so autoupdate is not working. This PR fixes the autoupdate URLs as well.

Relates to https://github.com/charmbracelet/vhs/issues/309

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
