### PR TITLE
boost: Update to version 1_85_0_b1_rc1

### DIFF
--- a/bucket/boost.json
+++ b/bucket/boost.json
@@ -14,7 +14,7 @@
         }
     },
     "innosetup": true,
-    "pre_install": "Rename-Item \"$dir/lib$($architecture.Substring(0, 2))-msvc-*.*\" lib",
+    "pre_install": "Get-ChildItem \"$dir/lib$($architecture.Substring(0, 2))-msvc-*.*\" | Rename-Item -NewName lib",
     "env_set": {
         "BOOST_ROOT": "$dir",
         "Boost_INCLUDE_DIR": "$dir\\boost"

--- a/bucket/boost.json
+++ b/bucket/boost.json
@@ -1,16 +1,16 @@
 {
-    "version": "1_84_0",
+    "version": "1_85_0_b1_rc1",
     "description": "Boost C++ Libraries",
     "homepage": "https://www.boost.org/",
     "license": "BSL-1.0",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/boost/boost-binaries/1.84.0/boost_1_84_0-msvc-14.3-64.exe",
-            "hash": "sha1:11effb2cff9e4c4a80d1b3ca2ead09117ba90b73"
+            "url": "https://downloads.sourceforge.net/project/boost/boost-binaries/1.85.0_b1/boost_1_85_0_b1_rc1-msvc-14.3-64.exe",
+            "hash": "sha1:38c529d5375431e1121a9fbeb08a5871cdaa9ce5"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/boost/boost-binaries/1.84.0/boost_1_84_0-msvc-14.3-32.exe",
-            "hash": "sha1:031dabe35ec68bdb05c29479b30239b961267297"
+            "url": "https://downloads.sourceforge.net/project/boost/boost-binaries/1.85.0_b1/boost_1_85_0_b1_rc1-msvc-14.3-32.exe",
+            "hash": "sha1:ef4c7acdeadb70468cd68e1835e142345252a7c8"
         }
     },
     "innosetup": true,
@@ -21,7 +21,7 @@
     },
     "checkver": {
         "sourceforge": "boost/boost-binaries",
-        "regex": "(?<short>[\\d.]+)+/boost_(\\w+)-msvc-(?<msvc>[\\d.]+)-64\\.exe"
+        "regex": "(?<short>[^/]+)+/boost_(\\w+)-msvc-(?<msvc>[\\d.]+)-64\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

So I accidentally introduced the following error
```pwsh
Running pre_install script...
Rename-Item : Cannot process argument because the value of argument "path" is not valid. Change the value of the
"path" argument and run the operation again.
At line:1 char:1
+ Rename-Item "$dir\lib$($architecture.Substring(0, 2))-msvc-*.*" lib
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Rename-Item], PSArgumentException
    + FullyQualifiedErrorId : Argument,Microsoft.PowerShell.Commands.RenameItemCommand
```
I wasn't aware that wildcards couldn't be used within PowerShell 5's `Rename-Item`, and since I don't use PowerShell 5 on any regular basis, someone had to tell me 😅.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).