### PR TITLE
scc: Update to version 3.2.0

### DIFF
--- a/bucket/scc.json
+++ b/bucket/scc.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Sloc, Cloc and Code (scc) is a very fast accurate code counter with complexity calculations and COCOMO estimates.",
     "homepage": "https://github.com/boyter/scc",
     "license": "MIT|Unlicense",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/boyter/scc/releases/download/v3.1.0/scc_3.1.0_Windows_x86_64.tar.gz",
-            "hash": "ba1e43810ff830abfa05bee6dc31839844f142b949ecfaa8d6940dfc49506c83"
+            "url": "https://github.com/boyter/scc/releases/download/v3.2.0/scc_Windows_x86_64.zip",
+            "hash": "665a230983967f651723a06676c925314a0875637a16bf636d83661adf079d5c"
         },
         "32bit": {
-            "url": "https://github.com/boyter/scc/releases/download/v3.1.0/scc_3.1.0_Windows_i386.tar.gz",
-            "hash": "615381e9e4d56f8101a706efdff48f61c2cf39cfc6455d248fbb335648fabc9b"
+            "url": "https://github.com/boyter/scc/releases/download/v3.2.0/scc_Windows_i386.zip",
+            "hash": "f4dc53b613ed01d2626914f2f1d27093d587df4580a5ccdc40c972f84c0a8ae4"
         }
     },
     "bin": "scc.exe",
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/boyter/scc/releases/download/v$version/scc_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/boyter/scc/releases/download/v$version/scc_Windows_x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/boyter/scc/releases/download/v$version/scc_$version_Windows_i386.tar.gz"
+                "url": "https://github.com/boyter/scc/releases/download/v$version/scc_Windows_i386.zip"
             }
         },
         "hash": {

--- a/bucket/scc.json
+++ b/bucket/scc.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/boyter/scc/releases/download/v3.2.0/scc_Windows_i386.zip",
             "hash": "f4dc53b613ed01d2626914f2f1d27093d587df4580a5ccdc40c972f84c0a8ae4"
+        },
+        "arm64": {
+            "url": "https://github.com/boyter/scc/releases/download/v3.2.0/scc_Windows_arm64.zip",
+            "hash": "e1977c2774859132bfe9a3b2d7af0511d433575f2e166bcd2edfbadc54b0b14c"
         }
     },
     "bin": "scc.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/boyter/scc/releases/download/v$version/scc_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/boyter/scc/releases/download/v$version/scc_Windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 3.2.0.
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
