### PR TITLE
dufs: Add arm64 & 32bit versions

### DIFF
--- a/bucket/dufs.json
+++ b/bucket/dufs.json
@@ -7,6 +7,14 @@
         "64bit": {
             "url": "https://github.com/sigoden/dufs/releases/download/v0.37.1/dufs-v0.37.1-x86_64-pc-windows-msvc.zip",
             "hash": "79beed5f8c1fceb62c9e906ec0af57eefc02c841bdfa999e92909f3c4a0f4163"
+        },
+        "32bit": {
+            "url": "https://github.com/sigoden/dufs/releases/download/v0.37.1/dufs-v0.37.1-i686-pc-windows-msvc.zip",
+            "hash": "43259e0d97d766fd360b5f62cf590affcddfa2531a950b07094234cef1a5f9f8"
+        },
+        "arm64": {
+            "url": "https://github.com/sigoden/dufs/releases/download/v0.37.1/dufs-v0.37.1-aarch64-pc-windows-msvc.zip",
+            "hash": "d9e01b6201d1cbba0d879bacef80caa1d6cf3ac861cf95278b3af2cf20b89f6a"
         }
     },
     "bin": "dufs.exe",
@@ -15,6 +23,12 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/sigoden/dufs/releases/download/v$version/dufs-v$version-x86_64-pc-windows-msvc.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/sigoden/dufs/releases/download/v$version/dufs-v$version-i686-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/sigoden/dufs/releases/download/v$version/dufs-v$version-aarch64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
- Add arm64 version.
- Add 32bit version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
