### PR TITLE
bflat: Add version 8.0.2

### DIFF
--- a/bucket/bflat.json
+++ b/bucket/bflat.json
@@ -1,6 +1,6 @@
 {
     "version": "8.0.2",
-    "description": "C# as you know it but with Go-inspired tooling (small, selfcontained, and native executables)",
+    "description": "C# as you know it but with Go-inspired tooling that produces small, selfcontained, and native executables out of the box.",
     "homepage": "https://github.com/bflattened/bflat",
     "license": "AGPL-3.0-only",
     "architecture": {

--- a/bucket/bflat.json
+++ b/bucket/bflat.json
@@ -2,7 +2,7 @@
     "version": "8.0.2",
     "description": "C# as you know it but with Go-inspired tooling that produces small, selfcontained, and native executables out of the box.",
     "homepage": "https://github.com/bflattened/bflat",
-    "license": "AGPL-3.0-only",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/bflattened/bflat/releases/download/v8.0.2/bflat-8.0.2-windows-x64.zip",

--- a/bucket/bflat.json
+++ b/bucket/bflat.json
@@ -1,0 +1,32 @@
+{
+    "version": "8.0.2",
+    "description": "C# as you know it but with Go-inspired tooling (small, selfcontained, and native executables)",
+    "homepage": "https://github.com/bflattened/bflat",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bflattened/bflat/releases/download/v8.0.2/bflat-8.0.2-windows-x64.zip",
+            "hash": "25b03214c6085607ec2ec5fc86139c93e054edd60266296e708f763455961e7e"
+        },
+        "arm64": {
+            "url": "https://github.com/bflattened/bflat/releases/download/v8.0.2/bflat-8.0.2-windows-arm64.zip",
+            "hash": "d44b87fdd00d3414d6032bfaf2cadb9ef8d22f342b61d5573d03ac4e7649c5e4"
+        }
+    },
+    "bin": "bflat.exe",
+    "checkver": {
+        "url": "https://api.github.com/repos/bflattened/bflat/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bflattened/bflat/releases/download/v$version/bflat-$version-windows-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/bflattened/bflat/releases/download/v$version/bflat-$version-windows-arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[bflat](https://github.com/bflattened/bflat) is a C# compiler that can produce [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) binaries without the need of the [.NET](https://dotnet.microsoft.com) SDK.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).