### PR TITLE
zstd: Add 32-bit architecture

### DIFF
--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -6,18 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win64.zip",
-            "hash": "7b4eff6719990e38aca93a4844c2e86a1935090625c4611f7e89675e999c56cc"
+            "hash": "7b4eff6719990e38aca93a4844c2e86a1935090625c4611f7e89675e999c56cc",
+            "extract_dir": "zstd-v1.5.6-win64"
         },
         "32bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win32.zip",
-            "hash": "d274d937b9b5c422c72c2689a92dae1642ddfd520aad4e0038e5b5a0fa657f8f"
+            "hash": "d274d937b9b5c422c72c2689a92dae1642ddfd520aad4e0038e5b5a0fa657f8f",
+            "extract_dir": "zstd-v1.5.6-win32"
         }
     },
-    "extract_to": "__temp",
-    "pre_install": [
-        "Move-Item \"$dir\\__temp\\zstd-v$version-win*\\*\" \"$dir\" -Force",
-        "Remove-Item \"$dir\\__temp\" -Force -Recurse"
-    ],
     "bin": "zstd.exe",
     "checkver": {
         "github": "https://github.com/facebook/zstd"
@@ -25,10 +22,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip",
+                "extract_dir": "zstd-v$version-win64"
             },
             "32bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win32.zip"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win32.zip",
+                "extract_dir": "zstd-v$version-win32"
             }
         }
     }

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -15,8 +15,7 @@
     },
     "extract_to": "__temp",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\__temp\\zstd-v$version*.zip\" \"$dir\\__temp\\extracted\"",
-        "Move-Item \"$dir\\__temp\\extracted\\zstd-v$version*\\*\" \"$dir\" -Force",
+        "Move-Item \"$dir\\__temp\\zstd-v$version-win*\\*\" \"$dir\" -Force",
         "Remove-Item \"$dir\\__temp\" -Force -Recurse"
     ],
     "bin": "zstd.exe",

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -6,15 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win64.zip",
-            "hash": "e84baaa9f8902bed43b4446405a9b59bf922d357475a281305c4885d8c83c4c2",
-            "extract_to": "__temp\\outer",
-            "pre_install": [
-                "Expand-7zipArchive \"$dir\\__temp\\outer\\zstd-v$version-win64.zip\" \"$dir\\__temp\\inner\"",
-                "Move-Item \"$dir\\__temp\\inner\\zstd-v$version-win64\\*\" \"$dir\" -Force",
-                "Remove-Item \"$dir\\__temp\" -Force -Recurse"
-            ]
+            "hash": "e84baaa9f8902bed43b4446405a9b59bf922d357475a281305c4885d8c83c4c2"
         }
     },
+    "extract_to": "__temp\\outer",
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\__temp\\outer\\zstd-v$version-win64.zip\" \"$dir\\__temp\\inner\"",
+        "Move-Item \"$dir\\__temp\\inner\\zstd-v$version-win64\\*\" \"$dir\" -Force",
+        "Remove-Item \"$dir\\__temp\" -Force -Recurse"
+    ],
     "bin": "zstd.exe",
     "checkver": {
         "github": "https://github.com/facebook/zstd"

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -7,12 +7,17 @@
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win64.zip",
             "hash": "e84baaa9f8902bed43b4446405a9b59bf922d357475a281305c4885d8c83c4c2"
+        },
+        "32bit": {
+            "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win32.zip",
+            "hash": "d274d937b9b5c422c72c2689a92dae1642ddfd520aad4e0038e5b5a0fa657f8f"
         }
     },
-    "extract_to": "__temp\\outer",
+    "extract_to": "__temp",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\__temp\\outer\\zstd-v$version-win64.zip\" \"$dir\\__temp\\inner\"",
-        "Move-Item \"$dir\\__temp\\inner\\zstd-v$version-win64\\*\" \"$dir\" -Force",
+        "Move-Item \"$dir\\__temp\\zstd-v$version*.zip\" \"$dir\\__temp\\zstd-v$version.zip\" -Force",
+        "Expand-7zipArchive \"$dir\\__temp\\zstd-v$version.zip\" \"$dir\\__temp\\extracted\"",
+        "Move-Item \"$dir\\__temp\\extracted\\zstd-v$version*\\*\" \"$dir\" -Force",
         "Remove-Item \"$dir\\__temp\" -Force -Recurse"
     ],
     "bin": "zstd.exe",
@@ -22,8 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip",
-                "extract_dir": "zstd-v$version-win64"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
             }
         }
     }

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -30,7 +30,7 @@
                 "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
             },
             "32bit": {
-                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win64.zip"
+                "url": "https://github.com/facebook/zstd/releases/download/v$version/zstd-v$version-win32.zip"
             }
         }
     }

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -15,8 +15,7 @@
     },
     "extract_to": "__temp",
     "pre_install": [
-        "Move-Item \"$dir\\__temp\\zstd-v$version*.zip\" \"$dir\\__temp\\zstd-v$version.zip\" -Force",
-        "Expand-7zipArchive \"$dir\\__temp\\zstd-v$version.zip\" \"$dir\\__temp\\extracted\"",
+        "Expand-7zipArchive \"$dir\\__temp\\zstd-v$version*.zip\" \"$dir\\__temp\\extracted\"",
         "Move-Item \"$dir\\__temp\\extracted\\zstd-v$version*\\*\" \"$dir\" -Force",
         "Remove-Item \"$dir\\__temp\" -Force -Recurse"
     ],

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win64.zip",
-            "hash": "e84baaa9f8902bed43b4446405a9b59bf922d357475a281305c4885d8c83c4c2"
+            "hash": "7b4eff6719990e38aca93a4844c2e86a1935090625c4611f7e89675e999c56cc"
         },
         "32bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win32.zip",

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -7,7 +7,12 @@
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-v1.5.6-win64.zip",
             "hash": "e84baaa9f8902bed43b4446405a9b59bf922d357475a281305c4885d8c83c4c2",
-            "extract_dir": "zstd-v1.5.6-win64"
+            "extract_to": "__temp\\outer",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\__temp\\outer\\zstd-v$version-win64.zip\" \"$dir\\__temp\\inner\"",
+                "Move-Item \"$dir\\__temp\\inner\\zstd-v$version-win64\\*\" \"$dir\" -Force",
+                "Remove-Item \"$dir\\__temp\" -Force -Recurse"
+            ]
         }
     },
     "bin": "zstd.exe",


### PR DESCRIPTION
There may be a simpler method, but this fix extracts the zip within the zip and then moves its contents to `$dir`. Tested locally.

Closes #5658

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).