### PR TITLE
zookeeper@3.9.1: Fix checkver

### DIFF
--- a/bucket/zookeeper.json
+++ b/bucket/zookeeper.json
@@ -6,7 +6,7 @@
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://www.apache.org/dist/zookeeper/zookeeper-3.9.1/apache-zookeeper-3.9.1-bin.tar.gz",
+    "url": "https://downloads.apache.org/zookeeper/zookeeper-3.9.1/apache-zookeeper-3.9.1-bin.tar.gz",
     "hash": "sha512:6a1c56557ee8de63dc0730de6c55640afa8ae9043e57539fed393120fe3adfb7f30a6ac13af0a6331ff34ba9c6f2b31e41e40c5446e669651522fffb9ce64e48",
     "extract_dir": "apache-zookeeper-3.9.1-bin",
     "post_install": [
@@ -19,12 +19,12 @@
     ],
     "persist": "data",
     "checkver": {
-        "url": "https://www.apache.org/dist/zookeeper/",
+        "url": "https://downloads.apache.org/zookeeper/",
         "regex": "zookeeper-([\\d.]+)/",
         "reverse": true
     },
     "autoupdate": {
-        "url": "https://www.apache.org/dist/zookeeper/zookeeper-$version/apache-zookeeper-$version-bin.tar.gz",
+        "url": "https://downloads.apache.org/zookeeper/zookeeper-$version/apache-zookeeper-$version-bin.tar.gz",
         "hash": {
             "url": "$url.sha512"
         },


### PR DESCRIPTION
- Update urls for binary/checkver/autoupdate since path for artifacts download changed.

From Excavator logs:

> zookeeper: couldn't match 'zookeeper-([\d.]+)/' in https://www.apache.org/dist/zookeeper/

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
