### PR TITLE
kubectl@1.29.0: update homepage, hashes, arm64, and exposing kubectl-convert.exe

### DIFF
--- a/bucket/kubectl.json
+++ b/bucket/kubectl.json
@@ -1,7 +1,7 @@
 {
     "version": "1.29.0",
     "description": "Control the Kubernetes cluster manager.",
-    "homepage": "https://kubernetes.io/docs/user-guide/kubectl-overview/",
+    "homepage": "https://kubernetes.io/docs/reference/kubectl/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -11,10 +11,17 @@
         "32bit": {
             "url": "https://storage.googleapis.com/kubernetes-release/release/v1.29.0/kubernetes-client-windows-386.tar.gz",
             "hash": "ed8106e9b2b6b613750f74c14e5de2358d2952e212e94418ac89a97d7b9c82be"
+        },
+        "arm64": {
+            "url": "https://storage.googleapis.com/kubernetes-release/release/v1.29.0/kubernetes-client-windows-arm64.tar.gz",
+            "hash": "1066fa078be01c1ed4829384800f323c02136250cd7930c6af8171ff137b354e"
         }
     },
     "extract_dir": "kubernetes\\client",
-    "bin": "bin\\kubectl.exe",
+    "bin": [
+        "bin\\kubectl.exe",
+        "bin\\kubectl-convert.exe"
+    ],
     "checkver": {
         "url": "https://storage.googleapis.com/kubernetes-release/release/stable.txt",
         "regex": "v([\\d.]+)"
@@ -26,10 +33,13 @@
             },
             "32bit": {
                 "url": "https://storage.googleapis.com/kubernetes-release/release/v$version/kubernetes-client-windows-386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://storage.googleapis.com/kubernetes-release/release/v$version/kubernetes-client-windows-arm64.tar.gz"
             }
         },
         "hash": {
-            "url": "$url.sha1"
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
Closes #5352 
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
