### PR TITLE
Add capnp.json manifest to Main bucket

### DIFF
--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -2,6 +2,7 @@
     "version": "1.0.2",
     "description": "Capnp Proto is an insanely fast data interchange format and capability-based RPC system",
     "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
+    "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a",
     "homepage": "https://capnproto.org",
     "license": "MIT",
     "bin": [

--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.0.2",
+    "description": "Capnp Proto is an insanely fast data interchange format and capability-based RPC system",
+    "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
+    "homepage": "https://capnproto.org",
+    "license": "MIT",
+    "bin": [
+        "capnproto-tools-win32-1.0.2/capnp.exe",
+        "capnproto-tools-win32-1.0.2/capnpc-c++.exe",
+        "capnproto-tools-win32-1.0.2/capnpc-capnp.exe"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repositories/9090933/tags",
+        "regex": "tags/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://capnproto.org/capnproto-c++-win32-$version.zip",
+        "bin": [
+            "capnproto-tools-win32-$ver/capnp.exe",
+            "capnproto-tools-win32-$ver/capnpc-c++.exe",
+            "capnproto-tools-win32-$ver/capnpc-capnp.exe"
+        ]
+    }
+}

--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -16,9 +16,9 @@
     "autoupdate": {
         "url": "https://capnproto.org/capnproto-c++-win32-$version.zip",
         "bin": [
-            "capnproto-tools-win32-$ver/capnp.exe",
-            "capnproto-tools-win32-$ver/capnpc-c++.exe",
-            "capnproto-tools-win32-$ver/capnpc-capnp.exe"
+            "capnproto-tools-win32-$version/capnp.exe",
+            "capnproto-tools-win32-$version/capnpc-c++.exe",
+            "capnproto-tools-win32-$version/capnpc-capnp.exe"
         ]
     }
 }

--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.2",
-    "description": "Capnp Proto is an insanely fast data interchange format and capability-based RPC system",
+    "description": "Cap'n Proto is an insanely fast data interchange format and capability-based RPC system",
     "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
     "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a",
     "homepage": "https://capnproto.org",

--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -1,8 +1,16 @@
 {
     "version": "1.0.2",
     "description": "Cap'n Proto is an insanely fast data interchange format and capability-based RPC system",
-    "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
-    "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a",
+    "architecture": {
+        "64bit": {
+            "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
+            "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a"
+        },
+        "32bit": {
+            "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
+            "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a"
+        }
+    },
     "homepage": "https://capnproto.org",
     "license": "MIT",
     "bin": [
@@ -15,7 +23,14 @@
         "regex": "tags/v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://capnproto.org/capnproto-c++-win32-$version.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://capnproto.org/capnproto-c++-win32-$version.zip"
+            },
+            "32bit": {
+                "url": "https://capnproto.org/capnproto-c++-win32-$version.zip"
+            }
+        },
         "bin": [
             "capnproto-tools-win32-$version/capnp.exe",
             "capnproto-tools-win32-$version/capnpc-c++.exe",

--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -1,18 +1,10 @@
 {
     "version": "1.0.2",
     "description": "Cap'n Proto is an insanely fast data interchange format and capability-based RPC system",
-    "architecture": {
-        "64bit": {
-            "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
-            "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a"
-        },
-        "32bit": {
-            "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
-            "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a"
-        }
-    },
     "homepage": "https://capnproto.org",
     "license": "MIT",
+    "url": "https://capnproto.org/capnproto-c++-win32-1.0.2.zip",
+    "hash": "48a69e9c10350e2c90041e7b8d7a610a43889c178b6431145da62610c9b5435a",
     "bin": [
         "capnproto-tools-win32-1.0.2/capnp.exe",
         "capnproto-tools-win32-1.0.2/capnpc-c++.exe",
@@ -23,14 +15,7 @@
         "regex": "tags/v([\\d.]+)"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://capnproto.org/capnproto-c++-win32-$version.zip"
-            },
-            "32bit": {
-                "url": "https://capnproto.org/capnproto-c++-win32-$version.zip"
-            }
-        },
+        "url": "https://capnproto.org/capnproto-c++-win32-$version.zip",
         "bin": [
             "capnproto-tools-win32-$version/capnp.exe",
             "capnproto-tools-win32-$version/capnpc-c++.exe",


### PR DESCRIPTION
Adds Cap'n protocol to main bucket

Create manifest, with the autoupdate, of the [Cap'n Proto](https://capnproto.org/).

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
