### PR TITLE
yt-dlp: add plugins directory

### DIFF
--- a/bucket/yt-dlp.json
+++ b/bucket/yt-dlp.json
@@ -20,7 +20,7 @@
     "pre_install": "if (-not (Test-Path \"$persist_dir\\yt-dlp.conf\")) { New-Item \"$dir\\yt-dlp.conf\" -ItemType file | Out-Null }",
     "persist": [
         "yt-dlp.conf",
-        "ytdlp_plugins"
+        "yt-dlp-plugins"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/yt-dlp.json
+++ b/bucket/yt-dlp.json
@@ -20,6 +20,7 @@
     "pre_install": "if (-not (Test-Path \"$persist_dir\\yt-dlp.conf\")) { New-Item \"$dir\\yt-dlp.conf\" -ItemType file | Out-Null }",
     "persist": [
         "yt-dlp.conf",
+        "ytdlp_plugins",
         "yt-dlp-plugins"
     ],
     "checkver": "github",


### PR DESCRIPTION
According to [document](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#installing-plugins), there is another path for loading plugins.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
