### PR TITLE
radius: Add version 0.31.0

### DIFF
--- a/bucket/radius.json
+++ b/bucket/radius.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.29.0",
+    "version": "0.30.0",
     "description": "Radius is a cloud-native, portable application platform that makes app development easier for teams building cloud-native apps.",
     "homepage": "https://radapp.io/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/radius-project/radius/releases/download/v0.29.0/rad_windows_amd64.exe#/rad.exe",
-            "hash": "7f855d0506912ad72b18d115992a247e2ef11040d95fa40fd6b36567ba9beeab",
+            "url": "https://github.com/radius-project/radius/releases/download/v0.30.0/rad_windows_amd64.exe#/rad.exe",
+            "hash": "e00be94077b0e9a61e21f67669111d63baee7a51052744c842b2740fd37ab506",
             "bin": "rad.exe"
         }
     },

--- a/bucket/radius.json
+++ b/bucket/radius.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.30.0",
+    "version": "0.31.0",
     "description": "Radius is a cloud-native, portable application platform that makes app development easier for teams building cloud-native apps.",
     "homepage": "https://radapp.io/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/radius-project/radius/releases/download/v0.30.0/rad_windows_amd64.exe#/rad.exe",
-            "hash": "e00be94077b0e9a61e21f67669111d63baee7a51052744c842b2740fd37ab506"
+            "url": "https://github.com/radius-project/radius/releases/download/v0.31.0/rad_windows_amd64.exe#/rad.exe",
+            "hash": "86fede0f1a0e8cf5645e8399a29cca7a7d34b95613c9dfd02a25851601c2df17"
         }
     },
     "bin": "rad.exe",

--- a/bucket/radius.json
+++ b/bucket/radius.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/radius-project/radius/releases/download/v0.30.0/rad_windows_amd64.exe#/rad.exe",
-            "hash": "e00be94077b0e9a61e21f67669111d63baee7a51052744c842b2740fd37ab506",
-            "bin": "rad.exe"
+            "hash": "e00be94077b0e9a61e21f67669111d63baee7a51052744c842b2740fd37ab506"
         }
     },
+    "bin": "rad.exe",
     "checkver": {
         "github": "https://github.com/radius-project/radius"
     },

--- a/bucket/radius.json
+++ b/bucket/radius.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.29.0",
+    "description": "Radius is a cloud-native, portable application platform that makes app development easier for teams building cloud-native apps.",
+    "homepage": "https://radapp.io/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/radius-project/radius/releases/download/v0.29.0/rad_windows_amd64.exe#/rad.exe",
+            "hash": "7f855d0506912ad72b18d115992a247e2ef11040d95fa40fd6b36567ba9beeab",
+            "bin": "rad.exe"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/radius-project/radius"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/radius-project/radius/releases/download/v$version/rad_windows_amd64.exe#/rad.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
This change adds the [radius](https://github.com/radius-project/radius) CLI tool to the bucket.

Closes #5474

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

As pointed out in the issue, there is another instance of this manifest for comparison [here](https://github.com/hoilc/scoop-lemon/blob/master/bucket/radius.json). I learned some tips to simplify the manifest from that instance.
