### PR TITLE
pdfbox@3.0.0: New major version

### DIFF
--- a/bucket/pdfbox.json
+++ b/bucket/pdfbox.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.30",
+    "version": "3.0.0",
     "description": "Java tool for working with PDF documents.",
     "homepage": "https://pdfbox.apache.org",
     "license": "Apache-2.0",
@@ -7,18 +7,18 @@
         "JDK": "java/openjdk"
     },
     "url": [
-        "https://downloads.apache.org/pdfbox/2.0.30/pdfbox-app-2.0.30.jar#/pdfbox.jar",
-        "https://downloads.apache.org/pdfbox/2.0.30/preflight-2.0.30.jar#/preflight.jar"
+        "https://downloads.apache.org/pdfbox/3.0.0/pdfbox-app-3.0.0.jar#/pdfbox.jar",
+        "https://downloads.apache.org/pdfbox/3.0.0/preflight-3.0.0.jar#/preflight.jar"
     ],
     "hash": [
-        "sha512:32080d4944fa505d3835c80706f8665a293a0234be1c53bb4b6ab59374eac706c80f1d66735a168085e1cdbbde0024fb2ccf53550c18d8ec85f6c89e969d1621",
-        "sha512:d242775d03c86c8975e4088125764bf984f6e1b93db6f48212b9e74627672a32d89f00cf4614ad11346e5d4ae1ec6addd97aaf576431adb1d9c3680f47569f78"
+        "sha512:a196fb12644fbac59f4d33b3ce6c779deee8b6bbac9af41f60a033b310f67568651096b27b76e69f6ef2cb88acd27aceda4bb0d24707a6c2c4e1d2da842d0d88",
+        "sha512:99ee19354840042a5b95ade1590bd90eabba97446ece0a3c99e32fb867b876012fea4fe99fb26552abe2f5d898f6a99bbd2eb9057faad908262d5b8a0c197450"
     ],
     "bin": [
         "pdfbox.jar",
         "preflight.jar"
     ],
-    "checkver": "Apache PDFBox ([\\d.]+) released",
+    "checkver": "Apache PDFBox (3\\.[\\d\\.]*) released",
     "autoupdate": {
         "url": [
             "https://downloads.apache.org/pdfbox/$version/pdfbox-app-$version.jar#/pdfbox.jar",


### PR DESCRIPTION
Add support for the latest major version of Apache PDFBox, v3.0.0.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
