### PR TITLE
gosec@2.16.0: Add arm64 architecture

### DIFF
--- a/bucket/gosec.json
+++ b/bucket/gosec.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/securego/gosec/releases/download/v2.16.0/gosec_2.16.0_windows_amd64.tar.gz",
             "hash": "56523c289bfc40f6a7b87d15ad14e425ce9436cb043c3e82e1c2764a5a1edc7e"
+        },
+        "arm64": {
+            "url": "https://github.com/securego/gosec/releases/download/v2.16.0/gosec_2.16.0_windows_arm64.tar.gz",
+            "hash": "724f6c1169790f86901f3c5d40fabd4d0de800c3173b70ca531b454330322efa"
         }
     },
     "bin": "gosec.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/securego/gosec/releases/download/v$version/gosec_$version_windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/securego/gosec/releases/download/v$version/gosec_$version_windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
