### PR TITLE
ssh3: Add version 0.1.5-rc5

### DIFF
--- a/bucket/ssh3.json
+++ b/bucket/ssh3.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.1.4-bsd",
+    "description": "SSH3: faster and rich secure shell using HTTP/3",
+    "homepage": "https://github.com/francoismichel/ssh3",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.4-bsd/ssh3_0.1.4-bsd_clientonly_windows_x86_64.zip",
+            "hash": "10f94c767923ec1b38f0c092fc6a818868626c61c0050869547899d4a2a61bb9"
+        },
+        "32bit": {
+            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.4-bsd/ssh3_0.1.4-bsd_clientonly_windows_i386.zip",
+            "hash": "80b803d82e9a2b8f11ea4f495aa19d04a064ffeb51b38dd3546cd546a77f3fa1"
+        },
+        "arm64": {
+            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.4-bsd/ssh3_0.1.4-bsd_clientonly_windows_arm64.zip",
+            "hash": "bf103629ae4445b4cd73c30d9aabecba08232f501d28ce8aec1626dccd7a0116"
+        }
+    },
+    "bin": "ssh3.exe",
+    "checkver": {
+        "url": "https://api.github.com/repositories/712363932/releases",
+        "jsonpath": "$[0].tag_name",
+        "regex": "v([\\d.]+(?:-[^-]+)?)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/francoismichel/ssh3/releases/download/v$version/ssh3_$version_clientonly_windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/francoismichel/ssh3/releases/download/v$version/ssh3_$version_clientonly_windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/francoismichel/ssh3/releases/download/v$version/ssh3_$version_clientonly_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/ssh3_$version_clientonly_windows_checksums.txt"
+        }
+    }
+}

--- a/bucket/ssh3.json
+++ b/bucket/ssh3.json
@@ -1,20 +1,20 @@
 {
-    "version": "0.1.4-bsd",
+    "version": "0.1.5-rc5",
     "description": "SSH3: faster and rich secure shell using HTTP/3",
     "homepage": "https://github.com/francoismichel/ssh3",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.4-bsd/ssh3_0.1.4-bsd_clientonly_windows_x86_64.zip",
-            "hash": "10f94c767923ec1b38f0c092fc6a818868626c61c0050869547899d4a2a61bb9"
+            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.5-rc5/ssh3_0.1.5-rc5_clientonly_windows_x86_64.zip",
+            "hash": "ca6e4d72763462ad092f2d7fd9363ecd25c8297e09b1068eb193391bf51ea976"
         },
         "32bit": {
-            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.4-bsd/ssh3_0.1.4-bsd_clientonly_windows_i386.zip",
-            "hash": "80b803d82e9a2b8f11ea4f495aa19d04a064ffeb51b38dd3546cd546a77f3fa1"
+            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.5-rc5/ssh3_0.1.5-rc5_clientonly_windows_i386.zip",
+            "hash": "44e8572c0d4d737dbd72fbcf28ba3d56a9043ebe077fcc3c1446376e0fd74549"
         },
         "arm64": {
-            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.4-bsd/ssh3_0.1.4-bsd_clientonly_windows_arm64.zip",
-            "hash": "bf103629ae4445b4cd73c30d9aabecba08232f501d28ce8aec1626dccd7a0116"
+            "url": "https://github.com/francoismichel/ssh3/releases/download/v0.1.5-rc5/ssh3_0.1.5-rc5_clientonly_windows_arm64.zip",
+            "hash": "fd6b52dc940b9fce5fa8e04f645eed95d34dc0803d3cc5b13a74a185bf906777"
         }
     },
     "bin": "ssh3.exe",


### PR DESCRIPTION
Currently on Windows, it's only a client
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).