### PR TITLE
git-cliff@2.1.2: Update homepage

### DIFF
--- a/bucket/git-cliff.json
+++ b/bucket/git-cliff.json
@@ -1,7 +1,7 @@
 {
     "version": "2.1.2",
     "description": "A highly customizable Changelog Generator that follows Conventional Commit specifications",
-    "homepage": "https://github.com/orhun/git-cliff",
+    "homepage": "https://git-cliff.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "32bit": {
@@ -15,7 +15,9 @@
     },
     "extract_dir": "git-cliff-2.1.2",
     "bin": "git-cliff.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/orhun/git-cliff"
+    },
     "autoupdate": {
         "architecture": {
             "32bit": {


### PR DESCRIPTION
This is a trivial PR. git-cliff now has a dedicated homepage, and it should be preferred over the repo.

Relates-to: #4161

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
