### PR TITLE
updatecli: add to path, remove shim

### DIFF
--- a/bucket/updatecli.json
+++ b/bucket/updatecli.json
@@ -13,13 +13,7 @@
             "hash": "fc7dc1cb60deeb194f0ba5bdec675f7695e97ca7a119742307e6b308a6cba69b"
         }
     },
-    "bin": [
-        "updatecli.exe",
-        [
-            "updatecli.exe",
-            "upd8cli"
-        ]
-    ],
+    "env_add_path": ".",
     "checkver": {
         "github": "https://github.com/updatecli/updatecli"
     },


### PR DESCRIPTION
# Motivation

>updatecli when added as a shim does not execute.

Fixes #4992

```
psh ❯ scoop install updatecli
Installing 'updatecli' (0.55.0) [64bit] from main bucket
Loading updatecli_Windows_x86_64.zip from cache.
Checking hash of updatecli_Windows_x86_64.zip ... ok.
Extracting updatecli_Windows_x86_64.zip ... done.
Linking ~\scoop\apps\updatecli\current => ~\scoop\apps\updatecli\0.55.0
Creating shim for 'updatecli'.
Creating shim for 'upd8cli'.
psh ❯ .\updatecli.exe
... At this point a elevated command prompt windows opens, if you click yes, then updatecli runs in another window; if you click no then...
ResourceUnavailable: Program 'updatecli.exe' failed to run: An error occurred trying to start process 'C:\Users\Lewin.Chan\scoop\shims\updatecli.exe' with working directory 'C:\Users\Lewin.Chan\scoop\shims'. The operation was canceled by the user.At line:1 char:1
+ .\updatecli.exe
+ ~~~~~~~~~~~~~~~.
```

```
EELONLC ~/scoop/shims took 3s
psh ❯ cd ..\apps\updatecli\current\

EELONLC apps/updatecli/current
psh ❯ .\updatecli.exe version

VERSION

Application:    0.55.0
Golang     :    1.20.6 linux/amd64
Build Time :    2023-07-30T16:13:20Z

```

The problem is the shim; so this change simply "adds" scoop/apps/updatecli/current to the path rather than creating a shim.

I installed this a while ago in my personal bucket :- https://github.com/quotidian-ennui/personal-scoop-bucket/blob/main/bucket/updatecli.json as a path enabled item back in February. Since it has been added to the main bucket, I wanted to retire my variant.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
