### PR TITLE
hashcat@6.2.6: Persist potfile

### DIFF
--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -10,10 +10,12 @@
         }
     },
     "extract_dir": "hashcat-6.2.6",
-    "persist": ["hashcat.potfile"],
+    "persist": "hashcat.potfile",
     "pre_install": [
         "Set-Content -Value \"@echo off`r`npushd $dir`r`nhashcat.exe %*`r`npopd\" -Path \"$dir\\hashcat.cmd\"",
-        "New-Item $dir\\hashcat.potfile -ItemType File"
+        "# potfile, https://hashcat.net/faq/potfile",
+        "$pot = 'hashcat.potfile'",
+        "if (!(Test-Path \"$persist_dir\\$pot\")) { New-Item \"$dir\\$pot\" }"
     ],
     "bin": "hashcat.cmd",
     "checkver": {

--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -10,7 +10,11 @@
         }
     },
     "extract_dir": "hashcat-6.2.6",
-    "pre_install": "Set-Content -Value \"@echo off`r`npushd $dir`r`nhashcat.exe %*`r`npopd\" -Path \"$dir\\hashcat.cmd\"",
+    "persist": ["hashcat.potfile"],
+    "pre_install": [
+        "Set-Content -Value \"@echo off`r`npushd $dir`r`nhashcat.exe %*`r`npopd\" -Path \"$dir\\hashcat.cmd\"",
+        "New-Item $dir\\hashcat.potfile -ItemType File"
+    ],
     "bin": "hashcat.cmd",
     "checkver": {
         "github": "https://github.com/hashcat/hashcat"


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

The potfile contains hashes and passwords that should be persisted.