### PR TITLE
haskell: use haskell.org instead of ghc github mirror and update to version 9.8.2

### DIFF
--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -12,7 +12,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-9.4.1-release/ghc-9.4.1-x86_64-unknown-mingw32.tar.xz",
+            "url": "https://downloads.haskell.org/~ghc/9.4.1/ghc-9.4.1-x86_64-unknown-mingw32.tar.xz",
             "hash": "fdc2d78b8a978e712a4edcc1628e36a36be736d8202107d2d61999ac7a9dc5d0",
             "extract_dir": "ghc-9.4.1-x86_64-unknown-mingw32"
         }
@@ -29,14 +29,14 @@
     ],
     "env_add_path": "lib\\bin",
     "checkver": {
-        "url": "https://api.github.com/repositories/46509594/tags",
-        "jsonpath": "$..name",
-        "regex": "ghc-([\\d\\.]+)-release"
+        "url": "https://downloads.haskell.org/~ghc/",
+        "regex": ">(\\d(\\.\\d)*)/",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-$version-release/ghc-$version-x86_64-unknown-mingw32.tar.xz",
+                "url": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-unknown-mingw32.tar.xz",
                 "extract_dir": "ghc-$version-x86_64-unknown-mingw32"
             }
         }

--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.4.1",
+    "version": "9.8.2",
     "description": "An advanced, purely functional programming language.",
     "homepage": "https://www.haskell.org",
     "license": "BSD-3-Clause",
@@ -12,9 +12,9 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.haskell.org/~ghc/9.4.1/ghc-9.4.1-x86_64-unknown-mingw32.tar.xz",
-            "hash": "fdc2d78b8a978e712a4edcc1628e36a36be736d8202107d2d61999ac7a9dc5d0",
-            "extract_dir": "ghc-9.4.1-x86_64-unknown-mingw32"
+            "url": "https://downloads.haskell.org/~ghc/9.8.2/ghc-9.8.2-x86_64-unknown-mingw32.tar.xz",
+            "hash": "f7d496b850686ea5fbfcecc722ec399ec7acb8d06ebec23bb4dcb9338f430764",
+            "extract_dir": "ghc-9.8.2-x86_64-unknown-mingw32"
         }
     },
     "bin": [

--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -29,14 +29,16 @@
     ],
     "env_add_path": "lib\\bin",
     "checkver": {
-        "url": "https://downloads.haskell.org/~ghc/",
-        "regex": ">(\\d(\\.\\d)*)/",
-        "reverse": true
+        "url": "https://www.haskell.org/ghc/download.html",
+        "regex": "(?s)Current Stable Releases.*?>([\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-unknown-mingw32.tar.xz",
+                "hash": {
+                    "url": "$baseurl/SHA256SUMS"
+                },
                 "extract_dir": "ghc-$version-x86_64-unknown-mingw32"
             }
         }


### PR DESCRIPTION
The GitHub ghc mirror seems outdated (newest release there is 9.4.1).
This PR will thus switch to [ghc from haskell.org](https://www.haskell.org/ghc/download.html) and also update the haskell package to 9.8.2.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
