### PR TITLE
7zip: Revert to version 22.01 and Fix checkver

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -1,23 +1,23 @@
 {
-    "version": "23.00",
+    "version": "22.01",
     "description": "A multi-format file archiver with high compression ratios",
     "homepage": "https://www.7-zip.org/",
     "license": "LGPL-2.1-or-later",
     "notes": "Add 7-Zip as a context menu option by running: \"$dir\\install-context.reg\"",
     "architecture": {
         "64bit": {
-            "url": "https://www.7-zip.org/a/7z2300-x64.msi",
-            "hash": "4dc4f14ffef0691108dd93bd032248ac47dc5cc7f444699d6bb8721c1a77cd0b",
+            "url": "https://www.7-zip.org/a/7z2201-x64.msi",
+            "hash": "f4afba646166999d6090b5beddde546450262dc595dddeb62132da70f70d14ca",
             "extract_dir": "Files\\7-Zip"
         },
         "32bit": {
-            "url": "https://www.7-zip.org/a/7z2300.msi",
-            "hash": "98d68c5a30f06b2181a876d5a5800b35976f604f2d6f6f1fcaf243011d987163",
+            "url": "https://www.7-zip.org/a/7z2201.msi",
+            "hash": "a4913f98821e0da0c58cd3a7f2a59f1834b85b6ca6b3fdefa5454d6c3bbef54c",
             "extract_dir": "Files\\7-Zip"
         },
         "arm64": {
-            "url": "https://www.7-zip.org/a/7z2300-arm64.exe",
-            "hash": "5a498b6f3804e8cd04f3442efe614a9a5614d384e4ee6ca9f02924ad4223b5fa",
+            "url": "https://www.7-zip.org/a/7z2201-arm64.exe",
+            "hash": "700dea3e4012319a09ccadfce91cf090334cfe658d0bdc42204e77acbea1ef99",
             "pre_install": [
                 "$7zr = Join-Path $env:TMP '7zr.exe'",
                 "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
@@ -53,8 +53,7 @@
         "Formats"
     ],
     "checkver": {
-        "url": "https://www.7-zip.org/download.html",
-        "regex": "Download 7-Zip ([\\d.]+)"
+        "sourceforge": "sevenzip/7-Zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
23.00 is a beta version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
