### PR TITLE
eksctl@0.146.0: Add arm64 architecture

### DIFF
--- a/bucket/eksctl.json
+++ b/bucket/eksctl.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/weaveworks/eksctl/releases/download/v0.146.0/eksctl_Windows_amd64.zip",
             "hash": "10c4c8bbc39bc78e9796cacbea0ffa5b09d8cbbb4e52d072f91fdd03d5f69070"
+        },
+        "arm64": {
+            "url": "https://github.com/weaveworks/eksctl/releases/download/v0.146.0/eksctl_Windows_arm64.zip",
+            "hash": "c9d62d43c553c07de6d6a4a010aece796f4abf2ff14591f55ee89a8dddf5a27b"
         }
     },
     "bin": "eksctl.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/weaveworks/eksctl/releases/download/v$version/eksctl_Windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/weaveworks/eksctl/releases/download/v$version/eksctl_Windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
