### PR TITLE
typst: Update to version 0.8.0

### DIFF
--- a/bucket/typst.json
+++ b/bucket/typst.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "A markup-based typesetting system for the sciences.",
     "homepage": "https://typst.app",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/typst/typst/releases/download/v0.7.0/typst-x86_64-pc-windows-msvc.zip",
-            "hash": "9fb7fe840a031a785018dd3d2f43e851bf436bf89ce3dae1b5a87033d2ba02d6"
+            "url": "https://github.com/typst/typst/releases/download/v0.8.0/typst-x86_64-pc-windows-msvc.zip",
+            "hash": "a0b9cdb6f474af6c90d9909e2a6c822df63e6fd1f1376d61498f10e60cc5128f"
         }
     },
     "extract_dir": "typst-x86_64-pc-windows-msvc",


### PR DESCRIPTION
Bumping `typst` to 0.8.0


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
