### PR TITLE
ptags: Add extract_dir to fix installation

### DIFF
--- a/bucket/ptags.json
+++ b/bucket/ptags.json
@@ -11,6 +11,7 @@
         }
     },
     "extract_dir": "target\\x86_64-pc-windows-msvc\\release",
+    "pre_install": "Remove-Item \"$dir\\target\" -Recurse -ErrorAction SilentlyContinue",
     "bin": "ptags.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/ptags.json
+++ b/bucket/ptags.json
@@ -10,6 +10,7 @@
             "hash": "0259df12c4f7a9d55e5f0b1817da166306f3e4407fa5721d757255a535453d30"
         }
     },
+    "extract_dir": "target\\x86_64-pc-windows-msvc\\release",
     "bin": "ptags.exe",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Latest upstream release changed the location of ptags.exe requiring a new `extract_dir` directive in the app manifist
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
