### PR TITLE
upgrade 7-zip to 23.01

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -1,23 +1,23 @@
 {
-    "version": "22.01",
+    "version": "23.01",
     "description": "A multi-format file archiver with high compression ratios",
     "homepage": "https://www.7-zip.org/",
     "license": "LGPL-2.1-or-later",
     "notes": "Add 7-Zip as a context menu option by running: \"$dir\\install-context.reg\"",
     "architecture": {
         "64bit": {
-            "url": "https://www.7-zip.org/a/7z2201-x64.msi",
-            "hash": "f4afba646166999d6090b5beddde546450262dc595dddeb62132da70f70d14ca",
+            "url": "https://www.7-zip.org/a/7z2301-x64.msi",
+            "hash": "0ba639b6dacdf573d847c911bd147c6384381a54dac082b1e8c77bc73d58958b",
             "extract_dir": "Files\\7-Zip"
         },
         "32bit": {
-            "url": "https://www.7-zip.org/a/7z2201.msi",
-            "hash": "a4913f98821e0da0c58cd3a7f2a59f1834b85b6ca6b3fdefa5454d6c3bbef54c",
+            "url": "https://www.7-zip.org/a/7z2301.msi",
+            "hash": "b32e47f88d03dc29b5cb02c6ed07a7e48015f655346b62a3b32033c49ed9bb06",
             "extract_dir": "Files\\7-Zip"
         },
         "arm64": {
-            "url": "https://www.7-zip.org/a/7z2201-arm64.exe",
-            "hash": "700dea3e4012319a09ccadfce91cf090334cfe658d0bdc42204e77acbea1ef99",
+            "url": "https://www.7-zip.org/a/7z2301-arm64.exe",
+            "hash": "6fa4cb35cbebb0a46b8bbc22d1686a340e183c1f875d8b714efdc39af93debda",
             "pre_install": [
                 "$7zr = Join-Path $env:TMP '7zr.exe'",
                 "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
@@ -53,7 +53,8 @@
         "Formats"
     ],
     "checkver": {
-        "sourceforge": "sevenzip/7-Zip"
+        "url": "https://www.7-zip.org/download.html",
+        "regex": "Download 7-Zip ([\\d.]+) \\(\\d{4}-\\d{2}-\\d{2}\\)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This upgrades 7-zip to latest stable version 23.01.

It also changes the auto-update url back to the https://www.7-zip.org/ website using a regex that should exclude beta versions. Another reason is that the current stable version 23.01 has not been published (yet?) on https://sourceforge.net/projects/sevenzip/files/7-Zip/

When there are multiple versions,  download links appear like this on the website:
```
Download 7-Zip 22.01 (2022-07-15) for Windows:
Download 7-Zip 23.00 (beta) (2023-05-07) for Windows:
Download 7-Zip 19.00 (2019-02-21) for Windows:
Download 7-Zip 21.03 beta (2021-07-20) for Windows:
Download 7-Zip 21.02 alpha (2021-05-06) for Windows:
Download 7-Zip 21.00 alpha for Windows ARM64:
```

The updated regex will only match the stable versions 19.00 and 22.01.

For examples see older pages on:
- https://web.archive.org/web/20230530050739/https://www.7-zip.org/
- https://web.archive.org/web/20211101063125/https://www.7-zip.org/
- https://web.archive.org/web/20210531233125/https://www.7-zip.org/

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
