### PR TITLE
Update zls.json, fix "The term 'bin\zls.exe' is not recognized as a name of a cmdlet, function, script file, or executable program. "

### DIFF
--- a/bucket/zls.json
+++ b/bucket/zls.json
@@ -13,7 +13,7 @@
             "hash": "9656942a98e6d582b8e1d7486d0d3523ee80b0120d4a1d0740e963e45ea88954"
         }
     },
-    "bin": "bin\\zls.exe",
+    "bin": "zls.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Installing 'zls' (0.12.0) [64bit] from 'main' bucket Loading zls-x86_64-windows.zip from cache.
Checking hash of zls-x86_64-windows.zip ... ok.
Extracting zls-x86_64-windows.zip ... done.
Linking ~\scoop\apps\zls\current => ~\scoop\apps\zls\0.12.0 Creating shim for 'zls'.
Get-Command: C:\Users\zhaoboqiang\scoop\apps\scoop\current\lib\install.ps1:783 Line |
 783 |              $bin = (Get-Command $target).Source
     |                      ~~~~~~~~~~~~~~~~~~~
     | The term 'bin\zls.exe' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if
     | a path was included, verify that the path is correct and try again.
Can't shim 'bin\zls.exe': File doesn't exist.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
