### PR TITLE
gig: Update manifest with "fzf" as dependency.

### DIFF
--- a/bucket/gig.json
+++ b/bucket/gig.json
@@ -3,6 +3,7 @@
     "description": "Generate .gitignore files from your terminal (mostly) offline!",
     "homepage": "https://github.com/shihanng/gig",
     "license": "MIT",
+    "depends": ["fzf"],
     "architecture": {
         "64bit": {
             "url": "https://github.com/shihanng/gig/releases/download/v0.8.3/gig_0.8.3_Windows_x86_64.tar.gz",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#5569 was merged last week, but I have since discovered that [`fzf`](/ScoopInstaller/Main/tree/master/bucket/fzf.json) should have been listed under the `depends` section of this manifest. Updating the manifest accordingly.

For more on this module, check out the repo [_shihanng/gig_](/shihanng/gig).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
