### PR TITLE
hledger: 1.32.2 added a new binary hledger-ui.exe

### DIFF
--- a/bucket/hledger.json
+++ b/bucket/hledger.json
@@ -11,7 +11,8 @@
     },
     "bin": [
         "hledger.exe",
-        "hledger-web.exe"
+        "hledger-web.exe",
+        "hledger-ui.exe"
     ],
     "checkver": {
         "github": "https://github.com/simonmichael/hledger"

--- a/bucket/hledger.json
+++ b/bucket/hledger.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/simonmichael/hledger/releases/download/1.32.2/hledger-windows-x64.zip",
-            "hash": "12fa9d70d6920584dac5072ab2d9038a2bc5d14b9bd445683dc3f750a84e3df0"
+            "hash": "fa16b3d6e29230a505746000c8fbc4c81145fcd961abc8bd1df63e22ed35f12d"
         }
     },
     "bin": [


### PR DESCRIPTION
The 1.32.2 release of `hledger` features a new Windows binary named `hledger-ui.exe`.  Unfortunately, the initial release .zip file did not include this binary. A new .zip was uploaded but the release version was not updated. So the download hash has changed.

This PR adds the `hledger-ui.exe` shim, and updates the hash for the updated .zip file.

