### PR TITLE
Update to the new asset names in Git Town v11

### DIFF
--- a/bucket/git-town.json
+++ b/bucket/git-town.json
@@ -19,7 +19,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/git-town/git-town/releases/download/v$version/git-town_$version_windows_intel_64.zip"
+                "url": "https://github.com/git-town/git-town/releases/download/v$version/git-town_windows_intel_64.zip"
             }
         }
     }

--- a/bucket/git-town.json
+++ b/bucket/git-town.json
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-town/git-town/releases/download/v10.0.2/git-town_10.0.2_windows_intel_64.zip",
-            "hash": "5f2c18dc2b7fef368dc40656dbe7abd32925b58e07ffd119b1c293f57d94a5e7"
+            "url": "https://github.com/git-town/git-town/releases/download/v11.1.0/git-town_windows_intel_64.zip",
+            "hash": "7e3090b142536c615ffc46901f4343653a1509318879756e859900c13f413a67"
         }
     },
     "bin": "git-town.exe",

--- a/bucket/git-town.json
+++ b/bucket/git-town.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.0.2",
+    "version": "11.1.0",
     "description": "Git plugin, that adds Git commands that make collaborative software development more efficient and safe.",
     "homepage": "https://www.git-town.com",
     "license": "MIT",

--- a/bucket/git-town.json
+++ b/bucket/git-town.json
@@ -1,6 +1,6 @@
 {
     "version": "11.1.0",
-    "description": "Git plugin, that adds Git commands that make collaborative software development more efficient and safe.",
+    "description": "Git plugin that adds Git commands that make collaborative software development more efficient and safe.",
     "homepage": "https://www.git-town.com",
     "license": "MIT",
     "suggest": {


### PR DESCRIPTION
Starting at v11, the assets in Git Town releases have new names.

Closes #5437

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
