### PR TITLE
redis@7.2.4: fix download+autoupdate URL

### DIFF
--- a/bucket/redis.json
+++ b/bucket/redis.json
@@ -5,9 +5,9 @@
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/redis-windows/redis-windows/releases/download/7.2.4/Redis-7.2.4-Windows-x64.tar.gz",
-            "hash": "733a6611c8cb84c2de6d1355dc0392fd1f31d2a8731ca4a3eadbea98a9cd1ccc",
-            "extract_dir": "Redis-7.2.4-Windows-x64"
+            "url": "https://github.com/redis-windows/redis-windows/releases/download/7.2.4/Redis-7.2.4-Windows-x64-msys2.zip",
+            "hash": "a4c0ca3d7f91559a9cf8db3ae86aeb5362f67d91968109c317dc3e858ff87f82",
+            "extract_dir": "Redis-7.2.4-Windows-x64-msys2"
         }
     },
     "bin": [
@@ -21,8 +21,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/redis-windows/redis-windows/releases/download/$version/Redis-$version-Windows-x64.tar.gz",
-                "extract_dir": "Redis-$version-Windows-x64"
+                "url": "https://github.com/redis-windows/redis-windows/releases/download/$version/Redis-$version-Windows-x64-msys2.zip",
+                "extract_dir": "Redis-$version-Windows-x64-msys2"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The Redis windows package changed URLs and suddenly stopped working. This commit adds a new updated manifest that installs the msys2 version of redis-windows.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5634
Closes #5633
<!-- or -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
