### PR TITLE
unrar: Update to version 7.00, fix autoupdate link

### DIFF
--- a/bucket/unrar.json
+++ b/bucket/unrar.json
@@ -1,6 +1,6 @@
 {
-    "version": "7.00-beta-3",
-    "description": "Decompress RAR files",
+    "version": "6.24",
+    "description": "Decompress RAR files.",
     "homepage": "https://www.rarlab.com/",
     "license": {
         "identifier": "Freeware",
@@ -8,30 +8,27 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://www.rarlab.com/rar/unrarw64.exe#/dl.7z",
-            "hash": "b18bf74faf2e12080e4087c36abb2a566943d8312cbb1fb7fd0cd6795816bd01"
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/unrar/6.24/UnRAR_x64.exe#/UnRAR.exe",
+            "hash": "90c2b2107a22ea8eb3593a155c4c0007b18b1ba552bf65f963c040038da248be"
+        },
+        "32bit": {
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/unrar/6.24/UnRAR.exe",
+            "hash": "c9e67b0474d3081827a73f1a7080b735d1d80d2d5f5c4aee508b335ed7e8a05a"
         }
     },
     "bin": "UnRAR.exe",
-    "checkver": {
-        "script": [
-            "$base_url = 'https://www.rarlab.com/'",
-            "$ver_regex = 'RAR ([\\d.]+\\s*[\\w]*\\s*[\\d.]*) version'",
-            "",
-            "$page = $(Invoke-WebRequest $base_url).Content",
-            "if (!($page -match $ver_regex)) { error \"Could not match '$ver_regex' in '$base_url'\"; continue }",
-            "$script_ver = $matches[1]",
-            "",
-            "$ver = ($script_ver).replace(' ', '-')",
-            "Write-Output $ver"
-        ],
-        "regex": "(\\S+)"
-    },
+    "checkver": "WinRAR and RAR ([\\d.]+) release",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.rarlab.com/rar/unrarw64.exe#/dl.7z"
+                "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/unrar/$version/UnRAR_x64.exe#/UnRAR.exe"
+            },
+            "32bit": {
+                "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/unrar/$version/UnRAR.exe"
             }
+        },
+        "hash": {
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/checksums.sha256"
         }
     }
 }

--- a/bucket/unrar.json
+++ b/bucket/unrar.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.00",
+    "version": "7.00 beta 2",
     "description": "Decompress RAR files",
     "homepage": "https://www.rarlab.com/",
     "license": {
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://www.rarlab.com/rar/unrarw64.exe#/dl.7z",
-            "hash": "3a371fa935130283dfae4cf117386316a74971bf7895f1890d454bcf68285cb8"
+            "hash": "e30287ba779b2f6324f3a46fce457a0c3f25b4ab63dfd0a3c5d27630a985be8c"
         }
     },
     "bin": "UnRAR.exe",
-    "checkver": "RAR ([\\d.]+)",
+    "checkver": "RAR ([\\d.]+\\s*[\\w]*\\s*[\\d.]*) version",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/unrar.json
+++ b/bucket/unrar.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.00 beta 2",
+    "version": "7.00 beta 3",
     "description": "Decompress RAR files",
     "homepage": "https://www.rarlab.com/",
     "license": {
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.rarlab.com/rar/unrarw64.exe#/dl.7z",
-            "hash": "e30287ba779b2f6324f3a46fce457a0c3f25b4ab63dfd0a3c5d27630a985be8c"
+            "hash": "b18bf74faf2e12080e4087c36abb2a566943d8312cbb1fb7fd0cd6795816bd01"
         }
     },
     "bin": "UnRAR.exe",

--- a/bucket/unrar.json
+++ b/bucket/unrar.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.00 beta 3",
+    "version": "7.00-beta-3",
     "description": "Decompress RAR files",
     "homepage": "https://www.rarlab.com/",
     "license": {
@@ -13,7 +13,20 @@
         }
     },
     "bin": "UnRAR.exe",
-    "checkver": "RAR ([\\d.]+\\s*[\\w]*\\s*[\\d.]*) version",
+    "checkver": {
+        "script": [
+            "$base_url = 'https://www.rarlab.com/'",
+            "$ver_regex = 'RAR ([\\d.]+\\s*[\\w]*\\s*[\\d.]*) version'",
+            "",
+            "$page = $(Invoke-WebRequest $base_url).Content",
+            "if (!($page -match $ver_regex)) { error \"Could not match '$ver_regex' in '$base_url'\"; continue }",
+            "$script_ver = $matches[1]",
+            "",
+            "$ver = ($script_ver).replace(' ', '-')",
+            "Write-Output $ver"
+        ],
+        "regex": "(\\S+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/unrar.json
+++ b/bucket/unrar.json
@@ -1,16 +1,24 @@
 {
-    "version": "6.24",
-    "description": "Decompress RAR files.",
+    "version": "7.00",
+    "description": "Decompress RAR files",
     "homepage": "https://www.rarlab.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.rarlab.com/license.htm"
     },
-    "url": "https://www.rarlab.com/rar/unrarw32.exe#/dl.7z",
-    "hash": "6b82265b7185a48014561670853cabacafaf502f06da8b0539882974a1f7b803",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.rarlab.com/rar/unrarw64.exe#/dl.7z",
+            "hash": "3a371fa935130283dfae4cf117386316a74971bf7895f1890d454bcf68285cb8"
+        }
+    },
     "bin": "UnRAR.exe",
-    "checkver": "RAR ([\\d.]+) [^ab]",
+    "checkver": "RAR ([\\d.]+)",
     "autoupdate": {
-        "url": "https://www.rarlab.com/rar/unrarw32.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://www.rarlab.com/rar/unrarw64.exe#/dl.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
For people who need `unrar.exe` desperately: `scoop bucket add extras; scoop install extras/winrar`

---

- Update to version 7.00 (**7.00 beta 3**).
- Fix `autoupdate` link since no [unrarw32.exe](https://www.rarlab.com/rar/unrarw32.exe) is available but only [unrarw64.exe](https://www.rarlab.com/rar/unrarw64.exe) instead.
- Change `checkver` regex to track the latest/newest available version (including beta) since the only downloadable binary for unrar - [unrarw64.exe](https://www.rarlab.com/rar/unrarw64.exe) - reports its version as **7.00 beta 3** (i.e. latest at the moment) but not **6.24** (i.e. previous stable). Looks like there is no possibility to define what version has the downloadable binary: link is always the same - https://www.rarlab.com/rar/unrarw64.exe - and doesn't content version as well.

Closes #5272.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
