### PR TITLE
helix: Scooping config file path

### DIFF
--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -16,7 +16,9 @@
     "pre_install": [
         "# NOTE: Remove the migration script after 6 months (2024-01-22)",
         "if (Test-Path \"$env:APPDATA\\helix\\config.toml\") {",
-        "  info 'Migrating config file...'"
+        "  info 'Migrating config file...'",
+        "  info \"Previous config patch: '$env:APPDATA\\helix\\config.toml'\"",
+        "  info \"Current config patch: '$persist_dir\\config.toml'\"",
         "  Copy-Item \"$env:APPDATA\\helix\\config.toml\" \"$persist_dir\\config.toml\"",
         "}",
         "# END"

--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -15,8 +15,8 @@
     },
     "pre_install": [
         "# NOTE: Remove the migration script after 6 months (2024-01-22)",
-        "info 'Migrating config file...'",
         "if (Test-Path \"$env:APPDATA\\helix\\config.toml\") {",
+        "  info 'Migrating config file...'"
         "  Copy-Item \"$env:APPDATA\\helix\\config.toml\" \"$persist_dir\\config.toml\"",
         "}",
         "# END"

--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -3,6 +3,9 @@
     "description": "A post-modern modal text editor",
     "homepage": "https://helix-editor.com",
     "license": "MPL-2.0",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/helix-editor/helix/releases/download/23.05/helix-23.05-x86_64-windows.zip",
@@ -10,6 +13,14 @@
             "extract_dir": "helix-23.05-x86_64-windows"
         }
     },
+    "pre_install": [
+        "# NOTE: Remove the migration script after 6 months (2024-01-22)",
+        "info 'Migrating config file...'",
+        "if (Test-Path \"$env:APPDATA\\helix\\config.toml\") {",
+        "  Copy-Item \"$env:APPDATA\\helix\\config.toml\" \"$persist_dir\\config.toml\"",
+        "}",
+        "# END"
+    ],
     "bin": [
         [
             "hx.exe",

--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -15,10 +15,11 @@
     },
     "pre_install": [
         "# NOTE: Remove the migration script after 6 months (2024-01-22)",
-        "if (Test-Path \"$env:APPDATA\\helix\\config.toml\") {",
+        "if ((Test-Path \"$env:APPDATA\\helix\\config.toml\") -and (!(Test-Path \"$persist_dir\\config.toml\"))) {",
         "  info 'Migrating config file...'",
-        "  info \"Previous config patch: '$env:APPDATA\\helix\\config.toml'\"",
-        "  info \"Current config patch: '$persist_dir\\config.toml'\"",
+        "  info \"Previous config path: '$env:APPDATA\\helix\\config.toml'\"",
+        "  info \"Current config path: '$persist_dir\\config.toml'\"",
+        "  ensure \"$persist_dir\"",
         "  Copy-Item \"$env:APPDATA\\helix\\config.toml\" \"$persist_dir\\config.toml\"",
         "}",
         "# END"

--- a/bucket/helix.json
+++ b/bucket/helix.json
@@ -11,10 +11,15 @@
         }
     },
     "bin": [
-        "hx.exe",
         [
             "hx.exe",
-            "helix"
+            "hx",
+            "--config \"$persist_dir\\config.toml\""
+        ],
+        [
+            "hx.exe",
+            "helix",
+            "--config \"$persist_dir\\config.toml\""
         ]
     ],
     "checkver": {


### PR DESCRIPTION
I added the "--config" parameter to the Helix shims to point to a config file that can be stored in the persis directory.

Closes #4948

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
