### PR TITLE
swift@5.9: Fix pre_install

### DIFF
--- a/bucket/swift.json
+++ b/bucket/swift.json
@@ -19,15 +19,15 @@
     },
     "pre_install": [
         "Expand-DarkArchive \"$dir\\swiftsetup.exe\" \"$dir\\extract_folder\" -Removal",
-        "Get-ChildItem \"$dir\\extract_folder\\AttachedContainer\\*.msi\" | ForEach-Object {",
-        "    if ($_.Name -in @('icu.msi', 'runtime.msi')) { Expand-MsiArchive $_ \"$dir\\Swift\" }",
-        "    else { Expand-MsiArchive $_ \"$dir\" }",
+        "Get-ChildItem \"$dir\\extract_folder\\AttachedContainer\\a*\" | ForEach-Object {",
+        "    Expand-MsiArchive $_ \"$dir\\extract_folder\"",
         "}",
+        "Move-Item \"$dir\\extract_folder\\PFiles64\\Swift\" -Destination \"$dir\"",
+        "Move-Item \"$dir\\extract_folder\\Library\\Developer\" -Destination \"$dir\"",
         "Remove-Item \"$dir\\extract_folder\" -Recurse | Out-Null"
     ],
     "env_add_path": [
         "Developer\\Toolchains\\unknown-Asserts-development.xctoolchain\\usr\\bin",
-        "Swift\\icu-69.1\\usr\\bin",
         "Swift\\runtime-development\\usr\\bin"
     ],
     "env_set": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix the pre_install script because the msi file and the path to be expanded have changed.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5133 
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
