### PR TITLE
go-feature-flag: Add version 1.14.1

### DIFF
--- a/bucket/go-feature-flag.json
+++ b/bucket/go-feature-flag.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.14.1",
+    "description": "Simple, complete, and lightweight feature flag solution",
+    "homepage": "https://gofeatureflag.org",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_i386.tar.gz",
+            "bin": [
+                "go-feature-flag.exe"
+            ],
+            "hash": "123a8933c1282537799f944b794d1173fc4a5564590efb9249a5228fa5a60690"
+        },
+        "64bit": {
+            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_x86_64.tar.gz",
+            "bin": [
+                "go-feature-flag.exe"
+            ],
+            "hash": "01995a43ed04c061b7efb8b64ee4c4a3ad9757b1a362df79c9064327929f1073"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz",
+                "bin": [
+                    "go-feature-flag.exe"
+                ]
+            },
+            "64bit": {
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz",
+                "bin": [
+                    "go-feature-flag.exe"
+                ]
+            }
+        }
+    }
+}

--- a/bucket/go-feature-flag.json
+++ b/bucket/go-feature-flag.json
@@ -4,35 +4,37 @@
     "homepage": "https://gofeatureflag.org",
     "license": "MIT",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_i386.tar.gz",
-            "bin": [
-                "go-feature-flag.exe"
-            ],
-            "hash": "123a8933c1282537799f944b794d1173fc4a5564590efb9249a5228fa5a60690"
-        },
         "64bit": {
             "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_x86_64.tar.gz",
-            "bin": [
-                "go-feature-flag.exe"
-            ],
             "hash": "01995a43ed04c061b7efb8b64ee4c4a3ad9757b1a362df79c9064327929f1073"
+        },
+        "32bit": {
+            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_i386.tar.gz",
+            "hash": "123a8933c1282537799f944b794d1173fc4a5564590efb9249a5228fa5a60690"
+        },
+        "arm64": {
+            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_arm64.tar.gz",
+            "hash": "685705e0b619f11627ababef107ac2f596999b6277cbad7238027fc7a1ca3fe3"
         }
+    },
+    "bin": "go-feature-flag.exe",
+    "checkver": {
+        "github": "https://github.com/thomaspoignant/go-feature-flag"
     },
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz",
-                "bin": [
-                    "go-feature-flag.exe"
-                ]
-            },
             "64bit": {
-                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz",
-                "bin": [
-                    "go-feature-flag.exe"
-                ]
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_arm64.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/go-feature-flag.json
+++ b/bucket/go-feature-flag.json
@@ -41,7 +41,11 @@
             ]
         }
     },
-    "bin": "go-feature-flag.exe",
+    "bin": [
+        "go-feature-flag.exe",
+        "go-feature-flag-migration-cli.exe",
+        "go-feature-flag-lint.exe"
+    ],
     "checkver": {
         "github": "https://github.com/thomaspoignant/go-feature-flag"
     },

--- a/bucket/go-feature-flag.json
+++ b/bucket/go-feature-flag.json
@@ -5,16 +5,40 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_x86_64.tar.gz",
-            "hash": "01995a43ed04c061b7efb8b64ee4c4a3ad9757b1a362df79c9064327929f1073"
+            "url": [
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_x86_64.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag-migration-cli_1.14.1_Windows_x86_64.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag-lint_1.14.1_Windows_x86_64.tar.gz"
+            ],
+            "hash": [
+                "01995a43ed04c061b7efb8b64ee4c4a3ad9757b1a362df79c9064327929f1073",
+                "1d87cd12c0f5577511d33542b620da8b8d743d91d5f2c0a0c818b032614362a5",
+                "f99eb6b4ea6376359fa64461e25595e7faf946012e9a207da9a44e034f652f4d"
+            ]
         },
         "32bit": {
-            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_i386.tar.gz",
-            "hash": "123a8933c1282537799f944b794d1173fc4a5564590efb9249a5228fa5a60690"
+            "url": [
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_i386.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag-migration-cli_1.14.1_Windows_i386.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag-lint_1.14.1_Windows_i386.tar.gz"
+            ],
+            "hash":[
+                "123a8933c1282537799f944b794d1173fc4a5564590efb9249a5228fa5a60690",
+                "21fd762d20687efea491686303f93316f78af349710cf9cb26c38805d8126d39",
+                "227c91af4e5e28c03c4f5ba96461c9d8490aa98fcb561ccdfea2ba88718eadf3"
+            ]
         },
         "arm64": {
-            "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_arm64.tar.gz",
-            "hash": "685705e0b619f11627ababef107ac2f596999b6277cbad7238027fc7a1ca3fe3"
+            "url": [
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag_1.14.1_Windows_arm64.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag-migration-cli_1.14.1_Linux_arm64.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.14.1/go-feature-flag-lint_1.14.1_Windows_arm64.tar.gz"
+            ],
+            "hash": [
+                "685705e0b619f11627ababef107ac2f596999b6277cbad7238027fc7a1ca3fe3",
+                "022c2cf68d3808e7e687035854918c5d9faefb70c8592b75b037e37481b37de7",
+                "934e5588a1761a5e2d2da990a91aadee1d9c4f50bf33e5896c3ad13992cbae3e"
+            ]
         }
     },
     "bin": "go-feature-flag.exe",
@@ -24,13 +48,25 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz"
+                "url": [
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz",
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-migration-cli_$version_Windows_x86_64.tar.gz",
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-lint_$version_Windows_x86_64.tar.gz"
+                ]
             },
             "32bit": {
-                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz"
+                "url": [
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz",
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-migration-cli_$version_Windows_i386.tar.gz",
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-lint_$version_Windows_i386.tar.gz"
+                ]
             },
             "arm64": {
-                "url": "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_arm64.tar.gz"
+                "url": [
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_arm64.tar.gz",
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-migration-cli_$version_Linux_arm64.tar.gz",
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-lint_$version_Windows_arm64.tar.gz"
+                ]
             }
         },
         "hash": {


### PR DESCRIPTION
Adding GO Feature Flag inside the scoop extra bucket.

fixes https://github.com/thomaspoignant/go-feature-flag/issues/817

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
