### PR TITLE
Update quarkus-cli.json to 3.2.9.Final

### DIFF
--- a/bucket/quarkus-cli.json
+++ b/bucket/quarkus-cli.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.2.9.Final",
+    "version": "3.2.9",
     "description": "A CLI for Quarkus Java framework",
     "homepage": "https://quarkus.io/",
     "license": "Apache-2.0",
@@ -12,7 +12,7 @@
     "bin": "bin\\quarkus.bat",
     "checkver": {
         "url": "https://registry.quarkus.io/client/platforms",
-        "jsonpath": "$.platforms[0].streams[0].releases[0].version",
+        "jsonpath": "$..version",
         "regex": "([\\d+\\.]+)\\.Final"
     },
     "autoupdate": {

--- a/bucket/quarkus-cli.json
+++ b/bucket/quarkus-cli.json
@@ -1,14 +1,14 @@
 {
-    "version": "3.2.4",
+    "version": "3.2.9.Final",
     "description": "A CLI for Quarkus Java framework",
     "homepage": "https://quarkus.io/",
     "license": "Apache-2.0",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://github.com/quarkusio/quarkus/releases/download/3.2.4.Final/quarkus-cli-3.2.4.Final.zip",
-    "extract_dir": "quarkus-cli-3.2.4.Final",
-    "hash": "08bd77b31c56a21dc5163983d16bfe7fc2f4a9481e388365de6c0b353d5bb033",
+    "url": "https://github.com/quarkusio/quarkus/releases/download/3.2.9.Final/quarkus-cli-3.2.9.Final.zip",
+    "extract_dir": "quarkus-cli-3.2.9.Final",
+    "hash": "1a9eb087193544a5cee7ae650bb78b51ca7a90cbdef04d33e0f9c2b93565ad86",
     "bin": "bin\\quarkus.bat",
     "checkver": {
         "url": "https://registry.quarkus.io/client/platforms",


### PR DESCRIPTION
My current quarkus-cli is still at quarkus-cli 3.2.4 event after updating using `scoop update *`

<!-- Provide a general summary of your changes in the title above -->

This PR provides an intermediary fix to #5229 where we update quarkus-cli to the latest LTS (3.2.9 at this time).

Relates to #5229

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).