### PR TITLE
DVC: Follow-up upgrade 3.5.x

### DIFF
--- a/bucket/dvc.json
+++ b/bucket/dvc.json
@@ -7,10 +7,8 @@
     "hash": "c754d088928cfe0faa21e18be271a6832ada5698527b8c77cab0f07f78a01686",
     "innosetup": true,
     "bin": "dvc.exe",
-    "checkver": {
-        "github": "https://github.com/iterative/dvc"
-    },
+    "checker": "\"/download/win/dvc-([^\"])*\"",
     "autoupdate": {
-        "url": "https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-$version.exe"
+        "url": "https://dvc.org/download/win/dvc-$version"
     }
 }

--- a/bucket/dvc.json
+++ b/bucket/dvc.json
@@ -1,13 +1,13 @@
 {
-    "version": "3.4.0",
+    "version": "3.5.0",
     "description": "Data & models versioning for ML projects, make them shareable and reproducible",
     "homepage": "https://dvc.org/",
     "license": "Apache-2.0",
-    "url": "https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-3.4.0.exe",
-    "hash": "c754d088928cfe0faa21e18be271a6832ada5698527b8c77cab0f07f78a01686",
+    "url": "https://dvc.org/download/win/dvc-3.5.0",
+    "hash": "6fdd4f35e126f83289f2ef39e44a3a971a77a74f39d618b97c3215741b4a5b27",
     "innosetup": true,
     "bin": "dvc.exe",
-    "checker": "\"/download/win/dvc-([^\"])*\"",
+    "checkver": "\"/download/win/dvc-([^\"]+)\"",
     "autoupdate": {
         "url": "https://dvc.org/download/win/dvc-$version"
     }


### PR DESCRIPTION
After my last PR https://github.com/ScoopInstaller/Main/pull/4931 I realise that the release process/synchronization for Windows Installers side isn't as mature as I assumed. So I raised an issue https://github.com/iterative/dvc-exe/issues/100 to round up version 3.5.1 and implemented their recommendations.

Please take a look, I'll let it sit for a day or two to see how things actually roll out on DVC's side.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
