### PR TITLE
sbt@1.9.8: Fix checkver url

### DIFF
--- a/bucket/sbt.json
+++ b/bucket/sbt.json
@@ -8,7 +8,7 @@
     "extract_dir": "sbt",
     "bin": "bin\\sbt.bat",
     "checkver": {
-        "url": "https://www.scala-sbt.org/download.html",
+        "url": "https://www.scala-sbt.org/download/",
         "regex": "/sbt-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/sbt.json
+++ b/bucket/sbt.json
@@ -6,7 +6,11 @@
     "url": "https://github.com/sbt/sbt/releases/download/v1.9.8/sbt-1.9.8.zip",
     "hash": "380192b772a02004b0677a4125954ef672c1e9971683e12c1c866a191757a5b9",
     "extract_dir": "sbt",
+    "env_set": {
+        "SBT_HOME": "$dir"
+    },
     "bin": "bin\\sbt.bat",
+    "persist": "conf",
     "checkver": {
         "url": "https://www.scala-sbt.org/download/",
         "regex": "/sbt-([\\d.]+)\\.zip"


### PR DESCRIPTION
From excavator logs:

```
sbt: couldn't match '/sbt-([\d.]+)\.zip' in https://www.scala-sbt.org/download.html`
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
