### PR TITLE
hurl: Fix autoupdate, update to version 4.1.0

### DIFF
--- a/bucket/hurl.json
+++ b/bucket/hurl.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "Command line tool that performs HTTP requests defined in a simple plain text format",
     "homepage": "https://hurl.dev",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Orange-OpenSource/hurl/releases/download/4.0.0/hurl-4.0.0-win64.zip",
-            "hash": "a3e15084a8001ea3db822bf751ad0d439221724afcc722eb460f577721b7e3db"
+            "url": "https://github.com/Orange-OpenSource/hurl/releases/download/4.1.0/hurl-4.1.0-x86_64-pc-windows-msvc.zip",
+            "hash": "25fb7e177e8b81b42024a04d9f4d05afbf9609bd2795f30c5b13429825d07e8d"
         }
     },
     "bin": [
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Orange-OpenSource/hurl/releases/download/$version/hurl-$version-win64.zip"
+                "url": "https://github.com/Orange-OpenSource/hurl/releases/download/$version/hurl-$version-x86_64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
- Fix `autoupdate` url since release artifact name changed.
- Update to version 4.1.0.

Relates to Orange-OpenSource/hurl#1951.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
