### PR TITLE
erlang: Fix checkver to get latest version

### DIFF
--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -37,8 +37,8 @@
         "ERLANG_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://erlang.org/download/otp_versions_tree_app_vsns.html",
-        "regex": "otp_win64_([\\d.]+)\\.exe"
+        "url": "https://www.erlang.org/downloads",
+        "regex": "https://github\\.com/erlang/otp/releases/download/OTP-([\\d.]+)/otp_win64_\\1\\.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -1,5 +1,5 @@
 {
-    "version": "25.3.2.6",
+    "version": "26.1.1",
     "description": "A programming language used to build massively scalable soft real-time systems with requirements on high availability.",
     "homepage": "https://www.erlang.org",
     "license": "Apache-2.0",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/erlang/otp/releases/download/OTP-25.3.2.6/otp_win64_25.3.2.6.exe#/dl.7z",
-            "hash": "b413d0869b04d41f482ed9c20b80b09032ce56b23fd81ca54794b7f86e40d614"
+            "url": "https://github.com/erlang/otp/releases/download/OTP-26.1.1/otp_win64_26.1.1.exe#/dl.7z",
+            "hash": "5a809a9a5ebee5e8881dd02bc18dde73ac79e3ac6e2a7fddfc3c5446761a4ca7"
         },
         "32bit": {
-            "url": "https://github.com/erlang/otp/releases/download/OTP-25.3.2.6/otp_win32_25.3.2.6.exe#/dl.7z",
-            "hash": "9bf5722f05ca6794d44773179f99159fb80c65fd7cb643f6c33e59fe0f40344a"
+            "url": "https://github.com/erlang/otp/releases/download/OTP-26.1.1/otp_win32_26.1.1.exe#/dl.7z",
+            "hash": "c49b2352e4b743a22a0cb9c3f1896a1d170c719733473af82f91aaf55c8f34b9"
         }
     },
     "installer": {


### PR DESCRIPTION
Change checkver to erlang downloads page as it always lists the latest version as first regex match

Closes #5119 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
