### PR TITLE
flamingo: Add version 0.10.2

### DIFF
--- a/bucket/flamingo.json
+++ b/bucket/flamingo.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/flux-subsystem-argo/flamingo/releases/download/v0.10.2/flamingo_0.10.2_windows_amd64.zip",
             "hash": "8b4161422f1aae9c5adee0d5c7c3812661dc295c190b2ea056cd6ddd74c2a873"
+        },
+        "arm64": {
+            "url": "https://github.com/flux-subsystem-argo/flamingo/releases/download/v0.10.2/flamingo_0.10.2_windows_arm64.zip",
+            "hash": "b2020c599533e9f1207c4027e5cedac3ea10a902150f31238d816fe1ec3f6011"
         }
     },
     "bin": "flamingo.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/flux-subsystem-argo/flamingo/releases/download/v$version/flamingo_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/flux-subsystem-argo/flamingo/releases/download/v$version/flamingo_$version_windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/flamingo.json
+++ b/bucket/flamingo.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.10.2",
+    "description": "Flamingo enhances ArgoCD by providing Flux subsystem capabilities, enabling visualization and management of Flux workloads alongside ArgoCD while ensuring timely backporting of CVEs for a secure environment.",
+    "homepage": "https://github.com/flux-subsystem-argo/flamingo",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/flux-subsystem-argo/flamingo/releases/download/v0.10.2/flamingo_0.10.2_windows_amd64.zip",
+            "hash": "8b4161422f1aae9c5adee0d5c7c3812661dc295c190b2ea056cd6ddd74c2a873"
+        }
+    },
+    "bin": "flamingo.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/flux-subsystem-argo/flamingo/releases/download/v$version/flamingo_$version_windows_amd64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/flamingo_$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
**Prerequisites**
- [X] I have searched all issues/PRs to ensure it has not already been reported or fixed.

**Criteria**
- [X] Non-GUI tool
- [X] Reasonably well-known and widely used (e.g. if it's a GitHub project, it should have at least 500 stars and/or 150 forks)
- [X] English interface (or at least English documentation)
- [X] Latest stable version
- [X] Full version (i.e. not a trial version)
- [X] Fairly standard install (e.g. uses a version-specific download URL, no elaborate pre/post install scripts)

**Name**
Flamingo

**Description**
Flamingo enhances [ArgoCD](https://github.com/argoproj/argo-cd) by providing [Flux](https://github.com/fluxcd/flux2) subsystem capabilities, enabling visualization and management of Flux workloads alongside ArgoCD while ensuring timely backporting of CVEs for a secure environment.

**Homepage**
https://github.com/flux-subsystem-argo/flamingo

**Download Link(s)**
https://github.com/flux-subsystem-argo/flamingo/releases/download/v0.10.2/flamingo_0.10.2_windows_amd64.zip

**Some Indication of Popularity/Repute**
GitHub stars: 560
GitHub forks: 39