### PR TITLE
(chore): Windows README for rdiff-backup is no longer obsolete

### DIFF
--- a/bucket/rdiff-backup.json
+++ b/bucket/rdiff-backup.json
@@ -3,7 +3,7 @@
     "description": "Reverse differential backup tool, over a network or locally",
     "homepage": "https://rdiff-backup.net",
     "license": "GPL-2.0-only",
-    "notes": "Please refer to https://rdiff-backup.net/Windows-README.html for (possibly outdated) Windows specific documentation.",
+    "notes": "Please refer to https://rdiff-backup.net/Windows-README.html for Windows specific documentation.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/rdiff-backup/rdiff-backup/releases/download/v2.2.6/rdiff-backup-2.2.6.win64exe.zip",


### PR DESCRIPTION
This PR removes the `(possibly outdated)` in notes, which was added in #4424. The maintainer has refreshed the documentation in https://github.com/rdiff-backup/rdiff-backup/pull/879, so it's no longer obsolete.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/rdiff-backup/rdiff-backup/pull/879

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md), but this is so trivial so I didn't create a new issue.
