### PR TITLE
croc: Update to version 9.6.11, fix autoupdate

### DIFF
--- a/bucket/croc.json
+++ b/bucket/croc.json
@@ -1,20 +1,16 @@
 {
-    "version": "9.6.6",
+    "version": "9.6.9",
     "description": "Easily and securely send things from one computer to another.",
     "homepage": "https://schollz.com/software/croc6",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.6/croc_9.6.6_Windows-64bit.zip",
-            "hash": "6af6182187163a88c630ce7b1eeb3ef166d84644225fd2cee502795f67c90e90"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.9/croc_v9.6.9_Windows-64bit.zip",
+            "hash": "3cf592430e574c0718fe00702923c30c714b3c9831d47f1c0bb15c7d892cc94b"
         },
         "32bit": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.6/croc_9.6.6_Windows-32bit.zip",
-            "hash": "042a49b4762e577ffb72b4bf502097898ceb47f8054fcd0a9d5636396680a7d9"
-        },
-        "arm64": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.6/croc_9.6.6_Windows-ARM64.zip",
-            "hash": "f7f47fdc306c7dbaf93c4a6efc14ae0e95b27da464581b1a3d373a06b79b482e"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.9/croc_v9.6.9_Windows-32bit.zip",
+            "hash": "d2a0b9df3c3c73453b8898f10b2a341a5daa63da3afbfda5e3aa56304d3824d6"
         }
     },
     "bin": "croc.exe",
@@ -24,17 +20,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/schollz/croc/releases/download/v$version/croc_$version_Windows-64bit.zip"
+                "url": "https://github.com/schollz/croc/releases/download/v$version/croc_v$version_Windows-64bit.zip"
             },
             "32bit": {
-                "url": "https://github.com/schollz/croc/releases/download/v$version/croc_$version_Windows-32bit.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/schollz/croc/releases/download/v$version/croc_$version_Windows-ARM64.zip"
+                "url": "https://github.com/schollz/croc/releases/download/v$version/croc_v$version_Windows-32bit.zip"
             }
         },
         "hash": {
-            "url": "$baseurl/croc_$version_checksums.txt"
+            "url": "$baseurl/croc_v$version_checksums.txt"
         }
     }
 }

--- a/bucket/croc.json
+++ b/bucket/croc.json
@@ -1,16 +1,20 @@
 {
-    "version": "9.6.9",
+    "version": "9.6.11",
     "description": "Easily and securely send things from one computer to another.",
     "homepage": "https://schollz.com/software/croc6",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.9/croc_v9.6.9_Windows-64bit.zip",
-            "hash": "3cf592430e574c0718fe00702923c30c714b3c9831d47f1c0bb15c7d892cc94b"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.11/croc_v9.6.11_Windows-64bit.zip",
+            "hash": "033367d5d4d6c4874722698f44416060bbae95057a2d10bc7a651f72efd21248"
         },
         "32bit": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.9/croc_v9.6.9_Windows-32bit.zip",
-            "hash": "d2a0b9df3c3c73453b8898f10b2a341a5daa63da3afbfda5e3aa56304d3824d6"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.11/croc_v9.6.11_Windows-32bit.zip",
+            "hash": "3ad7afefecab322e9b29dea66a8329e896529fee4ddfe82083d6f53dfe9a26f0"
+        },
+        "arm64": {
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.11/croc_v9.6.11_Windows-ARM64.zip",
+            "hash": "b68567ce334f9204961abaea0ab101e93a5a2d9554aaff78c7a816942062087a"
         }
     },
     "bin": "croc.exe",
@@ -24,6 +28,9 @@
             },
             "32bit": {
                 "url": "https://github.com/schollz/croc/releases/download/v$version/croc_v$version_Windows-32bit.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/schollz/croc/releases/download/v$version/croc_v$version_Windows-ARM64.zip"
             }
         },
         "hash": {

--- a/bucket/croc.json
+++ b/bucket/croc.json
@@ -1,20 +1,20 @@
 {
-    "version": "9.6.11",
+    "version": "9.6.14",
     "description": "Easily and securely send things from one computer to another.",
     "homepage": "https://schollz.com/software/croc6",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.11/croc_v9.6.11_Windows-64bit.zip",
-            "hash": "033367d5d4d6c4874722698f44416060bbae95057a2d10bc7a651f72efd21248"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.14/croc_v9.6.14_Windows-64bit.zip",
+            "hash": "fbf6d5a9247b3b94aa1cac4544b494e778d9aba337bb9f565d55564f9370d673"
         },
         "32bit": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.11/croc_v9.6.11_Windows-32bit.zip",
-            "hash": "3ad7afefecab322e9b29dea66a8329e896529fee4ddfe82083d6f53dfe9a26f0"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.14/croc_v9.6.14_Windows-32bit.zip",
+            "hash": "613c22eb4de89dfd04743ddfde15fd5200d086381928a51bb44857be9632ae14"
         },
         "arm64": {
-            "url": "https://github.com/schollz/croc/releases/download/v9.6.11/croc_v9.6.11_Windows-ARM64.zip",
-            "hash": "b68567ce334f9204961abaea0ab101e93a5a2d9554aaff78c7a816942062087a"
+            "url": "https://github.com/schollz/croc/releases/download/v9.6.14/croc_v9.6.14_Windows-ARM64.zip",
+            "hash": "ffcc4f73c47f5ba3fc2ee06f0365ad73c6766d2b32451a57fe580ffea5ff05c5"
         }
     },
     "bin": "croc.exe",


### PR DESCRIPTION
- Update to version 9.6.9.
- Fix autoupdate urls.
- Remove arm64 option (since not available in the recent releases).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
