### PR TITLE
kaf@0.2.6: Add arm64 architecture

### DIFF
--- a/bucket/kaf.json
+++ b/bucket/kaf.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/birdayz/kaf/releases/download/v0.2.6/kaf_0.2.6_Windows_x86_64.tar.gz",
             "hash": "09f5dd0188e44013b51a8166cb069f7fd2f8a45611eca5c921bb632eadf43c8a"
+        },
+        "arm64": {
+            "url": "https://github.com/birdayz/kaf/releases/download/v0.2.6/kaf_0.2.6_Windows_arm64.tar.gz",
+            "hash": "5f12cc55a0de98a7b2c10b72c192661bee41fa561bf858f49901f2af88e3e6d0"
         }
     },
     "bin": "kaf.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/birdayz/kaf/releases/download/v$version/kaf_$version_Windows_x86_64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/birdayz/kaf/releases/download/v$version/kaf_$version_Windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).