### PR TITLE
k9s: Persist config and logs

### DIFF
--- a/bucket/k9s.json
+++ b/bucket/k9s.json
@@ -14,6 +14,10 @@
         }
     },
     "bin": "k9s.exe",
+    "env_set": {
+        "K9S_CONFIG_DIR": "$persist_dir/config",
+        "K9S_LOGS_DIR": "$persist_dir/logs"
+    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Scoop persist folder is used to persist k9s config and logs.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5388

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
