### PR TITLE
monero-cli: Fix `extract_dir` and `autoupdate`

### DIFF
--- a/bucket/monero-cli.json
+++ b/bucket/monero-cli.json
@@ -7,12 +7,12 @@
         "64bit": {
             "url": "https://dlsrc.getmonero.org/cli/monero-win-x64-v0.18.2.2.zip",
             "hash": "964c13f5d596289d2ab8ba9e265ff1e255a06269cf8fd216187d7b77a11c1371",
-            "extract_dir": "monero-x86_64-w64-mingw32"
+            "extract_dir": "monero-x86_64-w64-mingw32-v0.18.2.2"
         },
         "32bit": {
             "url": "https://dlsrc.getmonero.org/cli/monero-win-x86-v0.18.2.2.zip",
             "hash": "b7366408e74b321aa5fa3993187a862d93dc41cbc43dc585f82fc17a4c423ded",
-            "extract_dir": "monero-i686-w64-mingw32"
+            "extract_dir": "monero-i686-w64-mingw32-v0.18.2.2"
         }
     },
     "bin": [
@@ -41,10 +41,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dlsrc.getmonero.org/cli/monero-win-x64-v$version.zip"
+                "url": "https://dlsrc.getmonero.org/cli/monero-win-x64-v$version.zip",
+                "extract_dir": "monero-x86_64-w64-mingw32-v$version"
             },
             "32bit": {
-                "url": "https://dlsrc.getmonero.org/cli/monero-win-x86-v$version.zip"
+                "url": "https://dlsrc.getmonero.org/cli/monero-win-x86-v$version.zip",
+                "extract_dir": "monero-i686-w64-mingw32-v$version"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixes:
```pwsh
Installing 'monero-cli' (0.18.2.2) [64bit] from main bucket
Loading monero-win-x64-v0.18.2.2.zip from cache.
Checking hash of monero-win-x64-v0.18.2.2.zip ... ok.
Extracting monero-win-x64-v0.18.2.2.zip ... DEBUG[1695345424] $stdoutTask.Result = -------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : Thursday, September 21, 2023 9:17:04 PM
   Source : ~\scoop\apps\monero-cli\0.18.2.2\monero-x86_64-w64-mingw32\
     Dest : ~\scoop\apps\monero-cli\0.18.2.2\

    Files : *.*

  Options : *.* /S /E /DCOPY:DA /COPY:DAT /MOVE /R:1000000 /W:30

------------------------------------------------------------------------------

2023/09/21 21:17:04 ERROR 2 (0x00000002) Accessing Source Directory ~\scoop\apps\monero-cli\0.18.2.2\monero-x86_64-w64-mingw32\
The system cannot find the file specified. -> ~\scoop\apps\scoop\current\lib\core.ps1:755:9
Exception: ~\scoop\apps\scoop\current\lib\core.ps1:756
Line |
 756 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'monero-x86_64-w64-mingw32'! (error 16)
```
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).