### PR TITLE
boxes: update incorrect hash

### DIFF
--- a/bucket/boxes.json
+++ b/bucket/boxes.json
@@ -4,7 +4,7 @@
     "homepage": "https://boxes.thomasjensen.com/",
     "license": "GPL-2.0-only",
     "url": "https://github.com/ascii-boxes/boxes/releases/download/v2.2.1/boxes-2.2.1-intel-win32.zip",
-    "hash": "d953373b696e431b53b28501fa74dc6ae53928852ea13504ab648f9f1250596c",
+    "hash": "41c840a4e766a75695dd776eae7a1964f042268f95aee7ccc429f38b1810213f",
     "extract_dir": "boxes-2.2.1",
     "bin": "boxes.exe",
     "checkver": {


### PR DESCRIPTION
It looks like the binary downloads were updated but the release number kept the same resulting in an incorrect hash for the new binaries.

gh: https://github.com/ascii-boxes/boxes/

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5487
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
