### PR TITLE
go-swagger@0.30.5: Add arm64 version

### DIFF
--- a/bucket/go-swagger.json
+++ b/bucket/go-swagger.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/go-swagger/go-swagger/releases/download/v0.30.5/swagger_windows_amd64.exe#/swagger.exe",
             "hash": "aceb692b5592e576bb1e88e70d026552f33898d8d53996b8e001de8bd9117de0"
+        },
+        "arm64": {
+            "url": "https://github.com/go-swagger/go-swagger/releases/download/v0.30.5/swagger_windows_arm64.exe#/swagger.exe",
+            "hash": "02aff4699ead8bc607d31c121bf9691f9cd4c24d62d207dd9e3163fe0f97e08a"
         }
     },
     "bin": "swagger.exe",
@@ -17,7 +21,13 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/go-swagger/go-swagger/releases/download/v$version/swagger_windows_amd64.exe#/swagger.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/go-swagger/go-swagger/releases/download/v$version/swagger_windows_arm64.exe#/swagger.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
         }
     }
 }


### PR DESCRIPTION
- Add arm64 version.
- Add `hash` section for autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
