### PR TITLE
(chore): `BBDown.data` (login data) should be kept as persist

### DIFF
--- a/bucket/bbdown.json
+++ b/bucket/bbdown.json
@@ -15,6 +15,7 @@
         }
     },
     "bin": "BBDown.exe",
+    "persist": "BBDown.data",
     "checkver": {
         "url": "https://api.github.com/repos/nilaoda/BBDown/releases",
         "jsonpath": "$[0].assets",


### PR DESCRIPTION
`bbdown` 's `BBDown.data` file stores BiliBili login Cookies which is created in `bbdown login`, and should be kept as persist.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
