### PR TITLE
tektoncd-cli@0.31.1: Add arm64 architecture

### DIFF
--- a/bucket/tektoncd-cli.json
+++ b/bucket/tektoncd-cli.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/tektoncd/cli/releases/download/v0.31.1/tkn_0.31.1_Windows_x86_64.zip",
             "hash": "f9a8c39d0ee6cf03a2a092466b0578c8740a4bddfc1910ce3042868cfac891b1"
+        },
+        "arm64": {
+            "url": "https://github.com/tektoncd/cli/releases/download/v0.31.1/tkn_0.31.1_Windows_aarch64.zip",
+            "hash": "c800c04f0e5c39329e5f04567f55e0e83784414d1b43b2a0a57dcc93b85632af"
         }
     },
     "bin": "tkn.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/tektoncd/cli/releases/download/v$version/tkn_$version_Windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/tektoncd/cli/releases/download/v$version/tkn_$version_Windows_aarch64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
