### PR TITLE
go-sqlcmd: Add version 1.5.0

### DIFF
--- a/bucket/go-sqlcmd.json
+++ b/bucket/go-sqlcmd.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/microsoft/go-sqlcmd/releases/download/v1.5.0/sqlcmd-v1.5.0-windows-x64.zip",
             "hash": "6cd1d11a463549757efd8ef6daaa3a9413ccf85950ef9a49716041fdbdedc01d"
+        },
+        "arm64": {
+            "url": "https://github.com/microsoft/go-sqlcmd/releases/download/v1.5.0/sqlcmd-v1.5.0-windows-arm64.zip",
+            "hash": "28ae735730f0020a0d44c9e453f56979c2da2a5e313e2f1209d3fbb121c361a1"
         }
     },
     "bin": "sqlcmd.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/microsoft/go-sqlcmd/releases/download/v$version/sqlcmd-v$version-windows-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/microsoft/go-sqlcmd/releases/download/v$version/sqlcmd-v$version-windows-arm64.zip"
             }
         }
     }

--- a/bucket/go-sqlcmd.json
+++ b/bucket/go-sqlcmd.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.5.0",
+    "description": "sqlcmd is a multi-platform command line experience for Microsoft SQL Server and Azure SQL",
+    "homepage": "https://github.com/microsoft/go-sqlcmd",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/microsoft/go-sqlcmd/releases/download/v1.5.0/sqlcmd-v1.5.0-windows-x64.zip",
+            "hash": "6cd1d11a463549757efd8ef6daaa3a9413ccf85950ef9a49716041fdbdedc01d"
+        }
+    },
+    "bin": "sqlcmd.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/microsoft/go-sqlcmd/releases/download/$version/sqlcmd-$version-windows-x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/go-sqlcmd.json
+++ b/bucket/go-sqlcmd.json
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/go-sqlcmd/releases/download/$version/sqlcmd-$version-windows-x64.zip"
+                "url": "https://github.com/microsoft/go-sqlcmd/releases/download/v$version/sqlcmd-v$version-windows-x64.zip"
             }
         }
     }


### PR DESCRIPTION
This PR will add the sqlcmd standalone implementation. sqlcmd is the standard Microsoft command line experience for Microsoft SQL Server and Azure SQL

Closes #5367

- [ X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
