### PR TITLE
supabase@1.145.4: Add arm64 version

### DIFF
--- a/bucket/supabase.json
+++ b/bucket/supabase.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/supabase/cli/releases/download/v1.145.4/supabase_windows_amd64.tar.gz",
             "hash": "66ac1565fec3ac0045dd6b863f9494fef737c3e58ed367da17e4d4a024a588b2"
+        },
+        "arm64": {
+            "url": "https://github.com/supabase/cli/releases/download/v1.145.4/supabase_windows_arm64.tar.gz",
+            "hash": "5de526bb4589e2496377262e1294d39b95dbb20b7ff8ae8cf4572f6eadf7d0d0"
         }
     },
     "bin": "supabase.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
