### PR TITLE
lab@0.25.1: Add arm64 version

### DIFF
--- a/bucket/lab.json
+++ b/bucket/lab.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/zaquestion/lab/releases/download/v0.25.1/lab_0.25.1_windows_amd64.zip",
             "hash": "75daf8d98678c5544b20a1a544ae77506d2f5bd011e7094f251d69bdf3262994"
+        },
+        "arm64": {
+            "url": "https://github.com/zaquestion/lab/releases/download/v0.25.1/lab_0.25.1_windows_arm64.zip",
+            "hash": "15715fb650e16aee10a0a2849aec4a96f33a4a2808df562aad28b3fc630c85f6"
         }
     },
     "bin": "lab.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/zaquestion/lab/releases/download/v$version/lab_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/zaquestion/lab/releases/download/v$version/lab_$version_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
