### PR TITLE
winget-ps: Remove `pwsh` dependency

### DIFF
--- a/bucket/winget-ps.json
+++ b/bucket/winget-ps.json
@@ -4,7 +4,6 @@
     "homepage": "https://github.com/microsoft/winget-cli/tree/master/src/PowerShell/Microsoft.WinGet.Client",
     "license": "MIT",
     "suggest": {
-        "PowerShell Core": "pwsh",
         "WinGet": "winget"
     },
     "url": "https://psg-prod-eastus.azureedge.net/packages/microsoft.winget.client.1.7.10661.nupkg",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

https://github.com/microsoft/winget-cli/issues/3183 has been resolved, which means the module now works properly on Powershell 5.1.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
