### PR TITLE
python@3.11.4: revert accidental change of env_add_path

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -84,7 +84,7 @@
         ]
     ],
     "env_add_path": [
-        "$persist_dir\\Scripts",
+        "Scripts",
         "."
     ],
     "persist": [


### PR DESCRIPTION
Revert accidental commit afb001c8f526ffd0d77fb430937f82924c582d98 changing the PATH entry for Scripts to an inorrect directory, causing pip.exe, among others, to not be found anymore.

Closes #5025 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
