### PR TITLE
Fix adb manifest

### DIFF
--- a/bucket/adb.json
+++ b/bucket/adb.json
@@ -10,7 +10,6 @@
     "hash": "3f8320152704377de150418a3c4c9d07d16d80a6c0d0d8f7289c22c499e33571",
     "bin": [
         "platform-tools\\adb.exe",
-        "platform-tools\\dmtracedump.exe",
         "platform-tools\\etc1tool.exe",
         "platform-tools\\fastboot.exe",
         "platform-tools\\hprof-conv.exe"


### PR DESCRIPTION
Remove non-exist binary.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
