### PR TITLE
powershell-yaml: Add version 0.4.7

### DIFF
--- a/bucket/powershell-yaml.json
+++ b/bucket/powershell-yaml.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.4.7",
+    "description": "PowerShell module for serializing and deserializing YAML",
+    "homepage": "https://github.com/cloudbase/powershell-yaml",
+    "license": "MIT",
+    "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-yaml.0.4.7.nupkg",
+    "hash": "8e5782012dd82928a8b79dfaef8be511f4ce34ac50cafaa469f17596f53c6ac2",
+    "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content_Types*.xml\" -Recurse",
+    "psmodule": {
+        "name": "powershell-yaml"
+    },
+    "checkver": {
+        "url": "https://www.powershellgallery.com/packages/powershell-yaml",
+        "regex": "<h2>([\\d\\.]+)</h2>"
+    },
+    "autoupdate": {
+        "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-yaml.$version.nupkg"
+    }
+}


### PR DESCRIPTION
This PR adds the powershell-yaml module, a PowerShell module for serializing and deserializing YAML.

For more on this module, check out the repo [cloudbase/powershell-yaml](https://github.com/cloudbase/powershell-yaml).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
