### PR TITLE
wixtoolset: Update to v4

### DIFF
--- a/bucket/wixtoolset.json
+++ b/bucket/wixtoolset.json
@@ -1,36 +1,17 @@
 {
-    "version": "3.14",
+    "version": "4.0.4",
     "description": "Set of tools for windows installer creation.",
     "homepage": "https://wixtoolset.org/",
     "license": "MS-RL",
-    "url": "https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314-binaries.zip",
-    "hash": "13f067f38969faf163d93a804b48ea0576790a202c8f10291f2000f0e356e934",
-    "bin": [
-        "candle.exe",
-        "dark.exe",
-        "heat.exe",
-        "insignia.exe",
-        "light.exe",
-        "lit.exe",
-        "lux.exe",
-        "melt.exe",
-        "nit.exe",
-        "pyro.exe",
-        "retina.exe",
-        "shine.exe",
-        "smoke.exe",
-        "ThmViewer.exe",
-        "torch.exe",
-        "WixCop.exe"
-    ],
-    "env_set": {
-        "WixToolPath": "$dir"
-    },
+    "url": "https://www.nuget.org/api/v2/package/wix/4.0.4#/wix.4.0.4.nupkg1",
+    "hash": "a9ca12214e61bb49430a8c6e5e48ac5ae6f27dc82573b5306955c4d35f2d34e2",
+    "pre_install": "Expand-7zipArchive -Path \"$dir\\wix.*.nupkg1\" -ExtractDir \"tools\\net6.0\\any\" -Removal",
+    "bin": "wix.exe",
     "checkver": {
-        "url": "https://github.com/wixtoolset/wix3/releases",
-        "regex": ">WiX Toolset v([\\d.]+)<"
+        "url": "https://www.nuget.org/packages/wix",
+        "regex": "--version ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/wixtoolset/wix3/releases/download/wix$cleanVersionrtm/wix$majorVersion$minorVersion-binaries.zip"
+        "url": "https://www.nuget.org/api/v2/package/wix/$version#/wix.$version.nupkg1"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Don't know if it is proper to update to v4 directly but Wix 4 works totally different from its previous versions... This will be a breaking change I think. Wix 4 is required to unpack installers that are packed with Wix 4, which means `dark` will not work, taking `swift` as the example..

P.S. Wix 5 release is planning..

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
