### PR TITLE
vultr: Update to version 2.21.0

### DIFF
--- a/bucket/vultr.json
+++ b/bucket/vultr.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.17.0",
+    "version": "2.21.0",
     "description": "The official Vultr CLI tool.",
     "homepage": "https://github.com/vultr/vultr-cli/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vultr/vultr-cli/releases/download/v2.17.0/vultr-cli_2.17.0_windows_64-bit.zip",
-            "hash": "bab4de51bf54014498528721eca67610d7e508b9f24f8c5b169ee6304f3d9b52"
+            "url": "https://github.com/vultr/vultr-cli/releases/download/v2.21.0/vultr-cli_v2.21.0_windows_amd64.zip",
+            "hash": "550e829e97da3c74e1e76e46141d1db8c5ba61fdef1f548fc61d509aa64c196e"
         },
         "arm64": {
-            "url": "https://github.com/vultr/vultr-cli/releases/download/v2.17.0/vultr-cli_2.17.0_windows_arm64-bit.zip",
-            "hash": "97e6ce0a606f6911ec0effd22baf6c3f3fa25ca365cc93cebecf4ad634e6449b"
+            "url": "https://github.com/vultr/vultr-cli/releases/download/v2.21.0/vultr-cli_v2.21.0_windows_arm64.zip",
+            "hash": "4b44ecd98aa12926a05d3085eeb1b245fe5718f6a7f665d7fa7eb1ac972f2349"
         }
     },
     "bin": "vultr-cli.exe",
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vultr/vultr-cli/releases/download/v$version/vultr-cli_$version_windows_64-bit.zip"
+                "url": "https://github.com/vultr/vultr-cli/releases/download/v$version/vultr-cli_v$version_windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/vultr/vultr-cli/releases/download/v$version/vultr-cli_$version_windows_arm64-bit.zip"
+                "url": "https://github.com/vultr/vultr-cli/releases/download/v$version/vultr-cli_v$version_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 2.21.0.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
