### PR TITLE
oxipng: Fix `extract_dir`

### DIFF
--- a/bucket/oxipng.json
+++ b/bucket/oxipng.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/shssoichiro/oxipng/releases/download/v9.0.0/oxipng-9.0.0-x86_64-pc-windows-msvc.zip",
-            "hash": "b6b3ab550424fe53f1618eeb7da2a453d368b5f5400ce8a5f323d6ef7820e861"
+            "hash": "b6b3ab550424fe53f1618eeb7da2a453d368b5f5400ce8a5f323d6ef7820e861",
+            "extract_dir": "oxipng-9.0.0-x86_64-pc-windows-msvc"
         }
     },
     "bin": "oxipng.exe",
@@ -14,7 +15,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/shssoichiro/oxipng/releases/download/v$version/oxipng-$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/shssoichiro/oxipng/releases/download/v$version/oxipng-$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "oxipng-$version-x86_64-pc-windows-msvc"
             }
         }
     }


### PR DESCRIPTION
Currently `bin` fails and throws an error
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).