### PR TITLE
zigup: Add version 2024_02_25

### DIFF
--- a/bucket/zigup.json
+++ b/bucket/zigup.json
@@ -1,0 +1,18 @@
+{
+    "version": "2024_02_25",
+    "description": "Download and manage Zig compilers",
+    "homepage": "https://github.com/marler8997/zigup",
+    "license": {
+        "identifier": "MIT-0",
+        "url": "https://github.com/marler8997/zigup/blob/master/LICENSE"
+    },
+    "url": "https://github.com/marler8997/zigup/releases/download/v2024_02_25/zigup.windows-latest-x86_64.zip",
+    "hash": "9aa5c98b55203712af61242753871ad75cada479373713b4dc2804c21c4db561",
+    "bin": "zigup.exe",
+    "checkver": {
+        "github": "https://github.com/marler8997/zigup"
+    },
+    "autoupdate": {
+        "url": "https://github.com/marler8997/zigup/releases/download/v$version/zigup.windows-latest-x86_64.zip"
+    }
+}


### PR DESCRIPTION
[zigup](https://github.com/marler8997/zigup) is a CLI tool for managing [Zig](https://ziglang.org/)'s compilers.

It does lack a little in stars and especially forks, but this manifest still seems best suited for Main over the Extras bucket.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
