### PR TITLE
rustic: (chore) Remove pre_install

### DIFF
--- a/bucket/rustic.json
+++ b/bucket/rustic.json
@@ -6,10 +6,9 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/rustic-rs/rustic/releases/download/v0.7.0/rustic-v0.7.0-x86_64-pc-windows-msvc.tar.gz",
-            "hash": "65d6d88a6257b215b15838c47866f47e9762e643ed22a3c073162ffa3f9e7569"
+            "hash": "ced7bca727006e435ec629d2bb4617d082adc6a1253cbfb9743e882186809330"
         }
     },
-    "pre_install": "Rename-Item \"$dir\\rustic\" 'rustic.exe' -ErrorAction SilentlyContinue # delete this when upstream fixes it",
     "env_set": {
         "RUSTIC_HOME": "$dir"
     },


### PR DESCRIPTION
Not sure, why the hash didn't get updated, did it now manually, but the address, that should be called is available with that hash. 🤔

Fixes https://github.com/ScoopInstaller/Main/issues/5495

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
