### PR TITLE
rga@0.9.6: Add runtime dependencies

### DIFF
--- a/bucket/rga.json
+++ b/bucket/rga.json
@@ -16,7 +16,10 @@
             "extract_dir": "ripgrep_all-v0.9.6-x86_64-pc-windows-msvc"
         }
     },
-    "bin": "rga.exe",
+    "bin": [
+        "rga.exe",
+        "rga-preproc.exe"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/rga.json
+++ b/bucket/rga.json
@@ -3,6 +3,12 @@
     "description": "ripgrep-all: ripgrep, but also search in PDFs, E-Books, Office documents, zip, tar.gz, etc.",
     "homepage": "https://github.com/phiresky/ripgrep-all",
     "license": "AGPL-3.0-or-later",
+    "depends": [
+        "ffmpeg",
+        "pandoc",
+        "poppler",
+        "ripgrep"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/phiresky/ripgrep-all/releases/download/v0.9.6/ripgrep_all-v0.9.6-x86_64-pc-windows-msvc.zip",

--- a/bucket/rga.json
+++ b/bucket/rga.json
@@ -20,7 +20,10 @@
         "rga.exe",
         "rga-preproc.exe"
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/phiresky/ripgrep-all/releases",
+        "regex": "tag/v([\\d.]+)\""
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
- Add list of dependencies.
- Add `rga-preproc` to binaries list.
- Update `checkver` to filter alpha-versions.

Closes #5310.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
