### PR TITLE
helm-docs: Fixed binary name change for v1.11.2

### DIFF
--- a/bucket/helm-docs.json
+++ b/bucket/helm-docs.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.11.0",
+    "version": "1.11.2",
     "description": "Generates Helm charts documentation as markdown files.",
     "homepage": "https://github.com/norwoodj/helm-docs",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/norwoodj/helm-docs/releases/download/v1.11.0/helm-docs_1.11.0_Windows_x86_64.tar.gz",
-            "hash": "6fa2554e8c0f67bc24230a5edd56eefbe9ba3ded56c37d48cb60c6c993ff028c"
+            "url": "https://github.com/norwoodj/helm-docs/releases/download/v1.11.2/helm-docs_Windows_x86_64.tar.gz",
+            "hash": "565e8a0ea3c5adb4467ab5741be57a6e0f9d006106484cc46f6d9dc1597cd045"
         }
     },
     "bin": "helm-docs.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/norwoodj/helm-docs/releases/download/v$version/helm-docs_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/norwoodj/helm-docs/releases/download/v$version/helm-docs_Windows_x86_64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR updates the manifest for [helm-docs](https://github.com/norwoodj/helm-docs) to fix a breaking change to the artifact naming and update the package to the latest version `v1.11.2`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
