### PR TITLE
golangci-lint@1.53.2: Add arm64 architecture

### DIFF
--- a/bucket/golangci-lint.json
+++ b/bucket/golangci-lint.json
@@ -13,6 +13,11 @@
             "url": "https://github.com/golangci/golangci-lint/releases/download/v1.53.2/golangci-lint-1.53.2-windows-386.zip",
             "hash": "a4ae07b2b9b96d1d08cd868e2d63abf461b5356bd7bae5d62fdbc98ee24c5e55",
             "extract_dir": "golangci-lint-1.53.2-windows-386"
+        },
+        "arm64": {
+            "url": "https://github.com/golangci/golangci-lint/releases/download/v1.53.2/golangci-lint-1.53.2-windows-arm64.zip",
+            "hash": "e0cf9da4dfdcf58322f10cee1ff8a64c817a0f26b2574cc16f30920cfaaa4e4f",
+            "extract_dir": "golangci-lint-1.53.2-windows-arm64"
         }
     },
     "bin": "golangci-lint.exe",
@@ -28,6 +33,10 @@
             "32bit": {
                 "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-386.zip",
                 "extract_dir": "golangci-lint-$version-windows-386"
+            },
+            "arm64": {
+                "url": "https://github.com/golangci/golangci-lint/releases/download/v$version/golangci-lint-$version-windows-arm64.zip",
+                "extract_dir": "golangci-lint-$version-windows-arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).