### PR TITLE
gibo: Update to version 3.0.5

### DIFF
--- a/bucket/gibo.json
+++ b/bucket/gibo.json
@@ -12,7 +12,7 @@
         "regex": "/releases/tag/(?:v|V)?([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/simonwhitaker/gibo/archive/$version.zip",
+        "url": "https://github.com/simonwhitaker/gibo/archive/v$version.zip",
         "extract_dir": "gibo-$version"
     }
 }

--- a/bucket/gibo.json
+++ b/bucket/gibo.json
@@ -1,18 +1,38 @@
 {
     "version": "3.0.5",
-    "description": "gibo (short for .gitignore boilerplates) is a shell script to help you easily access .gitignore boilerplates from github.com/github/gitignore.",
+    "description": "gibo (short for .gitignore boilerplates) is a shell script to help you easily access .gitignore boilerplates from github.com/github/gitignore",
     "homepage": "https://github.com/simonwhitaker/gibo",
     "license": "Unlicense",
-    "url": "https://github.com/simonwhitaker/gibo/archive/v3.0.5.zip",
-    "hash": "f93d78632441e23f740e6028bf5a0c2fc452a3230a8838cb9a79ed0b0638fb12",
-    "extract_dir": "gibo-v3.0.5",
-    "bin": "gibo.exe",
-    "checkver": {
-        "url": "https://github.com/simonwhitaker/gibo/tags",
-        "regex": "/releases/tag/(?:v|V)?([\\d.]+)"
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/simonwhitaker/gibo/releases/download/v3.0.5/gibo_Windows_x86_64.zip",
+            "hash": "f21fdb08ab2de03bb1acf38365ffe355373fc0f3b0e3e9e927a015428ed328c6"
+        },
+        "32bit": {
+            "url": "https://github.com/simonwhitaker/gibo/releases/download/v3.0.5/gibo_Windows_i386.zip",
+            "hash": "fb84fe89d1729c6b7beb007a463691985a5d55baf0f720f26a13c9b5b0a0d83e"
+        },
+        "arm64": {
+            "url": "https://github.com/simonwhitaker/gibo/releases/download/v3.0.5/gibo_Windows_arm64.zip",
+            "hash": "92728f5a9ef53493a7a80cd41f19427f88a4fc023b67f037f0c754c3f69514e1"
+        }
     },
+    "bin": "gibo.exe",
+    "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/simonwhitaker/gibo/archive/v$version.zip",
-        "extract_dir": "gibo-$version"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/simonwhitaker/gibo/releases/download/v$version/gibo_Windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/simonwhitaker/gibo/releases/download/v$version/gibo_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/simonwhitaker/gibo/releases/download/v$version/gibo_Windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.windows.txt"
+        }
     }
 }

--- a/bucket/gibo.json
+++ b/bucket/gibo.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.2.8",
+    "version": "3.0.5",
     "description": "gibo (short for .gitignore boilerplates) is a shell script to help you easily access .gitignore boilerplates from github.com/github/gitignore.",
     "homepage": "https://github.com/simonwhitaker/gibo",
     "license": "Unlicense",
-    "url": "https://github.com/simonwhitaker/gibo/archive/2.2.8.zip",
-    "hash": "51357774a34f24a388cd93d200dfa32f6792afff02a427b54e297a969c482748",
-    "extract_dir": "gibo-2.2.8",
-    "bin": "gibo.bat",
+    "url": "https://github.com/simonwhitaker/gibo/archive/v3.0.5.zip",
+    "hash": "f93d78632441e23f740e6028bf5a0c2fc452a3230a8838cb9a79ed0b0638fb12",
+    "extract_dir": "gibo-v3.0.5",
+    "bin": "gibo.exe",
     "checkver": {
         "url": "https://github.com/simonwhitaker/gibo/tags",
         "regex": "/releases/tag/(?:v|V)?([\\d.]+)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

v3.0 was a re-write in Go, hence we now need `gibo.exe` instead of `gibo.bat` on Windows. The version tag now also has a `v` prefix (e.g. `v3.0.5` compared with `2.2.8`).

Disclaimer: I don't have access to a Windows PC, so haven't been able to test this.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
