### PR TITLE
Update quarkus-cli.json to 3.6.0

### DIFF
--- a/bucket/quarkus-cli.json
+++ b/bucket/quarkus-cli.json
@@ -1,23 +1,23 @@
 {
-    "version": "3.2.9",
+    "version": "3.6.0",
     "description": "A CLI for Quarkus Java framework",
     "homepage": "https://quarkus.io/",
     "license": "Apache-2.0",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://github.com/quarkusio/quarkus/releases/download/3.2.9.Final/quarkus-cli-3.2.9.Final.zip",
-    "extract_dir": "quarkus-cli-3.2.9.Final",
-    "hash": "1a9eb087193544a5cee7ae650bb78b51ca7a90cbdef04d33e0f9c2b93565ad86",
+    "url": "https://github.com/quarkusio/quarkus/releases/download/3.6.0/quarkus-cli-3.6.0.zip",
+    "extract_dir": "quarkus-cli-3.6.0.zip",
+    "hash": "af5e4da6543d35124d599bbc0560dbac35e9953056f365e3ba44fa2243187660",
     "bin": "bin\\quarkus.bat",
     "checkver": {
         "url": "https://registry.quarkus.io/client/platforms",
-        "jsonpath": "$..version",
-        "regex": "([\\d+\\.]+)\\.Final"
+        "jsonpath": "$.platforms[0].streams[0].releases[0].version",
+        "regex": "([\\d+\\.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/quarkusio/quarkus/releases/download/$version.Final/quarkus-cli-$version.Final.zip",
-        "extract_dir": "quarkus-cli-$version.Final",
+        "url": "https://github.com/quarkusio/quarkus/releases/download/$version/quarkus-cli-$version.zip",
+        "extract_dir": "quarkus-cli-$version",
         "hash": {
             "url": "$baseurl/checksums_sha256.txt"
         }


### PR DESCRIPTION
- Remove "final" from version name since it has been removed by Quarkus starting version 3.3. https://quarkus.io/blog/quarkus-3-3-0-released/
- It is an updated version of this PR #5230 

Closes #5229 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
