### PR TITLE
nodejs-lts: fix checkver and add arm64 version

### DIFF
--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -1,23 +1,23 @@
 {
-    "version": "20.12.0",
+    "version": "20.12.1",
     "description": "As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications. (Long Term Support)",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v20.12.0/node-v20.12.0-win-x64.7z",
-            "hash": "2f623dac976071ef7a9cbf26081fd21b07349d234287bc863d690d4cf2adbe01",
-            "extract_dir": "node-v20.12.0-win-x64"
+            "url": "https://nodejs.org/dist/v20.12.1/node-v20.12.1-win-x64.7z",
+            "hash": "2628e9698f3bdada3fd36096fba0433fbd8f85832350bd5d2537f8f0ac50320f",
+            "extract_dir": "node-v20.12.1-win-x64"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v20.12.0/node-v20.12.0-win-x86.7z",
-            "hash": "47e57d5409b6dba0ab72868fc6691345ded1a54c3f6b0d724410bfdcb976d383",
-            "extract_dir": "node-v20.12.0-win-x86"
+            "url": "https://nodejs.org/dist/v20.12.1/node-v20.12.1-win-x86.7z",
+            "hash": "552c6fec6a0b28e9c49ad8574e4e67c35d9cfa718a3f940552e594e948caa6d9",
+            "extract_dir": "node-v20.12.1-win-x86"
         },
         "arm64": {
-            "url": "https://nodejs.org/dist/v20.12.0/node-v20.12.0-win-arm64.7z",
-            "hash": "96690fd6580aa8df8883ae7283c5702d7774441d7ba6b761901047d51760017d",
-            "extract_dir": "node-v20.12.0-win-arm64"
+            "url": "https://nodejs.org/dist/v20.12.1/node-v20.12.1-win-arm64.7z",
+            "hash": "17efd39f30e46b82ce94061ccee058fce3e1c3f1e5538a3f30463c52e5ab82e8",
+            "extract_dir": "node-v20.12.1-win-arm64"
         }
     },
     "post_install": [
@@ -33,8 +33,9 @@
         "cache"
     ],
     "checkver": {
-        "url": "https://nodejs.org/en/",
-        "regex": "Downloads Node.js <b>v([\\d.]+)</b>"
+        "url": "https://nodejs.org/dist/index.json",
+        "jsonpath": "$..[?(@.lts != false)].version",
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -1,18 +1,23 @@
 {
-    "version": "20.11.1",
+    "version": "20.12.0",
     "description": "As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications. (Long Term Support)",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-win-x64.7z",
-            "hash": "fb9b5348259988a562a48eed7349e7e716c0bec78d98ad0a336b2993a8b3bf34",
-            "extract_dir": "node-v20.11.1-win-x64"
+            "url": "https://nodejs.org/dist/v20.12.0/node-v20.12.0-win-x64.7z",
+            "hash": "2f623dac976071ef7a9cbf26081fd21b07349d234287bc863d690d4cf2adbe01",
+            "extract_dir": "node-v20.12.0-win-x64"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-win-x86.7z",
-            "hash": "c2b1863d8979546804a39fc63d0a9bc9c6e49cb2f6c9d1e52844a24629b24765",
-            "extract_dir": "node-v20.11.1-win-x86"
+            "url": "https://nodejs.org/dist/v20.12.0/node-v20.12.0-win-x86.7z",
+            "hash": "47e57d5409b6dba0ab72868fc6691345ded1a54c3f6b0d724410bfdcb976d383",
+            "extract_dir": "node-v20.12.0-win-x86"
+        },
+        "arm64": {
+            "url": "https://nodejs.org/dist/v20.12.0/node-v20.12.0-win-arm64.7z",
+            "hash": "96690fd6580aa8df8883ae7283c5702d7774441d7ba6b761901047d51760017d",
+            "extract_dir": "node-v20.12.0-win-arm64"
         }
     },
     "post_install": [
@@ -28,8 +33,8 @@
         "cache"
     ],
     "checkver": {
-        "url": "https://nodejs.org/en/download/",
-        "regex": "LTS Version.*: <strong>([\\d.]+)</strong>"
+        "url": "https://nodejs.org/en/",
+        "regex": "Downloads Node.js <b>v([\\d.]+)</b>"
     },
     "autoupdate": {
         "architecture": {
@@ -40,6 +45,10 @@
             "32bit": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
                 "extract_dir": "node-v$version-win-x86"
+            },
+            "arm64": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",
+                "extract_dir": "node-v$version-win-arm64"
             }
         },
         "hash": {

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -33,8 +33,9 @@
         "Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\""
     ],
     "checkver": {
-        "url": "https://nodejs.org/dist/latest/",
-        "regex": "node-v([\\d.]+)-win-x64\\.7z"
+        "url": "https://nodejs.org/dist/index.json",
+        "jsonpath": "$..version",
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Due to the [redesign](https://nodejs.org/en/blog/announcements/diving-into-the-nodejs-website-redesign) of the Node.js website, the checkver of the nodejs-lts package is broken, this pull request fixes it, and also adds the arm64 version

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
