### PR TITLE
qsv: Add version 0.119.0

### DIFF
--- a/bucket/qsv.json
+++ b/bucket/qsv.json
@@ -13,7 +13,11 @@
             "hash": "ae3149abec07ab73e826ee8ff7a497f2485dd2063d9a872f257ee66dd3bdc9d6"
         }
     },
-    "bin": "qsv.exe",
+    "bin": [
+        "qsv.exe",
+        "qsvdp.exe",
+        "qsvlite.exe"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/qsv.json
+++ b/bucket/qsv.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.119.0",
+    "description": "A command line CSV data-wrangling toolkit",
+    "homepage": "https://github.com/jqnatividad/qsv",
+    "license": "Unlicense|MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jqnatividad/qsv/releases/download/0.119.0/qsv-0.119.0-x86_64-pc-windows-msvc.zip",
+            "hash": "a33e3278d1bee72095250bda8cb07d0aed80b656dae4767cd1878c6aa4362ced"
+        },
+        "32bit": {
+            "url": "https://github.com/jqnatividad/qsv/releases/download/0.119.0/qsv-0.119.0-i686-pc-windows-msvc.zip",
+            "hash": "ae3149abec07ab73e826ee8ff7a497f2485dd2063d9a872f257ee66dd3bdc9d6"
+        }
+    },
+    "bin": "qsv.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jqnatividad/qsv/releases/download/$version/qsv-$version-x86_64-pc-windows-msvc.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/jqnatividad/qsv/releases/download/$version/qsv-$version-i686-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add [qsv](https://github.com/jqnatividad/qsv) - a command line CSV data-wrangling toolkit.

Closes #5284.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
