### PR TITLE
Add support for *_HOME variables in rustup.

### DIFF
--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -40,7 +40,7 @@
             "if ($null -eq [Environment]::GetEnvironmentVariable('RUSTUP_HOME', 'Process')) {",
             "   setx RUSTUP_HOME \"$persist_dir\\.rustup\"",
             "}",
-            "setx PATH \"%PATH%;%CARGO_HOME%\\bin\""
+            "setx Path \"$env:Path;$env:CARGO_HOME\\bin\""
     ],
     "persist": [
         ".cargo",

--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -24,16 +24,24 @@
     },
     "installer": {
         "script": [
-            "[Environment]::SetEnvironmentVariable('CARGO_HOME', \"$persist_dir\\.cargo\", 'Process')",
-            "[Environment]::SetEnvironmentVariable('RUSTUP_HOME', \"$persist_dir\\.rustup\", 'Process')",
+            "if ($null -eq [Environment]::GetEnvironmentVariable('CARGO_HOME', 'Process')) {",
+            "   [Environment]::SetEnvironmentVariable('CARGO_HOME', \"$persist_dir\\.cargo\", 'Process')",
+            "}",
+            "if ($null -eq [Environment]::GetEnvironmentVariable('RUSTUP_HOME', 'Process')) {",
+            "   [Environment]::SetEnvironmentVariable('RUSTUP_HOME', \"$persist_dir\\.rustup\", 'Process')",
+            "}",
             "Invoke-ExternalCommand -Path \"$dir\\rustup-init.exe\" -Args @('-y', '--no-modify-path') | Out-Null"
         ]
     },
-    "env_add_path": ".cargo\\bin",
-    "env_set": {
-        "CARGO_HOME": "$persist_dir\\.cargo",
-        "RUSTUP_HOME": "$persist_dir\\.rustup"
-    },
+    "post_install" :[
+            "if ($null -eq [Environment]::GetEnvironmentVariable('CARGO_HOME', 'Process')) {",
+            "   setx CARGO_HOME \"$persist_dir\\.cargo\"",
+            "}",
+            "if ($null -eq [Environment]::GetEnvironmentVariable('RUSTUP_HOME', 'Process')) {",
+            "   setx RUSTUP_HOME \"$persist_dir\\.rustup\"",
+            "}",
+            "setx PATH \"%PATH%;%CARGO_HOME%\\bin\""
+    ],
     "persist": [
         ".cargo",
         ".rustup"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Only set CARGO_HOME and RUSTUP_HOME environment variables if not set already.
If vars are set, install to those location.

Closes #5013 


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
