### PR TITLE
tectonic: Update checkver

### DIFF
--- a/bucket/tectonic.json
+++ b/bucket/tectonic.json
@@ -11,8 +11,8 @@
     },
     "bin": "tectonic.exe",
     "checkver": {
-        "url": "https://github.com/tectonic-typesetting/tectonic/releases",
-        "regex": "releases/tag/tectonic%40([\\d.]+)"
+        "url": "https://tectonic-typesetting.github.io/en-US/",
+        "regex": "Install Tectonic.*?([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
From Excavator logs:

```
tectonic: couldn't match 'releases/tag/tectonic%40([\d.]+)' in https://github.com/tectonic-typesetting/tectonic/releases
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
