### PR TITLE
signal-cli: Update to version 0.12.7

### DIFF
--- a/bucket/signal-cli.json
+++ b/bucket/signal-cli.json
@@ -1,18 +1,18 @@
 {
-    "version": "0.12.2",
+    "version": "0.12.7",
     "description": "A cross-platform encrypted messaging service (command line/dbus version).",
     "homepage": "https://github.com/AsamK/signal-cli",
     "license": "GPL-3.0-only",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://github.com/AsamK/signal-cli/releases/download/v0.12.2/signal-cli-0.12.2-Windows.tar.gz",
-    "hash": "191c52b48ba61a7282046e291b989f7734cefd1872a8a0c9fe2cad5bca88013d",
-    "extract_dir": "signal-cli-0.12.2",
+    "url": "https://github.com/AsamK/signal-cli/releases/download/v0.12.7/signal-cli-0.12.7.tar.gz",
+    "hash": "3e862fd32ab917e19c7645b184b0de841a818df2caa949e65adcfd9971890d5d",
+    "extract_dir": "signal-cli-0.12.7",
     "bin": "bin\\signal-cli.bat",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/AsamK/signal-cli/releases/download/v$version/signal-cli-$version-Windows.tar.gz",
+        "url": "https://github.com/AsamK/signal-cli/releases/download/v$version/signal-cli-$version.tar.gz",
         "extract_dir": "signal-cli-$version"
     }
 }


### PR DESCRIPTION
- Fix autoupdate.
- Update to version 0.12.7.

Relates to AsamK/signal-cli#1349.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
