### PR TITLE
openfga: Add version 0.2.3

### DIFF
--- a/bucket/openfga.json
+++ b/bucket/openfga.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.2.0",
+  "description": "Relationship-based access control made fast, scalable, and easy to use",
+  "homepage": "https://openfga.dev/",
+  "license": "Apache-2.0",
+  "architecture": {
+      "64bit": {
+          "url": "https://github.com/openfga/cli/releases/download/v0.2.0/fga_0.2.0_windows_amd64.tar.gz",
+          "hash": "17cbac3b95394828840a53407077d409721ad881ca9a3205d8b6c01b166b20bf"
+      },
+      "32bit": {
+        "url": "https://github.com/openfga/cli/releases/download/v0.2.0/fga_0.2.0_windows_386.tar.gz",
+        "hash": "1888d7e123483e5dca375fef787fe7100a9b0647552ffb2a68e54a3194bd36fd"
+    },
+      "arm64": {
+        "url": "https://github.com/openfga/cli/releases/download/v0.2.0/fga_0.2.0_windows_arm64.tar.gz",
+        "hash": "af7217b6eeb3a7c5a0c5e0917c0e1c2c972707f0e8587d84c8e581b5f220bfd1"
+    }
+
+  },
+  "bin": "fga.exe",
+  "checkver": {
+      "github": "https://github.com/openfga/cli"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_amd64.tar.gz"
+          },
+          "32bit": {
+              "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_386.tar.gz"
+          },
+          "arm64": {
+              "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_arm64.tar.gz"
+          }
+      },
+      "hash": {
+          "url": "$baseurl/checksums.txt"
+      }
+  }
+}

--- a/bucket/openfga.json
+++ b/bucket/openfga.json
@@ -1,41 +1,40 @@
 {
-  "version": "0.2.0",
-  "description": "Relationship-based access control made fast, scalable, and easy to use",
-  "homepage": "https://openfga.dev/",
-  "license": "Apache-2.0",
-  "architecture": {
-      "64bit": {
-          "url": "https://github.com/openfga/cli/releases/download/v0.2.0/fga_0.2.0_windows_amd64.tar.gz",
-          "hash": "17cbac3b95394828840a53407077d409721ad881ca9a3205d8b6c01b166b20bf"
-      },
-      "32bit": {
-        "url": "https://github.com/openfga/cli/releases/download/v0.2.0/fga_0.2.0_windows_386.tar.gz",
-        "hash": "1888d7e123483e5dca375fef787fe7100a9b0647552ffb2a68e54a3194bd36fd"
+    "version": "0.2.3",
+    "description": "Relationship-based access control made fast, scalable, and easy to use",
+    "homepage": "https://openfga.dev",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/openfga/cli/releases/download/v0.2.3/fga_0.2.3_windows_amd64.tar.gz",
+            "hash": "e9236d3bb2b04abae0d632d4f330be943ba15c020ccc613eac1a5bd9511a715a"
+        },
+        "32bit": {
+            "url": "https://github.com/openfga/cli/releases/download/v0.2.3/fga_0.2.3_windows_386.tar.gz",
+            "hash": "c59ad1698e7f0e6ad404ad48c131c53fb1fcd63070e4748fc5359de148a5cc4a"
+        },
+        "arm64": {
+            "url": "https://github.com/openfga/cli/releases/download/v0.2.3/fga_0.2.3_windows_arm64.tar.gz",
+            "hash": "30831889ac7907552038c2d087124425247fe27258ac803a6116dad69bb7ce3a"
+        }
     },
-      "arm64": {
-        "url": "https://github.com/openfga/cli/releases/download/v0.2.0/fga_0.2.0_windows_arm64.tar.gz",
-        "hash": "af7217b6eeb3a7c5a0c5e0917c0e1c2c972707f0e8587d84c8e581b5f220bfd1"
+    "bin": "fga.exe",
+    "checkver": {
+        "github": "https://github.com/openfga/cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_amd64.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_arm64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
     }
-
-  },
-  "bin": "fga.exe",
-  "checkver": {
-      "github": "https://github.com/openfga/cli"
-  },
-  "autoupdate": {
-      "architecture": {
-          "64bit": {
-              "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_amd64.tar.gz"
-          },
-          "32bit": {
-              "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_386.tar.gz"
-          },
-          "arm64": {
-              "url": "https://github.com/openfga/cli/releases/download/v$version/fga_$version_windows_arm64.tar.gz"
-          }
-      },
-      "hash": {
-          "url": "$baseurl/checksums.txt"
-      }
-  }
 }


### PR DESCRIPTION
Adds manifest to support OpenFGA cli. 

Supports 32bit, 64bit, arm64. 

Closes #5330

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
