### PR TITLE
chore (GitHub API): Use repo ID, instead of repo name

### DIFF
--- a/bucket/arc.json
+++ b/bucket/arc.json
@@ -15,7 +15,7 @@
     },
     "bin": "arc.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/mholt/archiver/releases",
+        "url": "https://api.github.com/repositories/55814200/releases",
         "regex": "arc_([\\d.]+)_windows_amd64\\.exe"
     },
     "autoupdate": {

--- a/bucket/aws.json
+++ b/bucket/aws.json
@@ -15,7 +15,7 @@
         "aws_completer.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/aws/aws-cli/tags",
+        "url": "https://api.github.com/repositories/6780767/tags",
         "jsonpath": "$[0].name"
     },
     "autoupdate": {

--- a/bucket/azure-ps.json
+++ b/bucket/azure-ps.json
@@ -18,7 +18,7 @@
         "name": "AzureRM"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/Azure/azure-powershell/releases",
+        "url": "https://api.github.com/repositories/23891194/releases",
         "regex": "download/v(?<release>[^/]+)/Az-Cmdlets-([0-9.]+)-x64[.]msi"
     },
     "autoupdate": {

--- a/bucket/bbdown.json
+++ b/bucket/bbdown.json
@@ -24,7 +24,7 @@
     "bin": "BBDown.exe",
     "persist": "BBDown.data",
     "checkver": {
-        "url": "https://api.github.com/repos/nilaoda/BBDown/releases",
+        "url": "https://api.github.com/repositories/282637924/releases",
         "jsonpath": "$[0].assets",
         "regex": "BBDown_(?<version>[\\d.]+)_(?<date>[\\d]+)_win-x64.zip"
     },

--- a/bucket/coq.json
+++ b/bucket/coq.json
@@ -33,7 +33,7 @@
         "COQBIN": "bin"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/coq/platform/releases/latest",
+        "url": "https://api.github.com/repositories/212040108/releases/latest",
         "regex": "Coq-Platform-release-([\\d.]+)-version.(?<coqver>[\\d.]+)-Windows-x86_64.exe",
         "reverse": true
     },

--- a/bucket/detekt.json
+++ b/bucket/detekt.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/detekt/detekt/releases",
+        "url": "https://api.github.com/repositories/71729669/releases",
         "regex": "detekt-cli-(?<version>[\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/dust.json
+++ b/bucket/dust.json
@@ -17,7 +17,7 @@
     },
     "bin": "dust.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/bootandy/dust/releases",
+        "url": "https://api.github.com/repositories/125563061/releases",
         "regex": "dust-v([\\d.]+)-x86_64-pc-windows-msvc\\.zip"
     },
     "autoupdate": {

--- a/bucket/flux.json
+++ b/bucket/flux.json
@@ -19,7 +19,7 @@
     },
     "bin": "flux.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/fluxcd/flux2/releases",
+        "url": "https://api.github.com/repositories/258469100/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "flux_([\\d.]+)_windows_amd64.zip"
     },

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -60,7 +60,7 @@
         "GIT_INSTALL_ROOT": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "url": "https://api.github.com/repositories/23216272/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+windows\\.\\d)/PortableGit-([\\d.]+)-64"
     },

--- a/bucket/grails.json
+++ b/bucket/grails.json
@@ -14,7 +14,7 @@
         "GRAILS_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/grails/grails-core/releases",
+        "url": "https://api.github.com/repositories/512295/releases",
         "regex": "/grails-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -15,7 +15,7 @@
     },
     "bin": "grpcurl.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/fullstorydev/grpcurl/releases",
+        "url": "https://api.github.com/repositories/111431261/releases",
         "regex": "grpcurl_([\\d.]+)_windows_x"
     },
     "autoupdate": {

--- a/bucket/hashlink.json
+++ b/bucket/hashlink.json
@@ -11,7 +11,7 @@
         "HASHLINKPATH": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/HaxeFoundation/hashlink/releases/latest",
+        "url": "https://api.github.com/repositories/42316018/releases/latest",
         "regex": "([\\d.]+)-win"
     },
     "autoupdate": {

--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -29,7 +29,7 @@
     ],
     "env_add_path": "lib\\bin",
     "checkver": {
-        "url": "https://api.github.com/repos/commercialhaskell/ghc/tags",
+        "url": "https://api.github.com/repositories/46509594/tags",
         "jsonpath": "$..name",
         "regex": "ghc-([\\d\\.]+)-release"
     },

--- a/bucket/ipinfo-cli.json
+++ b/bucket/ipinfo-cli.json
@@ -23,7 +23,7 @@
     ],
     "bin": "ipinfo.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/ipinfo/cli/releases/latest",
+        "url": "https://api.github.com/repositories/306538237/releases/latest",
         "jsonpath": "$.name",
         "regex": "ipinfo-(?<version>.*)$"
     },

--- a/bucket/kim.json
+++ b/bucket/kim.json
@@ -11,7 +11,7 @@
     },
     "bin": "kim.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/rancher/kim/releases",
+        "url": "https://api.github.com/repositories/333185595/releases",
         "regex": "download/v([\\w.-]+)/kim-windows-amd64.exe"
     },
     "autoupdate": {

--- a/bucket/kotlin-native.json
+++ b/bucket/kotlin-native.json
@@ -42,7 +42,7 @@
             }
         },
         "hash": {
-            "url": "https://api.github.com/repos/JetBrains/kotlin/releases/latest",
+            "url": "https://api.github.com/repositories/3432266/releases/latest",
             "regex": "(?sm)kotlin-native-windows-x86_64[\\w.-]+\\s+\\|\\s+$sha256"
         }
     }

--- a/bucket/libavif.json
+++ b/bucket/libavif.json
@@ -22,7 +22,7 @@
         "avifenc.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/AOMediaCodec/libavif/releases",
+        "url": "https://api.github.com/repositories/191218735/releases",
         "regex": "v([\\d.]+)/libavif_vs(?<vs>\\d+)_x64_(?<commit>\\w+)_Release\\.zip"
     },
     "autoupdate": {

--- a/bucket/mingit-busybox.json
+++ b/bucket/mingit-busybox.json
@@ -29,7 +29,7 @@
         "GIT_INSTALL_ROOT": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "url": "https://api.github.com/repositories/23216272/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+windows\\.\\d)/MinGit-([\\d.]+)-busybox-64"
     },

--- a/bucket/mingit.json
+++ b/bucket/mingit.json
@@ -26,7 +26,7 @@
         "GIT_INSTALL_ROOT": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "url": "https://api.github.com/repositories/23216272/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+windows\\.\\d)/MinGit-([\\d.]+)-64"
     },

--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -27,7 +27,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/neovim/neovim/releases/latest",
+        "url": "https://api.github.com/repositories/16408992/releases/latest",
         "jsonpath": "$.body",
         "regex": "NVIM v(?<majorVersion>[\\w.-]+)\\.(?<minorVersion>[\\w.-]+)\\.(?<patchVersion>[\\w.-]+)",
         "replace": "${majorVersion}.${minorVersion}.${patchVersion}"

--- a/bucket/openshift-okd-client.json
+++ b/bucket/openshift-okd-client.json
@@ -11,7 +11,7 @@
     },
     "bin": "oc.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/openshift/okd/tags",
+        "url": "https://api.github.com/repositories/222003131/tags",
         "jsonpath": "$[0].name"
     },
     "autoupdate": {

--- a/bucket/pdf2djvu.json
+++ b/bucket/pdf2djvu.json
@@ -18,7 +18,7 @@
         "djvused.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/jwilk/pdf2djvu/releases",
+        "url": "https://api.github.com/repositories/36523035/releases",
         "regex": "pdf2djvu-win32-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/pester.json
+++ b/bucket/pester.json
@@ -19,7 +19,7 @@
             "$auth = Get-GitHubToken",
             "$head = @{}",
             "if($auth) { $head.add('authorization', \"Bearer $auth\") }",
-            "$url = 'https://api.github.com/repos/pester/Pester/releases'",
+            "$url = 'https://api.github.com/repositories/1213474/releases'",
             "$latest_ver = [Version]::new(0,0,0,0) # note: Powershell 5 does not support casting 'int' or 'float' to 'System.Version'",
             "$releases = $(Invoke-WebRequest -Headers $head $url).Content | ConvertFrom-Json",
             "$releases | ForEach-Object {",

--- a/bucket/pnpm.json
+++ b/bucket/pnpm.json
@@ -16,7 +16,7 @@
             "$auth = Get-GitHubToken",
             "$head = @{}",
             "if($auth) { $head.add('authorization', \"Bearer $auth\") }",
-            "$url = 'https://api.github.com/repos/pnpm/pnpm/releases'",
+            "$url = 'https://api.github.com/repositories/50565430/releases'",
             "$latest_ver = [Version]::new(0,0,0,0) # note: Powershell 5 does not support casting 'int' or 'float' to 'System.Version'",
             "$releases = $(Invoke-WebRequest -Headers $head $url).Content | ConvertFrom-Json",
             "$releases | ForEach-Object {",

--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -24,7 +24,7 @@
     "extract_dir": "Sapling",
     "bin": "sl.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/facebook/sapling/releases/latest",
+        "url": "https://api.github.com/repositories/58146669/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})\\+(?<hash>[\\da-f]{8}))",
         "replace": "${ver}.${date}.${time}.${hash}"

--- a/bucket/simplex-chat.json
+++ b/bucket/simplex-chat.json
@@ -11,7 +11,7 @@
     },
     "bin": "simplex-chat.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/simplex-chat/simplex-chat/releases",
+        "url": "https://api.github.com/repositories/229407566/releases",
         "jsonpath": "$[?(@.prerelease == false)]..browser_download_url",
         "regex": "download/v([\\d.]+)/simplex-chat-windows-x86-64"
     },

--- a/bucket/terraform-provider-ibm.json
+++ b/bucket/terraform-provider-ibm.json
@@ -17,7 +17,7 @@
         }
     },
     "checkver": {
-        "url": "https://api.github.com/repos/IBM-Cloud/terraform-provider-ibm/releases",
+        "url": "https://api.github.com/repositories/94801963/releases",
         "regex": "releases/download/v([\\d.]+)/"
     },
     "autoupdate": {

--- a/bucket/upbound-cli.json
+++ b/bucket/upbound-cli.json
@@ -11,7 +11,7 @@
     },
     "bin": "up.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/upbound/up/tags",
+        "url": "https://api.github.com/repositories/345125931/tags",
         "regex": "tags/v([\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/v.json
+++ b/bucket/v.json
@@ -13,7 +13,7 @@
     "extract_dir": "v",
     "bin": "v.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/vlang/v/releases?per_page=100",
+        "url": "https://api.github.com/repositories/169677297/releases?per_page=100",
         "regex": "releases/tag/([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/wkhtmltopdf.json
+++ b/bucket/wkhtmltopdf.json
@@ -19,7 +19,7 @@
         "wkhtmltopdf.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/wkhtmltopdf/packaging/releases",
+        "url": "https://api.github.com/repositories/131323182/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/wkhtmltox-([\\d.-]+)\\.mxe-cross-"
     },


### PR DESCRIPTION
Repo names are subject to change, IDs aren't

Relates to https://github.com/ScoopInstaller/Extras/pull/12093 https://github.com/ScoopInstaller/Versions/pull/1429

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).