### PR TITLE
mtn: Fix bin path for v3.5.0

### DIFF
--- a/bucket/mtn.json
+++ b/bucket/mtn.json
@@ -13,7 +13,7 @@
             "extract_dir": "mtn-win64"
         }
     },
-    "bin": "mtn-win64\\mtn.exe",
+    "bin": "mtn.exe",
     "checkver": {
         "url": "https://bitbucket.org/wahibre/mtn/downloads/?tab=downloads",
         "regex": "(?<filename>mtn-(?<version>(?:\\d+\\.)+\\d+)-win64\\.zip)"

--- a/bucket/mtn.json
+++ b/bucket/mtn.json
@@ -13,7 +13,7 @@
             "extract_dir": "mtn-win64"
         }
     },
-    "bin": "bin\\mtn.exe",
+    "bin": "mtn-win64\\mtn.exe",
     "checkver": {
         "url": "https://bitbucket.org/wahibre/mtn/downloads/?tab=downloads",
         "regex": "(?<filename>mtn-(?<version>(?:\\d+\\.)+\\d+)-win64\\.zip)"


### PR DESCRIPTION
```
mtn: 3.4.2 -> 3.5.0
Updating one outdated app:
Updating 'mtn' (3.4.2 -> 3.5.0)
Downloading new version
Downloading https://bitbucket.org/wahibre/mtn/downloads/mtn-3.5.0-win64.zip (42.2 MB)...
Checking hash of mtn-3.5.0-win64.zip ... ok.
Uninstalling 'mtn' (3.4.2)
Removing shim 'mtn.shim'.
Removing shim 'mtn.exe'.
Unlinking D:\Scoop\apps\mtn\current
Installing 'mtn' (3.5.0) [64bit] from main bucket
Loading mtn-3.5.0-win64.zip from cache
Extracting mtn-3.5.0-win64.zip ... done.
Linking D:\Scoop\apps\mtn\current => D:\Scoop\apps\mtn\3.5.0
Creating shim for 'mtn'.
Can't shim 'bin\mtn.exe': File doesn't exist.
```

New `bin` path to exe in ZIP is `mtn.exe`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
