### PR TITLE
ruff: Update to version 0.1.8

### DIFF
--- a/bucket/ruff.json
+++ b/bucket/ruff.json
@@ -1,20 +1,20 @@
 {
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "An extremely fast Python linter, written in Rust",
-    "homepage": "https://github.com/charliermarsh/ruff",
+    "homepage": "https://github.com/astral-sh/ruff",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.1.7/ruff-x86_64-pc-windows-msvc.zip",
-            "hash": "cfb44b8fe17cf6b197722f89df6216509784731af8c9251b02c37e671f3dbcdd"
+            "url": "https://github.com/astral-sh/ruff/releases/download/v0.1.8/ruff-0.1.8-x86_64-pc-windows-msvc.zip",
+            "hash": "8706e8a644919f827f6e1af30184cfb7f74c675cc7b1a9c61047b0ca5b428dfd"
         },
         "32bit": {
-            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.1.7/ruff-i686-pc-windows-msvc.zip",
-            "hash": "746aea743e8734e992f40ed2de5afd8fb28a9916dbcfe34736071902532b902a"
+            "url": "https://github.com/astral-sh/ruff/releases/download/v0.1.8/ruff-0.1.8-i686-pc-windows-msvc.zip",
+            "hash": "ec03ca13aafabe067d4cd54f080efd3d7924f232966767dbdf448d987cfeabeb"
         },
         "arm64": {
-            "url": "https://github.com/charliermarsh/ruff/releases/download/v0.1.7/ruff-aarch64-pc-windows-msvc.zip",
-            "hash": "c99c9ba70a61cf816b4a3e2c1ce6fc132a6eb480eaf411c864de4bcf6a121374"
+            "url": "https://github.com/astral-sh/ruff/releases/download/v0.1.8/ruff-0.1.8-aarch64-pc-windows-msvc.zip",
+            "hash": "7a0f62c8c02d75fb83a12d55328aa853f6f90423ca6a6264b69bbcb8f7e97945"
         }
     },
     "bin": "ruff.exe",
@@ -22,13 +22,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/astral-sh/ruff/releases/download/v$version/ruff-$version-x86_64-pc-windows-msvc.zip"
             },
             "32bit": {
-                "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-i686-pc-windows-msvc.zip"
+                "url": "https://github.com/astral-sh/ruff/releases/download/v$version/ruff-$version-i686-pc-windows-msvc.zip"
             },
             "arm64": {
-                "url": "https://github.com/charliermarsh/ruff/releases/download/v$version/ruff-aarch64-pc-windows-msvc.zip"
+                "url": "https://github.com/astral-sh/ruff/releases/download/v$version/ruff-$version-aarch64-pc-windows-msvc.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 0.1.8.
- Update homepage.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
