### PR TITLE
powershell-beautifier: Add version 1.2.5

### DIFF
--- a/bucket/powershell-beautifier.json
+++ b/bucket/powershell-beautifier.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.2.5",
+    "description": "A whitespace reformatter and code cleaner for Windows PowerShell and PowerShell Core",
+    "homepage": "https://github.com/DTW-DanWard/PowerShell-Beautifier",
+    "license": "MIT",
+    "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-beautifier.1.2.5.nupkg",
+    "hash": "3ec3d76a2b303136bc73f91d278f03b748cf5cc6aa6287aa3ea180adf39c6ff3",
+    "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content_Types*.xml\" -Recurse",
+    "psmodule": {
+        "name": "PowerShell-Beautifier"
+    },
+    "checkver": {
+        "url": "https://www.powershellgallery.com/packages/PowerShell-Beautifier",
+        "regex": "<h2>([\\d\\.]+)</h2>"
+    },
+    "autoupdate": {
+        "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-beautifier.$version.nupkg"
+    }
+}


### PR DESCRIPTION
This PR adds the PowerShell-Beautifier module, a whitespace reformatter and code cleaner for Windows PowerShell and PowerShell Core that is compatible with all OSes.

This change was previously raised in ScoopInstaller/Extras#11652, but is being raised into Main as suggested by @HUMORCE.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
