### PR TITLE
binaryen@116: add shim for `wasm-merge`

### DIFF
--- a/bucket/binaryen.json
+++ b/bucket/binaryen.json
@@ -20,7 +20,8 @@
         "bin\\wasm-opt.exe",
         "bin\\wasm-reduce.exe",
         "bin\\wasm-shell.exe",
-        "bin\\wasm-split.exe"
+        "bin\\wasm-split.exe",
+        "bin\\wasm-merge.exe"
     ],
     "checkver": {
         "github": "https://github.com/WebAssembly/binaryen",


### PR DESCRIPTION
Binaryen added a new `wasm-merge` tool recently ([docs](https://github.com/WebAssembly/binaryen#wasm-merge)). Scoop installs it correctly already but no shim is made to make it available in the PATH. This fixes that.

I read in CONTRIBUTING that you dislike PRs without issues, but the issue here is so mundane that I hope it's okay.

ps. I struggled to get through the issue reporting mechanism. This is neither a bug in Scoop, nor a "package request" because the package already exists, so I wasn't even sure which kind of issue to make. So I picked "bug" cause it was the least wrong, but started strongly doubting that I did it right when it asked for my powershell configuration and whatnot.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
