### PR TITLE
DCMTK: Add version 3.6.7

### DIFF
--- a/bucket/dcmtk.json
+++ b/bucket/dcmtk.json
@@ -1,0 +1,35 @@
+{
+    "version": "3.6.7",
+    "description": "DCMTK is a collection of libraries and applications implementing large parts the DICOM standard.",
+    "homepage": "https://dcmtk.org/en/dcmtk/",
+    "license": "BSD-3-Clause",
+    "env_add_path": "./bin/",
+    "architecture": {
+        "32bit": {
+            "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-3.6.7-win32-dynamic.zip",
+            "hash": "0B74C48606E119975944B540F5DF741B996B180814841E962F6886FD24446D9E",
+            "extract_dir": "dcmtk-3.6.7-win32-dynamic"
+        },
+        "64bit": {
+            "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-3.6.7-win64-dynamic.zip",
+            "hash": "BD2765D2C4833EEE70CAE499F0F9059E1C3E5C83EC7C7F82F50E375914E58549",
+            "extract_dir": "dcmtk-3.6.7-win64-dynamic"
+        }
+    },
+    "checkver": {
+        "url": "https://dcmtk.cip/en/dcmtk/dcmtk-tools/",
+        "regex": "dcmtk-([\\d\\.]+)\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-$version-win32-dynamic.zip",
+                "extract_dir": "dcmtk-$matchVersion-win32-dynamic"
+            },
+            "64bit": {
+                "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-$version-win64-dynamic.zip",
+                "extract_dir": "dcmtk-$matchVersion-win64-dynamic"
+            }
+        }
+    }
+}

--- a/bucket/dcmtk.json
+++ b/bucket/dcmtk.json
@@ -3,7 +3,6 @@
     "description": "DCMTK is a collection of libraries and applications implementing large parts the DICOM standard.",
     "homepage": "https://dcmtk.org/en/dcmtk/",
     "license": "BSD-3-Clause",
-    "env_add_path": "./bin/",
     "architecture": {
         "32bit": {
             "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-3.6.7-win32-dynamic.zip",
@@ -16,6 +15,7 @@
             "extract_dir": "dcmtk-3.6.7-win64-dynamic"
         }
     },
+    "env_add_path": "./bin/",
     "checkver": {
         "url": "https://dicom.offis.de/download/dcmtk/current/",
         "regex": "dcmtk-([\\d\\.]+)\\.zip"

--- a/bucket/dcmtk.json
+++ b/bucket/dcmtk.json
@@ -17,18 +17,18 @@
         }
     },
     "checkver": {
-        "url": "https://dcmtk.cip/en/dcmtk/dcmtk-tools/",
+        "url": "https://dicom.offis.de/download/dcmtk/current/",
         "regex": "dcmtk-([\\d\\.]+)\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "32bit": {
                 "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-$version-win32-dynamic.zip",
-                "extract_dir": "dcmtk-$matchVersion-win32-dynamic"
+                "extract_dir": "dcmtk-$version-win32-dynamic"
             },
             "64bit": {
                 "url": "https://dicom.offis.de/download/dcmtk/dcmtk367/bin/dcmtk-$version-win64-dynamic.zip",
-                "extract_dir": "dcmtk-$matchVersion-win64-dynamic"
+                "extract_dir": "dcmtk-$version-win64-dynamic"
             }
         }
     }


### PR DESCRIPTION
Adds DCMTK 3.6.7 for 32bit and 64bit.

Closes #5283

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
