### PR TITLE
cpufetch: Update to version 1.05

### DIFF
--- a/bucket/cpufetch.json
+++ b/bucket/cpufetch.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.04",
+    "version": "1.05",
     "description": "Simple yet fancy CPU architecture fetching tool",
     "homepage": "https://github.com/Dr-Noob/cpufetch",
     "license": "MIT",
-    "url": "https://github.com/Dr-Noob/cpufetch/releases/download/v1.04/cpufetch.exe",
-    "hash": "05448769b75e101950c383df8bc2cfa1100f5f7c444aaa79b7e243c3852da790",
+    "url": "https://github.com/Dr-Noob/cpufetch/releases/download/v1.05/cpufetch_x86-64_windows.exe#/cpufetch.exe",
+    "hash": "2b4fc9596212762478ed1404a21a1031be0a83356d349e5636479b515fd2b770",
     "bin": "cpufetch.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Dr-Noob/cpufetch/releases/download/v$version/cpufetch.exe"
+        "url": "https://github.com/Dr-Noob/cpufetch/releases/download/v$version/cpufetch_x86-64_windows.exe#/cpufetch.exe"
     }
 }


### PR DESCRIPTION
- Update to version 1.05.
- Fix autoupdate (windows binary naming still changeable from release to release).

Relates to #4496, #4795.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
