### PR TITLE
Ko: Add version 0.14.1

### DIFF
--- a/bucket/ko.json
+++ b/bucket/ko.json
@@ -1,7 +1,6 @@
 {
     "version": "0.14.1",
-    "bin": "ko.exe",
-    "description": "ko is a simple, fast container image builder for Go applications.",
+    "description": "A simple, fast container image builder for Go applications",
     "homepage": "https://ko.build/",
     "license": "Apache-2.0",
     "architecture": {
@@ -18,6 +17,7 @@
             "hash": "2d3ae938efdc0215b8717f8ea79e6247af8e1298a47cd686adbfbda0f315b107"
         }
     },
+    "bin": "ko.exe",
     "checkver": {
         "github": "https://github.com/ko-build/ko/"
     },
@@ -34,8 +34,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.txt",
-            "regex": "$sha256  $basename\\n"
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/ko.json
+++ b/bucket/ko.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.14.1",
+    "bin": "ko.exe",
+    "description": "ko is a simple, fast container image builder for Go applications.",
+    "homepage": "https://ko.build/",
+    "license": "Apache-2.0",
+
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ko-build/ko/releases/download/v0.14.1/ko_0.14.1_Windows_x86_64.tar.gz",
+            "hash": "232d418380d3181b67d30967e3528adb3d924d85b42d2cde874db1ab33c9f8d1"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/ko-build/ko"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kubernetes/kops/releases/download/v$version/ko_$version_Windows_x86_64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256\\s+$basename"
+        }
+    }
+}

--- a/bucket/ko.json
+++ b/bucket/ko.json
@@ -4,7 +4,6 @@
     "description": "ko is a simple, fast container image builder for Go applications.",
     "homepage": "https://ko.build/",
     "license": "Apache-2.0",
-
     "architecture": {
         "64bit": {
             "url": "https://github.com/ko-build/ko/releases/download/v0.14.1/ko_0.14.1_Windows_x86_64.tar.gz",
@@ -12,17 +11,17 @@
         }
     },
     "checkver": {
-        "github": "https://github.com/ko-build/ko"
+        "github": "https://github.com/ko-build/ko/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kubernetes/kops/releases/download/v$version/ko_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/ko-build/ko/releases/download/v$version/ko_$version_Windows_x86_64.tar.gz"
             }
         },
         "hash": {
             "url": "$baseurl/checksums.txt",
-            "regex": "$sha256\\s+$basename"
+            "regex": "$sha256  $basename\\n"
         }
     }
 }

--- a/bucket/ko.json
+++ b/bucket/ko.json
@@ -8,6 +8,14 @@
         "64bit": {
             "url": "https://github.com/ko-build/ko/releases/download/v0.14.1/ko_0.14.1_Windows_x86_64.tar.gz",
             "hash": "232d418380d3181b67d30967e3528adb3d924d85b42d2cde874db1ab33c9f8d1"
+        },
+        "32bit": {
+            "url": "https://github.com/ko-build/ko/releases/download/v0.14.1/ko_0.14.1_Windows_i386.tar.gz",
+            "hash": "33ac30905255fb915d326f74a19493363d4568a38f3f7704b3666f77939ae36d"
+        },
+        "arm64": {
+            "url": "https://github.com/ko-build/ko/releases/download/v0.14.1/ko_0.14.1_Windows_arm64.tar.gz",
+            "hash": "2d3ae938efdc0215b8717f8ea79e6247af8e1298a47cd686adbfbda0f315b107"
         }
     },
     "checkver": {
@@ -17,6 +25,12 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ko-build/ko/releases/download/v$version/ko_$version_Windows_x86_64.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/ko-build/ko/releases/download/v$version/ko_$version_Windows_i386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/ko-build/ko/releases/download/v$version/ko_$version_Windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This pull requests adds Ko, a software to easily create multi-arch container images for Go binary files. Ko is a CNCF sandbox project and is a great tool for DevOps and developers.

Closes #5031 


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
