### PR TITLE
exercism: Fix URLs for v3.3.0

### DIFF
--- a/bucket/exercism.json
+++ b/bucket/exercism.json
@@ -5,6 +5,7 @@
     "homepage": "https://exercism.org/",
     "license": "MIT",
     "bin": "exercism.exe",
+    "notes": "To configure the CLI, follow the instructions at https://exercism.io/cli-walkthrough.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/exercism/cli/releases/download/v3.3.0/exercism-3.3.0-windows-x86_64.zip#/dl.7z",

--- a/bucket/exercism.json
+++ b/bucket/exercism.json
@@ -1,18 +1,18 @@
 {
     "##": "Rename from zip to 7z is needed due to 'invalid archive entry' error.",
-    "version": "3.2.0",
-    "description": "A Go based command line tool for exercism.io.",
+    "version": "3.3.0",
+    "description": "A Go based command line tool for exercism.io",
     "homepage": "https://exercism.org/",
     "license": "MIT",
     "bin": "exercism.exe",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/exercism/cli/releases/download/v3.2.0/exercism-windows-64bit.zip#/dl.7z",
-            "hash": "e6a15615e723e2ec3d3604648a74169b4fbe8cf9339b75b08c80b37048ddecf0"
+            "url": "https://github.com/exercism/cli/releases/download/v3.3.0/exercism-3.3.0-windows-x86_64.zip#/dl.7z",
+            "hash": "0490b02ddbea66f0898003113433c69b0762a460edb1ad1c98df332a19113b0f"
         },
         "32bit": {
-            "url": "https://github.com/exercism/cli/releases/download/v3.2.0/exercism-windows-32bit.zip#/dl.7z",
-            "hash": "d90a885a7728884ef6cc4af7f69bff11a3face8a73fd31bad335f2f8f3d9bcc7"
+            "url": "https://github.com/exercism/cli/releases/download/v3.3.0/exercism-3.3.0-windows-i386.zip#/dl.7z",
+            "hash": "e7dca99dda2b7b4ad83cec05c7ded40dd3e95b9c9bc6dbd0710312f0532bfc14"
         }
     },
     "checkver": {
@@ -21,10 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/exercism/cli/releases/download/v$version/exercism-windows-64bit.zip#/dl.7z"
+                "url": "https://github.com/exercism/cli/releases/download/v$version/exercism-$version-windows-x86_64.zip#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/exercism/cli/releases/download/v$version/exercism-windows-32bit.zip#/dl.7z"
+                "url": "https://github.com/exercism/cli/releases/download/v$version/exercism-$version-windows-i386.zip#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Previous autoupdate URLs no longer work for [exercism CLI v3.3.0](https://github.com/exercism/cli/releases). Tested locally, installs as expected.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).