### PR TITLE
fix(5182): Update Terraform license to BUSL-1.1

### DIFF
--- a/bucket/terraform.json
+++ b/bucket/terraform.json
@@ -2,7 +2,7 @@
     "version": "1.6.1",
     "description": "Create and manage infrastructure as code using simple declarative configuration files.",
     "homepage": "https://www.terraform.io",
-    "license": "BSL-1.1",
+    "license": "BUSL-1.1",
     "architecture": {
         "64bit": {
             "url": "https://releases.hashicorp.com/terraform/1.6.1/terraform_1.6.1_windows_amd64.zip",

--- a/bucket/terraform.json
+++ b/bucket/terraform.json
@@ -2,7 +2,7 @@
     "version": "1.6.1",
     "description": "Create and manage infrastructure as code using simple declarative configuration files.",
     "homepage": "https://www.terraform.io",
-    "license": "MPL-2.0",
+    "license": "BSL-1.1",
     "architecture": {
         "64bit": {
             "url": "https://releases.hashicorp.com/terraform/1.6.1/terraform_1.6.1_windows_amd64.zip",


### PR DESCRIPTION
This PR aims to resolve the license discrepancy for Terraform to properly annotate its Business Software License 1.1 status.

https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license

It may even be worth reviewing Homebrew's stance on this, given they have frozen at `1.5.7` due to the implications of this license change:  https://github.com/Homebrew/homebrew-core/pull/139538

Closes #5182

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
