### PR TITLE
Update libjxl.json

### DIFF
--- a/bucket/libjxl.json
+++ b/bucket/libjxl.json
@@ -20,7 +20,6 @@
         "butteraugli_main.exe",
         "cjpegli.exe",
         "cjxl.exe",
-        // "cjpeg_hdr.exe",
         "decode_and_encode.exe",
         "display_to_hlg.exe",
         "djpegli.exe",      

--- a/bucket/libjxl.json
+++ b/bucket/libjxl.json
@@ -17,9 +17,19 @@
     "bin": [
         "benchmark_xl.exe",
         "brotli.exe",
-        "cjpeg_hdr.exe",
+        "butteraugli_main.exe",
+        "cjpegli.exe",
         "cjxl.exe",
+        // "cjpeg_hdr.exe",
+        "decode_and_encode.exe",
+        "display_to_hlg.exe",
+        "djpegli.exe",      
         "djxl.exe",
+        "djxl_fuzzer_corpus.exe",
+        "exr_to_pq.exe",
+        "generate_lut_template.exe",
+        "jpegli_dec_fuzzer_corpus.exe",
+        "jxl_from_tree.exe",
         "jxlinfo.exe"
     ],
     "checkver": {


### PR DESCRIPTION
added all available bins in this release and commented out bin "cjpeg_hdr.exe" because it is no longer distributed in this release

Happy New Year 2024

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
