### PR TITLE
imagemagick-lean: Fix bins (`dcraw.exe`)

### DIFF
--- a/bucket/imagemagick-lean.json
+++ b/bucket/imagemagick-lean.json
@@ -22,7 +22,6 @@
     },
     "bin": [
         "magick.exe",
-        "dcraw.exe",
         "IMDisplay.exe"
     ],
     "notes": [


### PR DESCRIPTION
Currently errors on install, fails to shim bin (bin was removed).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).