### PR TITLE
git: expose `openssl.exe`

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -42,6 +42,7 @@
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
         "cmd\\scalar.exe",
+        "usr\\bin\\openssl.exe",
         "usr\\bin\\tig.exe",
         "git-bash.exe"
     ],


### PR DESCRIPTION
`git` conveniently comes with `openssl.exe`, which can be a pain to install otherwise. However, I just noticed this by accident because it is not exposed as a shim. This PR fixes that.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
