### PR TITLE
gifsicle: Fix `extract_dir`

### DIFF
--- a/bucket/gifsicle.json
+++ b/bucket/gifsicle.json
@@ -6,13 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://eternallybored.org/misc/gifsicle/releases/gifsicle-1.95-win64.zip",
-            "hash": "7e47dd0bfd5ee47f911464c57faeed89a8709a7625dd1c449b16579889539ee8",
-            "extract_dir": "gifsicle-1.95"
+            "hash": "7e47dd0bfd5ee47f911464c57faeed89a8709a7625dd1c449b16579889539ee8"
         },
         "32bit": {
             "url": "https://eternallybored.org/misc/gifsicle/releases/gifsicle-1.95-win32.zip",
-            "hash": "f31464e334b9fb83d4dc60a25bde7cfa35829564bc378c40f0d3c6350910256c",
-            "extract_dir": "gifsicle-1.95"
+            "hash": "f31464e334b9fb83d4dc60a25bde7cfa35829564bc378c40f0d3c6350910256c"
         }
     },
     "bin": [
@@ -26,12 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://eternallybored.org/misc/gifsicle/releases/gifsicle-$version-win64.zip",
-                "extract_dir": "gifsicle-$version"
+                "url": "https://eternallybored.org/misc/gifsicle/releases/gifsicle-$version-win64.zip"
             },
             "32bit": {
-                "url": "https://eternallybored.org/misc/gifsicle/releases/gifsicle-$version-win32.zip",
-                "extract_dir": "gifsicle-$version"
+                "url": "https://eternallybored.org/misc/gifsicle/releases/gifsicle-$version-win32.zip"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

fixes #5537