### PR TITLE
apache: Update to version 2.4.59

### DIFF
--- a/bucket/ab.json
+++ b/bucket/ab.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.4.58",
+    "version": "2.4.59",
     "description": "Apache HTTP server benchmarking tool ('ab')",
     "homepage": "https://www.apachelounge.com",
     "license": "Apache-2.0",

--- a/bucket/ab.json
+++ b/bucket/ab.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://fossies.org/windows/www/httpd-2.4.58-win64-VS17.zip",
-            "hash": "e9a179ad4767c595be55024ee0415a96ae522f492deca4b0d54cf136ff2b092c"
+            "hash": "12e50ea2ccd1a0617cbf679150b48f9a21bad1ad05fe2715386c51c087e18543"
         }
     },
     "extract_dir": "Apache24",

--- a/bucket/ab.json
+++ b/bucket/ab.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://fossies.org/windows/www/httpd-2.4.58-win64-VS17.zip",
+            "url": "https://fossies.org/windows/www/httpd-2.4.59-240404-win64-VS17.zip",
             "hash": "12e50ea2ccd1a0617cbf679150b48f9a21bad1ad05fe2715386c51c087e18543"
         }
     },

--- a/bucket/ab.json
+++ b/bucket/ab.json
@@ -17,12 +17,12 @@
     ],
     "checkver": {
         "url": "https://fossies.org/windows/www/",
-        "regex": "httpd-([\\d.]+)-win64-VS17\\.zip"
+        "regex": "httpd-([\\d.]+)-(?<date>[\\d]+)-win64-VS17\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://fossies.org/windows/www/httpd-$version-win64-VS17.zip"
+                "url": "https://fossies.org/windows/www/httpd-$version-$matchDate-win64-VS17.zip"
             }
         },
         "hash": {

--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -35,12 +35,12 @@
     ],
     "checkver": {
         "url": "https://fossies.org/windows/www/",
-        "regex": "httpd-([\\d.]+)-win64-VS17\\.zip"
+        "regex": "httpd-([\\d.]+)-(?<date>[\\d]+)-win64-VS17\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://fossies.org/windows/www/httpd-$version-win64-VS17.zip"
+                "url": "https://fossies.org/windows/www/httpd-$version-$matchDate-win64-VS17.zip"
             }
         },
         "hash": {

--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://fossies.org/windows/www/httpd-2.4.58-win64-VS17.zip",
-            "hash": "e9a179ad4767c595be55024ee0415a96ae522f492deca4b0d54cf136ff2b092c"
+            "hash": "12e50ea2ccd1a0617cbf679150b48f9a21bad1ad05fe2715386c51c087e18543"
         }
     },
     "extract_dir": "Apache24",

--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.4.58",
+    "version": "2.4.59",
     "description": "The Apache HTTP Server ('httpd')",
     "homepage": "https://www.apachelounge.com",
     "license": "Apache-2.0",

--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://fossies.org/windows/www/httpd-2.4.58-win64-VS17.zip",
+            "url": "https://fossies.org/windows/www/httpd-2.4.59-240404-win64-VS17.zip",
             "hash": "12e50ea2ccd1a0617cbf679150b48f9a21bad1ad05fe2715386c51c087e18543"
         }
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Update Apache version to 2.4.59 since 2.4.58 is gone.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5714 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
