### PR TITLE
k9s@0.29.1: Fix hash check

### DIFF
--- a/bucket/k9s.json
+++ b/bucket/k9s.json
@@ -25,7 +25,8 @@
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.txt"
+            "url": "$baseurl/checksums.sha256",
+            "regex": "$sha256  $basename\\n"
         }
     }
 }


### PR DESCRIPTION
- Update link to checksums file.
- Add hash regex to filter out `.sbom` files.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
