### PR TITLE
Update go download url in go.json

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -1,19 +1,19 @@
 {
     "version": "1.20.5",
     "description": "An open source programming language that makes it easy to build simple, reliable, and efficient software.",
-    "homepage": "https://golang.org",
+    "homepage": "https://go.dev",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/go/go1.20.5.windows-amd64.zip",
+            "url": "https://go.dev/dl/go1.20.5.windows-amd64.zip",
             "hash": "c04a4ed73c3624d5b4c4f62e44a141549cc0bfd83a7492c31ca8b86b3752f077"
         },
         "32bit": {
-            "url": "https://dl.google.com/go/go1.20.5.windows-386.zip",
+            "url": "https://go.dev/dl/go1.20.5.windows-386.zip",
             "hash": "af6655ad9eff15baebb738b7b416f0f67037b1cd03036bfa4e8aede393fb7c44"
         },
         "arm64": {
-            "url": "https://dl.google.com/go/go1.20.5.windows-arm64.zip",
+            "url": "https://go.dev/dl/go1.20.5.windows-arm64.zip",
             "hash": "12473045a34e21574fee8f9a4ecfcff55be2b9d19663d9aaec659f9495212c73"
         }
     },
@@ -39,19 +39,19 @@
         "bin\\gofmt.exe"
     ],
     "checkver": {
-        "url": "https://golang.org/dl/",
+        "url": "https://go.dev/dl/",
         "regex": "go([\\d.]+)\\.windows-"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.google.com/go/go$version.windows-amd64.zip"
+                "url": "https://go.dev/dl/go$version.windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://dl.google.com/go/go$version.windows-386.zip"
+                "url": "https://go.dev/dl/go$version.windows-386.zip"
             },
             "arm64": {
-                "url": "https://dl.google.com/go/go$version.windows-arm64.zip"
+                "url": "https://go.dev/dl/go$version.windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
The official home page of the go language has been changed to [https://go.dev](https://go.dev), and this pr has modified the original home page and download address.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
