### PR TITLE
Update teleport.json

### DIFF
--- a/bucket/teleport.json
+++ b/bucket/teleport.json
@@ -9,7 +9,6 @@
             "hash": "1516f3468e16fb7a2241fc267fa7c3d7a5f64214b81ae298dede628f5a5ae359"
         }
     },
-    "extract_dir": "teleport",
     "bin": "tsh.exe",
     "checkver": {
         "url": "https://goteleport.com/docs/installation",


### PR DESCRIPTION
14.1.5 zip structure was changed. there is no subfolder 'teleport' anymore.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
