### PR TITLE
Windows application driver fix

### DIFF
--- a/bucket/windows-application-driver.json
+++ b/bucket/windows-application-driver.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi",
     "hash": "a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe",
     "bin": "Windows Application Driver\\WinAppDriver.exe",
+    "post_install": "mv $dir\\System\\* $dir\\Windows*",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v$version/WindowsApplicationDriver_$version.msi"

--- a/bucket/windows-application-driver.json
+++ b/bucket/windows-application-driver.json
@@ -5,11 +5,13 @@
     "license": "MIT",
     "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi",
     "hash": "a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe",
-    "bin": "Windows Application Driver\\WinAppDriver.exe",
-    "post_install": "mv $dir\\System\\* $dir\\Windows*",
     "env_set": {
         "APPIUM_WAD_PATH": "$dir\\Windows Application Driver\\WinAppDriver.exe"
     },
+    "post_install": [
+        "Move-Item \"$dir\\System\\*\", \"$dir\\Windows Application Driver\\*\" -Destination \"$dir\"",
+        "Remove-Item \"$dir\\System\", \"$dir\\Windows Application Driver\""
+    ],
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v$version/WindowsApplicationDriver_$version.msi"

--- a/bucket/windows-application-driver.json
+++ b/bucket/windows-application-driver.json
@@ -7,6 +7,9 @@
     "hash": "a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe",
     "bin": "Windows Application Driver\\WinAppDriver.exe",
     "post_install": "mv $dir\\System\\* $dir\\Windows*",
+    "env_set": {
+        "APPIUM_WAD_PATH": "$dir\\Windows Application Driver\\WinAppDriver.exe"
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v$version/WindowsApplicationDriver_$version.msi"

--- a/bucket/windows-application-driver.json
+++ b/bucket/windows-application-driver.json
@@ -5,12 +5,13 @@
     "license": "MIT",
     "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi",
     "hash": "a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe",
-    "env_set": {
-        "APPIUM_WAD_PATH": "$dir\\Windows Application Driver\\WinAppDriver.exe"
-    },
     "post_install": [
         "Move-Item \"$dir\\System\\*\", \"$dir\\Windows Application Driver\\*\" -Destination \"$dir\"",
         "Remove-Item \"$dir\\System\", \"$dir\\Windows Application Driver\""
+    ],
+    "notes": [
+        "Declare custom WinAppDriver.exe location for appium-windows-driver:",
+        "'setx APPIUM_WAD_PATH \"$dir\\WinAppDriver.exe\"'"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/windows-application-driver.json
+++ b/bucket/windows-application-driver.json
@@ -3,16 +3,17 @@
     "description": "Supports Selenium-like UI Test Automation on Windows Applications.",
     "homepage": "https://github.com/Microsoft/WinAppDriver",
     "license": "MIT",
+    "notes": [
+        "Declare custom WinAppDriver.exe location for appium-windows-driver:",
+        "'$Env:APPIUM_WAD_PATH = \"$dir\\WinAppDriver.exe\"'"
+    ],
     "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi",
     "hash": "a76a8f4e44b29bad331acf6b6c248fcc65324f502f28826ad2acd5f3c80857fe",
     "post_install": [
         "Move-Item \"$dir\\System\\*\", \"$dir\\Windows Application Driver\\*\" -Destination \"$dir\"",
         "Remove-Item \"$dir\\System\", \"$dir\\Windows Application Driver\""
     ],
-    "notes": [
-        "Declare custom WinAppDriver.exe location for appium-windows-driver:",
-        "'setx APPIUM_WAD_PATH \"$dir\\WinAppDriver.exe\"'"
-    ],
+    "bin": "WinAppDriver.exe",
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/Microsoft/WinAppDriver/releases/download/v$version/WindowsApplicationDriver_$version.msi"


### PR DESCRIPTION
Two fixes to streamline the use of Windows Application Driver aka WinAppDriver aka WAD:
- move supporting dlls from System folder next to WinAppDriver.exe: otherwise the supporting dlls are not in path and WAD fails to run
- set APPIUM_WAD_PATH environment variable with custom WAD location: appium-windows-driver can use WAD as installed by the installer, but needs to be informed of the location of the scoop installed version

These two fixes allow to transparently replace WAD installed by the installer with WAD installed by scoop.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
