### PR TITLE
apache&ab@2.4.58: old version was not reachable

### DIFF
--- a/bucket/ab.json
+++ b/bucket/ab.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.4.57",
+    "version": "2.4.58",
     "description": "Apache HTTP server benchmarking tool ('ab')",
     "homepage": "https://www.apachelounge.com",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://fossies.org/windows/www/httpd-2.4.57-win64-VS16.zip",
-            "hash": "f74e3ef944d3d8fe5db4ad353304cbaf3c038d28307697e0d12cd8f8201dbbb4"
+            "url": "https://fossies.org/windows/www/httpd-2.4.58-win64-VS17.zip",
+            "hash": "e9a179ad4767c595be55024ee0415a96ae522f492deca4b0d54cf136ff2b092c"
         }
     },
     "extract_dir": "Apache24",
@@ -17,12 +17,12 @@
     ],
     "checkver": {
         "url": "https://fossies.org/windows/www/",
-        "regex": "httpd-([\\d.]+)-win64-VS16\\.zip"
+        "regex": "httpd-([\\d.]+)-win64-VS17\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://fossies.org/windows/www/httpd-$version-win64-VS16.zip"
+                "url": "https://fossies.org/windows/www/httpd-$version-win64-VS17.zip"
             }
         },
         "hash": {

--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.4.57",
+    "version": "2.4.58",
     "description": "The Apache HTTP Server ('httpd')",
     "homepage": "https://www.apachelounge.com",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://fossies.org/windows/www/httpd-2.4.57-win64-VS16.zip",
-            "hash": "f74e3ef944d3d8fe5db4ad353304cbaf3c038d28307697e0d12cd8f8201dbbb4"
+            "url": "https://fossies.org/windows/www/httpd-2.4.58-win64-VS17.zip",
+            "hash": "e9a179ad4767c595be55024ee0415a96ae522f492deca4b0d54cf136ff2b092c"
         }
     },
     "extract_dir": "Apache24",
@@ -35,12 +35,12 @@
     ],
     "checkver": {
         "url": "https://fossies.org/windows/www/",
-        "regex": "httpd-([\\d.]+)-win64-VS16\\.zip"
+        "regex": "httpd-([\\d.]+)-win64-VS17\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://fossies.org/windows/www/httpd-$version-win64-VS16.zip"
+                "url": "https://fossies.org/windows/www/httpd-$version-win64-VS17.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
ab@2.4.58: old version was not reachable
apache@2.4.58: old version was not reachable

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
