### PR TITLE
swift@5.10: Fix pre_install

### DIFF
--- a/bucket/swift.json
+++ b/bucket/swift.json
@@ -35,18 +35,20 @@
         "Move-Item -Path \"$dir\\Swift\\Platforms\\$ver\\Windows.platform\" -Destination \"$dir\\Swift\\Platforms\"",
         "Move-Item -Path \"$dir\\Swift\\Toolchains\\$($ver)+Asserts\\usr\" -Destination \"$dir\\Swift\\Toolchains\"",
         "Move-Item -Path \"$dir\\Swift\\Tools\\$ver\\*\" -Destination \"$dir\\Swift\\Tools\"",
-        "Remove-Item \"$dir\\Swift\\Platforms\\$ver\" -Recurse | Out-Null",
-        "Remove-Item \"$dir\\Swift\\Toolchains\\$ver+Asserts\" -Recurse | Out-Null",
-        "Remove-Item \"$dir\\Swift\\Tools\\$ver\" -Recurse | Out-Null",
-        "Remove-Item \"$dir\\extract_folder\" -Recurse | Out-Null"
+        "Remove-Item \"$dir\\Swift\\Platforms\\$ver\" | Out-Null",
+        "Remove-Item \"$dir\\Swift\\Toolchains\\$ver+Asserts\" | Out-Null",
+        "Remove-Item \"$dir\\Swift\\Tools\\$ver\" | Out-Null",
+        "Remove-Item \"$dir\\extract_folder\" -Recurse | Out-Null",
+        "Move-Item -Path \"$dir\\Swift\\*\" -Destination \"$dir\"",
+        "Remove-Item \"$dir\\Swift\" | Out-Null"
     ],
     "env_add_path": [
-        "Swift\\Runtimes\\usr\\bin",
-        "Swift\\Toolchains\\usr\\bin",
-        "Swift\\Tools"
+        "Runtimes\\usr\\bin",
+        "Toolchains\\usr\\bin",
+        "Tools"
     ],
     "env_set": {
-        "SDKROOT": "$dir\\Swift\\Platforms\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
+        "SDKROOT": "$dir\\Platforms\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     },
     "checkver": {
         "url": "https://github.com/apple/swift",

--- a/bucket/swift.json
+++ b/bucket/swift.json
@@ -25,21 +25,28 @@
         "}",
         "$xml.BurnManifest.Payload | Where-Object { $_.FilePath.EndsWith(\".msi\") } | ForEach-Object {",
         "    if ($($_.FilePath) -eq \"rtl.msi\") {",
-        "        Expand-MsiArchive \"$dir\\extract_folder\\AttachedContainer\\$($_.FilePath)\" \"$dir\\extract_folder\\LocalApp\\Programs\\Swift\\Runtimes\\5.10.0\\usr\\bin\"",
+        "        Expand-MsiArchive \"$dir\\extract_folder\\AttachedContainer\\$($_.FilePath)\" \"$dir\\extract_folder\\LocalApp\\Programs\\Swift\\Runtimes\\usr\\bin\"",
         "    } else {",
         "        Expand-MsiArchive \"$dir\\extract_folder\\AttachedContainer\\$($_.FilePath)\" \"$dir\\extract_folder\"",
         "    }",
         "}",
+        "$ver = $xml.BurnManifest.Registration.Version",
         "Move-Item -Path \"$dir\\extract_folder\\LocalApp\\Programs\\Swift\" -Destination \"$dir\"",
+        "Move-Item -Path \"$dir\\Swift\\Platforms\\$ver\\Windows.platform\" -Destination \"$dir\\Swift\\Platforms\"",
+        "Move-Item -Path \"$dir\\Swift\\Toolchains\\$($ver)+Asserts\\usr\" -Destination \"$dir\\Swift\\Toolchains\"",
+        "Move-Item -Path \"$dir\\Swift\\Tools\\$ver\\*\" -Destination \"$dir\\Swift\\Tools\"",
+        "Remove-Item \"$dir\\Swift\\Platforms\\$ver\" -Recurse | Out-Null",
+        "Remove-Item \"$dir\\Swift\\Toolchains\\$ver+Asserts\" -Recurse | Out-Null",
+        "Remove-Item \"$dir\\Swift\\Tools\\$ver\" -Recurse | Out-Null",
         "Remove-Item \"$dir\\extract_folder\" -Recurse | Out-Null"
     ],
     "env_add_path": [
-        "Swift\\Runtimes\\5.10.0\\usr\\bin",
-        "Swift\\Toolchains\\5.10.0+Asserts\\usr\\bin",
-        "Swift\\Tools\\5.10.0\\"
+        "Swift\\Runtimes\\usr\\bin",
+        "Swift\\Toolchains\\usr\\bin",
+        "Swift\\Tools"
     ],
     "env_set": {
-        "SDKROOT": "$dir\\Swift\\Platforms\\5.10.0\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
+        "SDKROOT": "$dir\\Swift\\Platforms\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     },
     "checkver": {
         "url": "https://github.com/apple/swift",

--- a/bucket/swift.json
+++ b/bucket/swift.json
@@ -41,7 +41,6 @@
     "env_set": {
         "SDKROOT": "$dir\\Swift\\Platforms\\5.10.0\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     },
-    "bin": "Swift\\Runtimes\\5.10.0\\usr\\bin\\plutil.exe",
     "checkver": {
         "url": "https://github.com/apple/swift",
         "regex": "/swift-([\\d.]+)-RELEASE"

--- a/bucket/swift.json
+++ b/bucket/swift.json
@@ -19,22 +19,29 @@
     },
     "pre_install": [
         "Expand-DarkArchive \"$dir\\swiftsetup.exe\" \"$dir\\extract_folder\" -Removal",
-        "Get-ChildItem \"$dir\\extract_folder\\AttachedContainer\\a*\" | ForEach-Object {",
-        "    Expand-MsiArchive $_ \"$dir\\extract_folder\"",
+        "$xml = [xml](Get-Content -Raw \"$dir\\extract_folder\\UX\\manifest.xml\" -Encoding utf8)",
+        "$xml.BurnManifest.Payload | ForEach-Object {",
+        "    Move-Item -Path \"$dir\\extract_folder\\AttachedContainer\\$($_.SourcePath)\" -Destination \"$dir\\extract_folder\\AttachedContainer\\$($_.FilePath)\"",
         "}",
-        "Move-Item \"$dir\\extract_folder\\PFiles64\\Swift\" -Destination \"$dir\"",
-        "Move-Item \"$dir\\extract_folder\\Library\\Developer\" -Destination \"$dir\"",
+        "$xml.BurnManifest.Payload | Where-Object { $_.FilePath.EndsWith(\".msi\") } | ForEach-Object {",
+        "    if ($($_.FilePath) -eq \"rtl.msi\") {",
+        "        Expand-MsiArchive \"$dir\\extract_folder\\AttachedContainer\\$($_.FilePath)\" \"$dir\\extract_folder\\LocalApp\\Programs\\Swift\\Runtimes\\5.10.0\\usr\\bin\"",
+        "    } else {",
+        "        Expand-MsiArchive \"$dir\\extract_folder\\AttachedContainer\\$($_.FilePath)\" \"$dir\\extract_folder\"",
+        "    }",
+        "}",
+        "Move-Item -Path \"$dir\\extract_folder\\LocalApp\\Programs\\Swift\" -Destination \"$dir\"",
         "Remove-Item \"$dir\\extract_folder\" -Recurse | Out-Null"
     ],
     "env_add_path": [
-        "Developer\\Toolchains\\unknown-Asserts-development.xctoolchain\\usr\\bin",
-        "Swift\\runtime-development\\usr\\bin"
+        "Swift\\Runtimes\\5.10.0\\usr\\bin",
+        "Swift\\Toolchains\\5.10.0+Asserts\\usr\\bin",
+        "Swift\\Tools\\5.10.0\\"
     ],
     "env_set": {
-        "SDKROOT": "$dir\\Developer\\Platforms\\Windows.platform\\Developer\\SDKs\\Windows.sdk",
-        "DEVELOPER_DIR": "$dir\\Developer"
+        "SDKROOT": "$dir\\Swift\\Platforms\\5.10.0\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     },
-    "bin": "Swift\\runtime-development\\usr\\bin\\plutil.exe",
+    "bin": "Swift\\Runtimes\\5.10.0\\usr\\bin\\plutil.exe",
     "checkver": {
         "url": "https://github.com/apple/swift",
         "regex": "/swift-([\\d.]+)-RELEASE"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix the pre_install script because the msi file and the path to be expanded have changed.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5581

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
