### PR TITLE
Fix exe location in zls.json for version 0.12.0

### DIFF
--- a/bucket/zls.json
+++ b/bucket/zls.json
@@ -13,7 +13,7 @@
             "hash": "9656942a98e6d582b8e1d7486d0d3523ee80b0120d4a1d0740e963e45ea88954"
         }
     },
-    "bin": "bin\\zls.exe",
+    "bin": "zls.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
zls.exe is no longer in bin/ directory so installation fails on shim creation as file is not found.