### PR TITLE
chafa: Update to 1.14.0-2 build

### DIFF
--- a/bucket/chafa.json
+++ b/bucket/chafa.json
@@ -5,9 +5,9 @@
     "license": "LGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://hpjansson.org/chafa/releases/static/chafa-1.14.0-1-x86_64-windows.zip",
-            "hash": "35c8c507940540c3269a0a4d97344ae9c1ac791134aec1c3cdaace9a9d65d028",
-            "extract_dir": "chafa-1.14.0-1-x86_64-win"
+            "url": "https://hpjansson.org/chafa/releases/static/chafa-1.14.0-2-x86_64-windows.zip",
+            "hash": "004f906a0d37624a0bfab5f4f4695e23001187303d3827aeadd80226901e5705",
+            "extract_dir": "chafa-1.14.0-2-x86_64-win"
         }
     },
     "bin": "chafa.exe",
@@ -18,8 +18,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://hpjansson.org/chafa/releases/static/chafa-$version-1-x86_64-windows.zip",
-                "extract_dir": "chafa-$version-1-x86_64-win"
+                "url": "https://hpjansson.org/chafa/releases/static/chafa-$version-2-x86_64-windows.zip",
+                "extract_dir": "chafa-$version-2-x86_64-win"
             }
         }
     }

--- a/bucket/chafa.json
+++ b/bucket/chafa.json
@@ -13,13 +13,13 @@
     "bin": "chafa.exe",
     "checkver": {
         "url": "https://hpjansson.org/chafa/download/",
-        "regex": "Get Chafa ([\\d.]+) for Windows"
+        "regex": "releases/static/chafa-([\\d.]+)-(?<rel>\\d)-x86_64-windows.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://hpjansson.org/chafa/releases/static/chafa-$version-2-x86_64-windows.zip",
-                "extract_dir": "chafa-$version-2-x86_64-win"
+                "url": "https://hpjansson.org/chafa/releases/static/chafa-$version-$matchRel-x86_64-windows.zip",
+                "extract_dir": "chafa-$version-$matchRel-x86_64-win"
             }
         }
     }


### PR DESCRIPTION
This fixes a crash in the MS Windows build.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

See https://github.com/hpjansson/chafa/issues/182.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
