### PR TITLE
protolint: Update to version 0.46.3

### DIFF
--- a/bucket/protolint.json
+++ b/bucket/protolint.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/yoheimuta/protolint/releases/download/v0.46.3/protolint_0.46.3_windows_amd64.tar.gz",
             "hash": "9bd65feb4237eff8d4498bd0e29bfc45205dcf63664e60b06172df82e83b790f"
+        },
+        "arm64": {
+            "url": "https://github.com/yoheimuta/protolint/releases/download/v0.46.3/protolint_0.46.3_windows_arm64.tar.gz",
+            "hash": "858bdcbe7aa108fa8138845d76bc251c0ef1c7f5121bd9636b7c0ec1ad86d7c7"
         }
     },
     "bin": [
@@ -18,6 +22,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/yoheimuta/protolint/releases/download/v$version/protolint_$version_windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/yoheimuta/protolint/releases/download/v$version/protolint_$version_windows_arm64.tar.gz"
             }
         },
         "hash": {

--- a/bucket/protolint.json
+++ b/bucket/protolint.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.45.0",
+    "version": "0.46.3",
     "description": "A pluggable linter and fixer to enforce Protocol Buffer style and conventions",
     "homepage": "https://github.com/yoheimuta/protolint",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/yoheimuta/protolint/releases/download/v0.45.0/protolint_0.45.0_Windows_x86_64.tar.gz",
-            "hash": "13afd01ff49f04dd688d4b346d2e350d854c96a0834a4683d0c83b78631f5f27"
+            "url": "https://github.com/yoheimuta/protolint/releases/download/v0.46.3/protolint_0.46.3_windows_amd64.tar.gz",
+            "hash": "9bd65feb4237eff8d4498bd0e29bfc45205dcf63664e60b06172df82e83b790f"
         }
     },
     "bin": [
@@ -17,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/yoheimuta/protolint/releases/download/v$version/protolint_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/yoheimuta/protolint/releases/download/v$version/protolint_$version_windows_amd64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 0.46.3.
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
