### PR TITLE
FIX: adjusted `mods` manifest to the new ZIP structure

### DIFF
--- a/bucket/mods.json
+++ b/bucket/mods.json
@@ -6,11 +6,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/charmbracelet/mods/releases/download/v1.2.2/mods_1.2.2_Windows_x86_64.zip",
-            "hash": "a542c0ddb0d30f3a04fff3a0b2ab43135d795089790e20c5cfbe1eba033e2089"
+            "hash": "a542c0ddb0d30f3a04fff3a0b2ab43135d795089790e20c5cfbe1eba033e2089",
+            "extract_dir": "mods_1.2.2_Windows_x86_64"
         },
         "arm64": {
             "url": "https://github.com/charmbracelet/mods/releases/download/v1.2.2/mods_1.2.2_Windows_arm64.zip",
-            "hash": "c82d186523dcb8e1e37e9fe0413afa8d98b0d11efd425d9a6fb0e9b289fa7954"
+            "hash": "c82d186523dcb8e1e37e9fe0413afa8d98b0d11efd425d9a6fb0e9b289fa7954",
+            "extract_dir": "mods_1.2.2_Windows_arm64"
         }
     },
     "bin": "mods.exe",
@@ -18,10 +20,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_x86_64.zip"
+                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_x86_64.zip",
+                "extract_dir": "mods_$version_Windows_x86_64"
             },
             "arm64": {
-                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_arm64.zip"
+                "url": "https://github.com/charmbracelet/mods/releases/download/v$version/mods_$version_Windows_arm64.zip",
+                "extract_dir": "mods_$version_Windows_arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixes broken `mods` manifest for `1.2.2`. See https://github.com/charmbracelet/mods/discussions/238#discussion-6403901

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
