### PR TITLE
qrcp: Update to version 0.11.0

### DIFF
--- a/bucket/qrcp.json
+++ b/bucket/qrcp.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.10.1",
+    "version": "0.11.0",
     "description": "Transfers files over wifi from computer to mobile device by scanning a QR code without leaving the terminal.",
-    "homepage": "https://claudiodangelis.com/qrcp/",
+    "homepage": "https://qrcp.sh/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/claudiodangelis/qrcp/releases/download/0.10.1/qrcp_0.10.1_Windows_x86_64.tar.gz",
-            "hash": "93aa8b56c2eb543f97d2e36682e2d47d9aa0cac6f82713af275168c92ff4a1f7"
+            "url": "https://github.com/claudiodangelis/qrcp/releases/download/0.11.0/qrcp_0.11.0_windows_amd64.tar.gz",
+            "hash": "c7eef84a343b68ec81a2a8ee5701af59202a2f151b27cb74589a02cb5eac43d6"
         },
         "32bit": {
-            "url": "https://github.com/claudiodangelis/qrcp/releases/download/0.10.1/qrcp_0.10.1_Windows_i386.tar.gz",
-            "hash": "8c54fd9d613cfa9049634e42476a6317d4fe59e99cc1412824aa1d1c2956f678"
+            "url": "https://github.com/claudiodangelis/qrcp/releases/download/0.11.0/qrcp_0.11.0_windows_386.tar.gz",
+            "hash": "70c32ef00ae19efc3abdce094f8e1a1171d26222597ae65daeb5b615d5e009d8"
         }
     },
     "bin": "qrcp.exe",
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/claudiodangelis/qrcp/releases/download/$version/qrcp_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/claudiodangelis/qrcp/releases/download/$version/qrcp_$version_windows_amd64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/claudiodangelis/qrcp/releases/download/$version/qrcp_$version_Windows_i386.tar.gz"
+                "url": "https://github.com/claudiodangelis/qrcp/releases/download/$version/qrcp_$version_windows_386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 0.11.0.
- Update homepage.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
