### PR TITLE
circleci-cli: Add arm64 version

### DIFF
--- a/bucket/circleci-cli.json
+++ b/bucket/circleci-cli.json
@@ -8,6 +8,11 @@
             "url": "https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.28995/circleci-cli_0.1.28995_windows_amd64.zip",
             "hash": "01629f289723bee2dd61b86bf5055633c8e4b8ae9385b4b3eaf9205750054225",
             "extract_dir": "circleci-cli_0.1.28995_windows_amd64"
+        },
+        "arm64": {
+            "url": "https://github.com/CircleCI-Public/circleci-cli/releases/download/v0.1.28995/circleci-cli_0.1.28995_windows_arm64.zip",
+            "hash": "d8ae4c68f5e3ce868fa632d6c155c83447104d269bfc06317c34a489880a7729",
+            "extract_dir": "circleci-cli_0.1.28995_windows_arm64"
         }
     },
     "bin": "circleci.exe",
@@ -19,6 +24,10 @@
             "64bit": {
                 "url": "https://github.com/CircleCI-Public/circleci-cli/releases/download/v$version/circleci-cli_$version_windows_amd64.zip",
                 "extract_dir": "circleci-cli_$version_windows_amd64"
+            },
+            "arm64": {
+                "url": "https://github.com/CircleCI-Public/circleci-cli/releases/download/v$version/circleci-cli_$version_windows_arm64.zip",
+                "extract_dir": "circleci-cli_$version_windows_arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
