### PR TITLE
px: fix px.ini creation for persist directive

### DIFF
--- a/bucket/px.json
+++ b/bucket/px.json
@@ -9,7 +9,10 @@
             "hash": "0e492431ef836091d34f44a6de8caf2a0aaef1737ba7b8202fa54285a5db4101"
         }
     },
-    "pre_install": "Push-Location $dir && ./px --save && Pop-Location",
+    "pre_install": [
+        "if (Test-Path -PathType Container \"$persist_dir\\px.ini\") { Remove-Item \"$persist_dir\\px.ini\" } # removes folder px.ini if exists",
+        "if (!(Test-Path \"$persist_dir\\px.ini\")) { New-Item \"$dir\\px.ini\" | Out-Null } # creates config file px.ini if doesn't exist"
+    ],
     "bin": "px.exe",
     "persist": "px.ini",
     "checkver": "github",

--- a/bucket/px.json
+++ b/bucket/px.json
@@ -9,6 +9,10 @@
             "hash": "0e492431ef836091d34f44a6de8caf2a0aaef1737ba7b8202fa54285a5db4101"
         }
     },
+    "env_set": {
+        "PX_CONFIG": "$dir\\px.ini"
+    },
+    "pre_install": "Push-Location $dir && ./px --save && Pop-Location",
     "bin": "px.exe",
     "persist": "px.ini",
     "checkver": "github",

--- a/bucket/px.json
+++ b/bucket/px.json
@@ -9,9 +9,6 @@
             "hash": "0e492431ef836091d34f44a6de8caf2a0aaef1737ba7b8202fa54285a5db4101"
         }
     },
-    "env_set": {
-        "PX_CONFIG": "$dir\\px.ini"
-    },
     "pre_install": "Push-Location $dir && ./px --save && Pop-Location",
     "bin": "px.exe",
     "persist": "px.ini",


### PR DESCRIPTION
Initialize px.ini before persist directive to avoid creating a px.ini folder.
Configure PX_CONFIG environment variable to point to persist/px/px.ini.
 
Closes https://github.com/ScoopInstaller/Main/issues/5609

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
