### PR TITLE
mods: Adjust manifest to new release scheme

### DIFF
--- a/bucket/mods.json
+++ b/bucket/mods.json
@@ -3,12 +3,27 @@
     "description": "AI for the command line, built for pipelines.",
     "homepage": "https://github.com/charmbracelet/mods",
     "license": "MIT",
-    "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_x86_64.zip",
-    "hash": "b0877e8c291da1e046ce87b768d6f34e984958e2719a3187087da1568edc7dcc",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_x86_64.zip",
+            "hash": "b0877e8c291da1e046ce87b768d6f34e984958e2719a3187087da1568edc7dcc"
+        },
+        "arm64": {
+            "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_arm64.zip",
+            "hash": "f686a2ae2748f9037b6e4cedb7fad71d4416a58523fa70758c07afd476b9e315"
+        }
+    },
     "bin": "mods.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_x86_64.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_arm64.zip"
+            }
+        },
         "hash": {
             "url": "$baseurl/checksums.txt"
         }

--- a/bucket/mods.json
+++ b/bucket/mods.json
@@ -21,7 +21,7 @@
                 "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_x86_64.zip"
             },
             "arm64": {
-                "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_arm64.zip"
+                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/mods.json
+++ b/bucket/mods.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/charmbracelet/mods",
     "license": "MIT",
     "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_x86_64.zip",
-    "hash": "2db82f221e062d34ff676f5088b31f3bde111f06e94b646bacfa6ea2950780df",
+    "hash": "b0877e8c291da1e046ce87b768d6f34e984958e2719a3187087da1568edc7dcc",
     "bin": "mods.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/mods.json
+++ b/bucket/mods.json
@@ -1,29 +1,14 @@
 {
-    "version": "0.2.0",
+    "version": "1.0.0",
     "description": "AI for the command line, built for pipelines.",
     "homepage": "https://github.com/charmbracelet/mods",
     "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/charmbracelet/mods/releases/download/v0.2.0/mods_Windows_x86_64.zip",
-            "hash": "4712e6894c9a4fc2e7c3ff12431705e2b89b7385becf20d22f2c45a0bf530bea"
-        },
-        "32bit": {
-            "url": "https://github.com/charmbracelet/mods/releases/download/v0.2.0/mods_Windows_i386.zip",
-            "hash": "e0217f611fba934990081840eafc9c1560091a88b05460e794ea1940c4509f3e"
-        }
-    },
+    "url": "https://github.com/charmbracelet/mods/releases/download/v1.0.0/mods_1.0.0_Windows_x86_64.zip",
+    "hash": "2db82f221e062d34ff676f5088b31f3bde111f06e94b646bacfa6ea2950780df",
     "bin": "mods.exe",
     "checkver": "github",
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_Windows_x86_64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_Windows_i386.zip"
-            }
-        },
+        "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_x86_64.zip",
         "hash": {
             "url": "$baseurl/checksums.txt"
         }


### PR DESCRIPTION
The manifest is now architecture independent because since `mods` v1.0.0 there's no `32bit` architecture binary preventing the Excavator from auto-updating it.