### PR TITLE
add pdf2svg

### DIFF
--- a/bucket/pdf2svg.json
+++ b/bucket/pdf2svg.json
@@ -6,10 +6,10 @@
     "url": "https://github.com/jalios/pdf2svg-windows/archive/refs/tags/v1.0.zip",
     "hash": "fd93fc1161076a3718b9be67104468b5baf243371756a7ecb16b551bce272b92",
     "architecture": {
-        "64bit": {            
+        "64bit": {
             "extract_dir": "pdf2svg-windows-1.0/dist-64bits"
         },
-        "32bit": {            
+        "32bit": {
             "extract_dir": "pdf2svg-windows-1.0/dist-32bits"
         }
     },

--- a/bucket/pdf2svg.json
+++ b/bucket/pdf2svg.json
@@ -3,11 +3,14 @@
     "description": "A simple PDF to SVG converter using the Poppler and Cairo libraries.",
     "homepage": "https://github.com/dawbarton/pdf2svg",
     "license": "GPL-2.0",
+    "url": "https://github.com/jalios/pdf2svg-windows/archive/refs/tags/v1.0.zip",
+    "hash": "fd93fc1161076a3718b9be67104468b5baf243371756a7ecb16b551bce272b92",
     "architecture": {
-        "64bit": {
-            "url": "https://github.com/jalios/pdf2svg-windows/archive/refs/tags/v1.0.zip",
-            "hash": "fd93fc1161076a3718b9be67104468b5baf243371756a7ecb16b551bce272b92",
+        "64bit": {            
             "extract_dir": "pdf2svg-windows-1.0/dist-64bits"
+        },
+        "32bit": {            
+            "extract_dir": "pdf2svg-windows-1.0/dist-32bits"
         }
     },
     "bin": "pdf2svg.exe",
@@ -16,15 +19,5 @@
             "pdf2svg.exe",
             "pdf2svg"
         ]
-    ],
-    "checkver": {
-        "github": "https://github.com/jalios/pdf2svg-windows"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/jalios/pdf2svg-windows/archive/refs/tags/v$version.zip"
-            }
-        }
-    }
+    ]
 }

--- a/bucket/pdf2svg.json
+++ b/bucket/pdf2svg.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0",
+    "description": "A simple PDF to SVG converter using the Poppler and Cairo libraries.",
+    "homepage": "https://github.com/dawbarton/pdf2svg",
+    "license": "GPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jalios/pdf2svg-windows/archive/refs/tags/v1.0.zip",
+            "hash": "fd93fc1161076a3718b9be67104468b5baf243371756a7ecb16b551bce272b92",
+            "extract_dir": "pdf2svg-windows-1.0/dist-64bits"
+        }
+    },
+    "bin": "pdf2svg.exe",
+    "shortcuts": [
+        [
+            "pdf2svg.exe",
+            "pdf2svg"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/jalios/pdf2svg-windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jalios/pdf2svg-windows/archive/refs/tags/v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
A simple PDF to SVG converter using the Poppler and Cairo libraries. This is a basic library required for many apps, like Inkscape TexText (latex plugin) and the latextools python library.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
