### PR TITLE
vcpkg: Add root directory as env variable

### DIFF
--- a/bucket/vcpkg.json
+++ b/bucket/vcpkg.json
@@ -11,6 +11,9 @@
         "keep": true
     },
     "bin": "vcpkg.exe",
+    "env_set": {
+        "VCPKG_ROOT": "$dir"
+    },
     "post_install": "vcpkg integrate install",
     "uninstaller": {
         "script": "vcpkg integrate remove"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Adds `VCPKG_ROOT` as an environment variable pointing to the current installed `vcpkg`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5189 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


I'd just like to say, that it could be an idea to set even more of the environment variables, because otherwise this is very tedious to use, but let's start with one. 