### PR TITLE
kubeshark: Update to version 51.0.39

### DIFF
--- a/bucket/kubeshark.json
+++ b/bucket/kubeshark.json
@@ -1,12 +1,12 @@
 {
-    "version": "50.4",
+    "version": "51.0.39",
     "description": "The API Traffic Viewer for Kubernetes",
     "homepage": "https://kubeshark.co",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kubeshark/kubeshark/releases/download/50.4/kubeshark.exe",
-            "hash": "fb208ed1f476e0400797056bc8c98f61e253c6216785741e9161f939faac358b"
+            "url": "https://github.com/kubeshark/kubeshark/releases/download/v51.0.39/kubeshark.exe",
+            "hash": "ae9ce00b1dccb580608ae639dca46b360f0c0db2850d77dae4afa266d3f2a1da"
         }
     },
     "bin": "kubeshark.exe",
@@ -16,7 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kubeshark/kubeshark/releases/download/$version/kubeshark.exe",
+                "url": "https://github.com/kubeshark/kubeshark/releases/download/v$version/kubeshark.exe",
                 "hash": {
                     "url": "$baseurl/kubeshark_windows_amd64.sha256",
                     "regex": "$sha256"


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 51.0.39.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
