### PR TITLE
oauth2c: Add version 1.15.0

### DIFF
--- a/bucket/oauth2c.json
+++ b/bucket/oauth2c.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.13.0",
+    "description": "A command-line tool for interacting with OAuth 2.0 authorization servers.",
+    "homepage": "https://github.com/cloudentity/oauth2c",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cloudentity/oauth2c/releases/download/v1.13.0/oauth2c_1.13.0_Windows_x86_64.tar.gz",
+            "hash": "12d82e33551f5bed81550ef0727e05b8e2c70d7cb31a0c34ff4a34ca9b1746b4"
+        },
+        "arm64": {
+            "url": "https://github.com/cloudentity/oauth2c/releases/download/v1.13.0/oauth2c_1.13.0_Windows_arm64.tar.gz",
+            "hash": "f7e0931711c51272798beabefea2a0c0d23a7b03a6b5076d3c330202081ddbe0"
+        }
+    },
+    "bin": "oauth2c.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cloudentity/oauth2c/releases/download/v$version/oauth2c_$version_Windows_x86_64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/cloudentity/oauth2c/releases/download/v$version/oauth2c_$version_Windows_arm64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}

--- a/bucket/oauth2c.json
+++ b/bucket/oauth2c.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.13.0",
+    "version": "1.15.0",
     "description": "A command-line tool for interacting with OAuth 2.0 authorization servers.",
     "homepage": "https://github.com/cloudentity/oauth2c",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cloudentity/oauth2c/releases/download/v1.13.0/oauth2c_1.13.0_Windows_x86_64.tar.gz",
-            "hash": "12d82e33551f5bed81550ef0727e05b8e2c70d7cb31a0c34ff4a34ca9b1746b4"
+            "url": "https://github.com/cloudentity/oauth2c/releases/download/v1.15.0/oauth2c_1.15.0_Windows_x86_64.tar.gz",
+            "hash": "65212a8955ae25f04909289bdb952f63ee887b48ce38576b54328da58d10b4b4"
         },
         "arm64": {
-            "url": "https://github.com/cloudentity/oauth2c/releases/download/v1.13.0/oauth2c_1.13.0_Windows_arm64.tar.gz",
-            "hash": "f7e0931711c51272798beabefea2a0c0d23a7b03a6b5076d3c330202081ddbe0"
+            "url": "https://github.com/cloudentity/oauth2c/releases/download/v1.15.0/oauth2c_1.15.0_Windows_arm64.tar.gz",
+            "hash": "6022efcaeec611f60775e040902b85cd7eaccd5ca45146be419e256ec34ddb5f"
         }
     },
     "bin": "oauth2c.exe",


### PR DESCRIPTION
oauth2c: Add version 1.13.0

https://github.com/cloudentity/oauth2c

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
