### PR TITLE
(chore): Update Jenkins Java recommendations for Java 17

### DIFF
--- a/bucket/jenkins-lts.json
+++ b/bucket/jenkins-lts.json
@@ -4,8 +4,8 @@
     "homepage": "https://www.jenkins.io",
     "license": "MIT",
     "suggest": {
-        "Java 8": "java/oraclejre8",
-        "Java 11": "java/openjdk11"
+        "Java 11": "java/openjdk11",
+        "Java 17": "java/openjdk17"
     },
     "url": "https://get.jenkins.io/war-stable/2.401.3/jenkins.war#/jenkins.jar",
     "hash": "a798a0c5481a8ffb0320d9121f6cf49dc575c369028daae17a4dd398b69e000d",

--- a/bucket/jenkins.json
+++ b/bucket/jenkins.json
@@ -4,8 +4,8 @@
     "homepage": "https://www.jenkins.io",
     "license": "MIT",
     "suggest": {
-        "Java 8": "java/oraclejre8",
-        "Java 11": "java/openjdk11"
+        "Java 11": "java/openjdk11",
+        "Java 17": "java/openjdk17"
     },
     "url": "https://get.jenkins.io/war/2.419/jenkins.war#/jenkins.jar",
     "hash": "895a90dd5929a38c8cc8c0342478d27a6e01470cd7e8da8c4ae51f26aa1bdf85",


### PR DESCRIPTION
Jenkins does no longer support Java 8, therefore I replaced the suggestion with Java 17, because Jenkins operates on Java 11 and 17 nowadays.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
