### PR TITLE
git-machete: Add version 3.23.2

### DIFF
--- a/bucket/git-machete.json
+++ b/bucket/git-machete.json
@@ -1,0 +1,29 @@
+{
+    "version": "3.23.2",
+    "description": "Probably the sharpest git repository organizer & rebase/merge workflow automation tool you've ever seen",
+    "homepage": "https://github.com/VirtusLab/git-machete",
+    "license": "MIT",
+    "depends": "python",
+    "url": "https://files.pythonhosted.org/packages/py3/g/git-machete/git_machete-3.23.2-py3-none-any.whl",
+    "hash": "5755803007c9588228ae16f97ca1a0dc032156c88a932d715dc1c374e0217d4a",
+    "installer": {
+        "script": [
+            "Push-Location \"$dir\"",
+            "python -m venv git-machete",
+            ".\\git-machete\\Scripts\\activate",
+            "try {",
+            "    python -m pip install \"$fname\"",
+            "}",
+            "finally {",
+            "    Remove-Item \"$fname\"",
+            "    deactivate",
+            "    Pop-Location",
+            "}"
+        ]
+    },
+    "bin": "git-machete\\Scripts\\git-machete.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://files.pythonhosted.org/packages/py3/g/git-machete/git_machete-$version-py3-none-any.whl"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Adding manifest for [git-machete](https://github.com/VirtusLab/git-machete), as suggested by one of the users (CC @ppasieka).

This project has ~800 stars but only ~40 forks &mdash; does it qualify for Main bucket?
Note that it's in an equivalent of main bucket in multiple package managers, including Homebrew... see [the full list of known packages](https://github.com/VirtusLab/git-machete/blob/master/PACKAGES.md).

JSON mostly taken from [Extras -> cruft](https://github.com/ScoopInstaller/Extras/blob/master/bucket/cruft.json).

Checked that installation & autoupdate works on a CI Windows VM: [build log](https://app.circleci.com/pipelines/github/VirtusLab/git-machete/4723/workflows/f907da7b-f7b3-4dc1-9a56-899f99230cdc/jobs/28783).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
