### PR TITLE
nu@0.86.0: Use the full binary for nushell

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/nushell/nushell/releases/download/0.86.0/nu-0.86.0-x86_64-windows-msvc-full.zip",
             "hash": "2aa597719f3afb28d43fb4b718efb2fc8d00df02e106bbfa5e802bf9caf9d8e3"
+        },
+        "arm64": {
+            "url": "https://github.com/nushell/nushell/releases/download/0.86.0/nu-0.86.0-aarch64-windows-msvc-full.zip",
+            "hash": "713a5dcba063be48dd4a0da90e144a25fdf0c3bf695ef6737659e3189b602e83"
         }
     },
     "bin": "nu.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-x86_64-windows-msvc-full.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-aarch64-windows-msvc-full.zip"
             }
         }
     }

--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/nushell/nushell/releases/download/0.86.0/nu-0.86.0-x86_64-pc-windows-msvc.zip",
-            "hash": "64e381a82289594e5cc2053cdd3c34e597affd2419acdd1645a983f9953aaba5"
+            "url": "https://github.com/nushell/nushell/releases/download/0.86.0/nu-0.86.0-x86_64-windows-msvc-full.zip",
+            "hash": "2aa597719f3afb28d43fb4b718efb2fc8d00df02e106bbfa5e802bf9caf9d8e3"
         }
     },
     "bin": "nu.exe",
@@ -16,7 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-x86_64-windows-msvc-full.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #5199

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
