### PR TITLE
dvc: update to 3.4 and new download URL

### DIFF
--- a/bucket/dvc.json
+++ b/bucket/dvc.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.1.0",
+    "version": "3.4.0",
     "description": "Data & models versioning for ML projects, make them shareable and reproducible",
     "homepage": "https://dvc.org/",
     "license": "Apache-2.0",
-    "url": "https://github.com/iterative/dvc/releases/download/3.1.0/dvc-3.1.0.exe",
-    "hash": "5d20788ee8204dce987fc20dd2c3bfb9b24991ef8cc65a297944acd359801d1d",
+    "url": "https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-3.4.0.exe",
+    "hash": "c754d088928cfe0faa21e18be271a6832ada5698527b8c77cab0f07f78a01686",
     "innosetup": true,
     "bin": "dvc.exe",
     "checkver": {
         "github": "https://github.com/iterative/dvc"
     },
     "autoupdate": {
-        "url": "https://github.com/iterative/dvc/releases/download/$version/dvc-$version.exe"
+        "url": "https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-$version.exe"
     }
 }


### PR DESCRIPTION
The scoop autoupdate looks at an outdated link.

Some sleuthing brought me to https://github.com/iterative/dvc-exe/blob/main/upload.py and that confirms that the AWS S3 bucket https link is used in future as well, see the Windows specific download link on homepage


- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
