### PR TITLE
cargo-binstall: Add version 1.6.0

### DIFF
--- a/bucket/cargo-binstall.json
+++ b/bucket/cargo-binstall.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.6.0",
+    "description": "Binary installation for rust projects",
+    "homepage": "https://github.com/cargo-bins/cargo-binstall",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.6.0/cargo-binstall-x86_64-pc-windows-msvc.zip",
+        },
+        "arm64": {
+            "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.6.0/cargo-binstall-aarch64-pc-windows-msvc.zip",
+        }
+    },
+    "bin": "cargo-binstall.exe",
+    "checkver": {
+        "github": "https://github.com/cargo-bins/cargo-binstall"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v$version/cargo-binstall-x86_64-pc-windows-msvc.zip",
+            },
+            "arm64": {
+                "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v$version/cargo-binstall-aarch64-pc-windows-msvc.zip",
+            }
+        },
+    }
+}

--- a/bucket/cargo-binstall.json
+++ b/bucket/cargo-binstall.json
@@ -6,9 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.6.0/cargo-binstall-x86_64-pc-windows-msvc.zip",
+            "hash": "sha256:0D37A0B39DFEE1E48F4FB38E9028DA81A0D7F78B66BD2DF1FA5A64DE786249BA"
         },
         "arm64": {
             "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.6.0/cargo-binstall-aarch64-pc-windows-msvc.zip",
+            "hash": "sha256:E3D01324E569DC4C7E09370D3B80FBE35870055D5EF8C6A0FD5F724DDA7ADA4E"
         }
     },
     "bin": "cargo-binstall.exe",

--- a/bucket/cargo-binstall.json
+++ b/bucket/cargo-binstall.json
@@ -23,6 +23,6 @@
             "arm64": {
                 "url": "https://github.com/cargo-bins/cargo-binstall/releases/download/v$version/cargo-binstall-aarch64-pc-windows-msvc.zip",
             }
-        },
+        }
     }
 }


### PR DESCRIPTION
Closes #5373

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
