### PR TITLE
2024-01-05: Windows zip file fixed to include hledger-ui. Hash changed.

### DIFF
--- a/bucket/hledger.json
+++ b/bucket/hledger.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/simonmichael/hledger/releases/download/1.32.2/hledger-windows-x64.zip",
-            "hash": "12fa9d70d6920584dac5072ab2d9038a2bc5d14b9bd445683dc3f750a84e3df0"
+            "hash": "fa16b3d6e29230a505746000c8fbc4c81145fcd961abc8bd1df63e22ed35f12d"
         }
     },
     "bin": [


### PR DESCRIPTION
2024-01-05: Windows zip file fixed to include hledger-ui.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
