### PR TITLE
sqlpage: Add version 0.17.1

### DIFF
--- a/bucket/sqlpage.json
+++ b/bucket/sqlpage.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.15.1",
+    "description": "SQL-only webapp builder, empowering data analysts to build websites and applications quickly",
+    "homepage": "https://github.com/lovasoa/SQLpage",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lovasoa/SQLpage/releases/download/v0.15.1/sqlpage-windows.zip",
+            "hash": "b092d2380332d406268da89a19a5ea6623800721cc949562f70b969d29dcef3d"
+        }
+    },
+    "bin": [
+        "sqlpage.exe",
+        [
+            "sqlpage.exe",
+            "sqlpage"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lovasoa/SQLpage/releases/download/v$version/sqlpage-windows.zip"
+            }
+        }
+    }
+}

--- a/bucket/sqlpage.json
+++ b/bucket/sqlpage.json
@@ -1,22 +1,19 @@
 {
-    "version": "0.15.1",
+    "version": "0.17.1",
     "description": "SQL-only webapp builder, empowering data analysts to build websites and applications quickly",
-    "homepage": "https://github.com/lovasoa/SQLpage",
+    "homepage": "https://sql.ophir.dev",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lovasoa/SQLpage/releases/download/v0.15.1/sqlpage-windows.zip",
-            "hash": "b092d2380332d406268da89a19a5ea6623800721cc949562f70b969d29dcef3d"
+            "url": "https://github.com/lovasoa/SQLpage/releases/download/v0.17.1/sqlpage-windows.zip",
+            "hash": "60fe994da471dddd104fe997c0310f8a74c61833450319500ba7fb8d2554167f"
         }
     },
-    "bin": [
-        "sqlpage.exe",
-        [
-            "sqlpage.exe",
-            "sqlpage"
-        ]
-    ],
-    "checkver": "github",
+    "bin": "sqlpage.exe",
+    "persist": "sqlpage",
+    "checkver": {
+        "github": "https://github.com/lovasoa/SQLpage"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Closes #5240 

See SQLPage [website](https://sql.ophir.dev/) and [repo](https://github.com/lovasoa/SQLpage).