### PR TITLE
cht@0.7.2: Update cht.exe to 0.7.2 and add auto update.

### DIFF
--- a/bucket/cht.json
+++ b/bucket/cht.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.7.1",
+    "version": "0.7.2",
     "description": "A command line client for https://cht.sh, working examples about various commands, APIs, ... Unified access to the best community driven documentation repositories of the world.",
     "homepage": "https://github.com/tpanj/cht.exe",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tpanj/cht.exe/releases/download/v0.7.1/cht_windows.zip",
-            "hash": "9d39696fc905b6762dfdebea82692ed3e212c8fa12ea21e3e1a500eb4fd0af4b",
+            "url": "https://github.com/tpanj/cht.exe/releases/download/v0.7.2/cht_windows.zip",
+            "hash": "9f678ae500377c735fdc296b105e19092ffef5769e64a719cff0fc0962b97997",
             "extract_dir": "bin"
         }
     },

--- a/bucket/cht.json
+++ b/bucket/cht.json
@@ -1,10 +1,22 @@
 {
-    "version": "0.6",
+    "version": "0.7.1",
     "description": "A command line client for https://cht.sh, working examples about various commands, APIs, ... Unified access to the best community driven documentation repositories of the world.",
     "homepage": "https://github.com/tpanj/cht.exe",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/tpanj/cht.exe/archive/v0.6.zip",
-    "hash": "771061cefff950be8ec3f2987e0b56e8ec20b79c8d451e24e5f89b7f391629df",
-    "extract_dir": "cht.exe-0.6\\bin",
-    "bin": "cht.exe"
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tpanj/cht.exe/releases/download/v0.7.1/cht_windows.zip",
+            "hash": "9d39696fc905b6762dfdebea82692ed3e212c8fa12ea21e3e1a500eb4fd0af4b",
+            "extract_dir": "bin"
+        }
+    },
+    "bin": "cht.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tpanj/cht.exe/releases/download/v$version/cht_windows.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
cht was still on version `0.6` but is currently at `0.7.2` which fixes, for example https://github.com/tpanj/cht.exe/issues/7#issue-1458740110. This PR also adds auto-update to the cht manifest.

> I have not created a seperate issue for this, since it is not a new package or a bug with the manifest but just an update to the already available version.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
