### PR TITLE
static-web-server: Add ARM64 support

### DIFF
--- a/bucket/static-web-server.json
+++ b/bucket/static-web-server.json
@@ -10,6 +10,11 @@
             "hash": "5edaf3ece91474ccb94f9daca06ca87eb36d4ae1cea020c7201569d770fcca94",
             "extract_dir": "static-web-server-v2.24.0-x86_64-pc-windows-msvc"
         },
+        "arm64": {
+            "url": "https://github.com/static-web-server/static-web-server/releases/download/v2.24.0/static-web-server-v2.24.0-aarch64-pc-windows-msvc.zip",
+            "hash": "c26bc69f651465cd922d2a4a74edde3b26a4dd6eb5319d2dffedfecb87b4f261",
+            "extract_dir": "static-web-server-v2.24.0-aarch64-pc-windows-msvc"
+        },
         "32bit": {
             "url": "https://github.com/static-web-server/static-web-server/releases/download/v2.24.0/static-web-server-v2.24.0-i686-pc-windows-msvc.zip",
             "hash": "d34e7defe1c4124f566d1364a66cf4dd4ac754837a9c7d3f7d4bd3eebd095e8d",
@@ -25,6 +30,10 @@
             "64bit": {
                 "url": "https://github.com/static-web-server/static-web-server/releases/download/v$version/static-web-server-v$version-x86_64-pc-windows-msvc.zip",
                 "extract_dir": "static-web-server-v$version-x86_64-pc-windows-msvc"
+            },
+            "arm64": {
+                "url": "https://github.com/static-web-server/static-web-server/releases/download/v$version/static-web-server-v$version-aarch64-pc-windows-msvc.zip",
+                "extract_dir": "static-web-server-v$version-aarch64-pc-windows-msvc"
             },
             "32bit": {
                 "url": "https://github.com/static-web-server/static-web-server/releases/download/v$version/static-web-server-v$version-i686-pc-windows-msvc.zip",


### PR DESCRIPTION
**Static Web Server** officially provides ARM64 binaries on the latest `v2.24.0`, so this PR just adds support for it. 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
