### PR TITLE
OptiPNG@0.7.8: Add 64-bit

### DIFF
--- a/bucket/optipng.json
+++ b/bucket/optipng.json
@@ -3,13 +3,30 @@
     "description": "A PNG optimizer that recompresses image files to a smaller size, without losing any information.",
     "homepage": "https://optipng.sourceforge.net/",
     "license": "Zlib",
-    "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8-win32.zip",
-    "hash": "sha1:746a398eef9d5ae7df4388c2dad6d5ae73ae18d7",
-    "extract_dir": "optipng-0.7.8-win32",
+    "architecture": {
+        "32bit": {
+            "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8-win32.zip",
+            "hash": "sha1:746a398eef9d5ae7df4388c2dad6d5ae73ae18d7",
+            "extract_dir": "optipng-0.7.8-win32"
+        },
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8-win64.zip",
+            "hash": "sha1:c1a2783fb5c5798710a63f69c9be288d6e91ec0f",
+            "extract_dir": "optipng-0.7.8-win64"
+        }
+    },
     "bin": "optipng.exe",
     "checkver": "([\\d.]+)<\\/b><\\/font> \\(stable\\)",
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$version/optipng-$version-win32.zip",
-        "extract_dir": "optipng-$version-win32"
+        "architecture": {
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$version/optipng-$version-win32.zip",
+                "extract_dir": "optipng-$version-win32"
+            },
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-$version/optipng-$version-win64.zip",
+                "extract_dir": "optipng-$version-win64"
+            }
+        }
     }
 }


### PR DESCRIPTION
Now OptiPNG provides 64-bit version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
