### PR TITLE
uutils-coreutils-lean@0.0.23: Update homepage

### DIFF
--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/uutils/coreutils",
+        "github": "https://github.com/uutils/coreutils"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -1,7 +1,7 @@
 {
     "version": "0.0.23",
     "description": "Rust implementation of GNU coreutils (binaries compiled with MSVC)",
-    "homepage": "https://github.com/uutils/coreutils",
+    "homepage": "https://uutils.github.io/coreutils/",
     "license": "MIT",
     "architecture": {
         "64bit": {
@@ -22,7 +22,9 @@
             "uutils"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/uutils/coreutils",
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
This is a trivial PR. It has a dedicated homepage now, which should be preferred over the repo.

Relates to #5742

Relates to https://github.com/uutils/coreutils/pull/2897

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

