### PR TITLE
zvm: add version 0.2.2

### DIFF
--- a/bucket/zvm.json
+++ b/bucket/zvm.json
@@ -1,0 +1,56 @@
+{
+    "homepage": "https://github.com/tristanisham/zvm",
+    "version": "0.2.2",
+    "description": "Zig Version Manager (zvm) is a tool for managing your Zig installs",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tristanisham/zvm/releases/download/v0.2.2/zvm-windows-amd64.zip",
+            "hash": "19489bb4c39812238a138bf4b596042b4eea27a13bec995e3cf6c1cfc93f247d",
+            "extract_dir": "zvm-windows-amd64"
+        },
+        "arm64": {
+            "url": "https://github.com/tristanisham/zvm/releases/download/v0.2.2/zvm-windows-arm64.zip",
+            "hash": "7ff4fdf4e9c8cd08fe8cc3c3ac2888aef1710ea82eeccea82c85382126ccc909",
+            "extract_dir": "zvm-windows-arm64"
+        }
+    },
+    "bin": "zvm.exe",
+    "checkver": {
+        "github": "https://github.com/tristanisham/zvm"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tristanisham/zvm/releases/download/v$version/zvm-windows-amd64.zip",
+                "extract_dir": "zvm-windows-amd64"
+            },
+            "arm64": {
+                "url": "https://github.com/tristanisham/zvm/releases/download/v$version/zvm-windows-arm64.zip",
+                "extract_dir": "zvm-windows-arm64"
+            }
+        }
+    },
+    "post_install": [
+        "if (Test-Path ~\\.zvm) {",
+        "   if ($null -eq (Get-Item ~\\.zvm).LinkType) {",
+        "       Rename-Item -Path ~\\.zvm -NewName ~\\.zvm.old -Force",
+        "   } else {",
+        "       Remove-Item -Path ~\\.zvm -Force",
+        "   }",
+        "}",
+        "New-Item -Path ~/.zvm -Target \"$dir\\data\" -ItemType Junction | Out-Null"
+    ],
+    "uninstaller": {
+        "script": [
+            "if ((Test-Path ~\\.zvm) -and ($null -ne (Get-Item ~\\.zvm).LinkType)) {",
+            "   Remove-Item -Path ~\\.zvm -Force",
+            "}",
+            "if (Test-Path ~\\.zvm.old) {",
+            "   Rename-Item -Path ~\\.zvm.old -NewName .zvm -Force",
+            "}"
+        ]
+    },
+    "persist": "data",
+    "env_add_path": "data\\bin"
+}


### PR DESCRIPTION
Adds zvm (Zig Version Manager): https://github.com/tristanisham/zvm

Notably I generated this manifest with ChatGPT 4. I find creating manifests a bit tedious, but reviewing and testing them is really simple. 

I gave ChatGPT the github repo address and the URLs of the release files and it happily generated a valid manifest. I asked it to generate the previous version with blank hashes so that I could use the autoupdate script. Worked perfectly 👌 All I had to update was the project description. 