### PR TITLE
bat: suggest installing vcredist2022

### DIFF
--- a/bucket/bat.json
+++ b/bucket/bat.json
@@ -4,6 +4,7 @@
     "homepage": "https://github.com/sharkdp/bat",
     "license": "Apache-2.0",
     "suggest": {
+        "vcredist": "extras/vcredist2022",
         "less": "less"
     },
     "architecture": {


### PR DESCRIPTION
As stated in bat README.md (https://github.com/sharkdp/bat?tab=readme-ov-file#prerequisites), Visual C++ Redistributable must be installed.

I noticed that when I installed bat on fresh Windows: bat fails to run without it.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
