### PR TITLE
Fix mozjpeg auto update

### DIFF
--- a/bucket/mozjpeg.json
+++ b/bucket/mozjpeg.json
@@ -34,7 +34,9 @@
             "jpegtran"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/garyzyg/mozjpeg-windows"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/mozjpeg.json
+++ b/bucket/mozjpeg.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1.1",
+    "version": "4.1.5",
     "description": "Improved JPEG encoder",
     "homepage": "https://github.com/mozilla/mozjpeg",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/garyzyg/mozjpeg-windows/releases/download/4.1.1/mozjpeg-x64.zip",
-            "hash": "7575b5a4564d0974dd3739195580559666ee4427e0358195a324d4bae9f02184"
+            "url": "https://github.com/garyzyg/mozjpeg-windows/releases/download/4.1.5/mozjpeg-x64.zip",
+            "hash": "176ef4f632b09dca449e27bc11df090c1222528dff9f583a14bbd026a0c8eb2f"
         },
         "32bit": {
-            "url": "https://github.com/garyzyg/mozjpeg-windows/releases/download/4.1.1/mozjpeg-x86.zip",
-            "hash": "46e669e3d105778c267bd2d2701936c470fc916521643b3eec2288e504242fb4"
+            "url": "https://github.com/garyzyg/mozjpeg-windows/releases/download/4.1.5/mozjpeg-x86.zip",
+            "hash": "ef5c30b892b48e1c4bf82752ecbea1280e03d285ede8f1d3d47cb939f4ca150a"
         }
     },
     "bin": [


### PR DESCRIPTION
Mozjpeg builds by Gary Zhang ( https://github.com/garyzyg/mozjpeg-windows ) has been stuck on v4.1.1 in Scoop, but v4.1.5 is available.

I found a change to "checkver" that made "checkver.ps1" return correct new version.

Fixes issue: #5681

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
