### PR TITLE
kubectx@0.9.5: Add arm64 version

### DIFF
--- a/bucket/kubectx.json
+++ b/bucket/kubectx.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/ahmetb/kubectx/releases/download/v0.9.5/kubectx_v0.9.5_windows_x86_64.zip",
             "hash": "cfff77b5c59ed37e0aff39b16effb2c4cc47ccb96d58999a0fe5c6e2fa3c0013"
+        },
+        "arm64": {
+            "url": "https://github.com/ahmetb/kubectx/releases/download/v0.9.5/kubectx_v0.9.5_windows_arm64.zip",
+            "hash": "8fe01511ac925b6ed0c16e57d8fd6d69961aab9cf73f23a0d1cd46f6cb6495aa"
         }
     },
     "bin": "kubectx.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ahmetb/kubectx/releases/download/v$version/kubectx_v$version_windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/ahmetb/kubectx/releases/download/v$version/kubectx_v$version_windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/kubens.json
+++ b/bucket/kubens.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/ahmetb/kubectx/releases/download/v0.9.5/kubens_v0.9.5_windows_x86_64.zip",
             "hash": "1ee8adb273a391bbf35f67484bf41fd9b02aa0cd06cbcfbd488b211619fd4da9"
+        },
+        "arm64": {
+            "url": "https://github.com/ahmetb/kubectx/releases/download/v0.9.5/kubens_v0.9.5_windows_arm64.zip",
+            "hash": "2d7e53c3a34413d3a0c43ffb15f3ab4d97305fc694b1a4b5e8cc84ec09a796b1"
         }
     },
     "bin": "kubens.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/ahmetb/kubectx/releases/download/v$version/kubens_v$version_windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/ahmetb/kubectx/releases/download/v$version/kubens_v$version_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Since both `kubectx` and `kubens` are from the same repo I used the only PR to update both manifests.

- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
