### PR TITLE
charm-gum@0.14.1: Fix `extract_dir`

### DIFF
--- a/bucket/charm-gum.json
+++ b/bucket/charm-gum.json
@@ -6,11 +6,13 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/charmbracelet/gum/releases/download/v0.14.0/gum_0.14.0_Windows_i386.zip",
-            "hash": "474bb7ef101a00011ba8af1179329a5ac8ac12b7029dc3c9b051b52f2dc2a291"
+            "hash": "474bb7ef101a00011ba8af1179329a5ac8ac12b7029dc3c9b051b52f2dc2a291",
+            "extract_dir": "gum_0.14.0_Windows_i386"
         },
         "64bit": {
             "url": "https://github.com/charmbracelet/gum/releases/download/v0.14.0/gum_0.14.0_Windows_x86_64.zip",
-            "hash": "faa0e75a4d2f2541e0556f5dc9378c82b5e6eb3d3f618ebe4be685376d7c7d82"
+            "hash": "faa0e75a4d2f2541e0556f5dc9378c82b5e6eb3d3f618ebe4be685376d7c7d82",
+            "extract_dir": "gum_0.14.0_Windows_x86_64"
         }
     },
     "bin": "gum.exe",
@@ -19,6 +21,7 @@
         "architecture": {
             "32bit": {
                 "url": "https://github.com/charmbracelet/gum/releases/download/v$version/gum_$version_Windows_i386.zip",
+                "extract_dir": "gum_0.14.0_Windows_i386",
                 "hash": {
                     "url": "$baseurl/checksums.txt",
                     "regex": "($sha256)\\s+gum_[\\d.]+_Windows_i386\\.zip"
@@ -26,6 +29,7 @@
             },
             "64bit": {
                 "url": "https://github.com/charmbracelet/gum/releases/download/v$version/gum_$version_Windows_x86_64.zip",
+                "extract_dir": "gum_0.14.0_Windows_x86_64",
                 "hash": {
                     "url": "$baseurl/checksums.txt",
                     "regex": "($sha256)\\s+gum_[\\d.]+_Windows_x86_64\\.zip"

--- a/bucket/charm-gum.json
+++ b/bucket/charm-gum.json
@@ -21,20 +21,16 @@
         "architecture": {
             "32bit": {
                 "url": "https://github.com/charmbracelet/gum/releases/download/v$version/gum_$version_Windows_i386.zip",
-                "extract_dir": "gum_$version_Windows_i386",
-                "hash": {
-                    "url": "$baseurl/checksums.txt",
-                    "regex": "($sha256)\\s+gum_[\\d.]+_Windows_i386\\.zip"
-                }
+                "extract_dir": "gum_$version_Windows_i386"
             },
             "64bit": {
                 "url": "https://github.com/charmbracelet/gum/releases/download/v$version/gum_$version_Windows_x86_64.zip",
-                "extract_dir": "gum_$version_Windows_x86_64",
-                "hash": {
-                    "url": "$baseurl/checksums.txt",
-                    "regex": "($sha256)\\s+gum_[\\d.]+_Windows_x86_64\\.zip"
-                }
+                "extract_dir": "gum_$version_Windows_x86_64"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "($sha256).*?$basename"
         }
     }
 }

--- a/bucket/charm-gum.json
+++ b/bucket/charm-gum.json
@@ -21,7 +21,7 @@
         "architecture": {
             "32bit": {
                 "url": "https://github.com/charmbracelet/gum/releases/download/v$version/gum_$version_Windows_i386.zip",
-                "extract_dir": "gum_0.14.0_Windows_i386",
+                "extract_dir": "gum_$version_Windows_i386",
                 "hash": {
                     "url": "$baseurl/checksums.txt",
                     "regex": "($sha256)\\s+gum_[\\d.]+_Windows_i386\\.zip"
@@ -29,7 +29,7 @@
             },
             "64bit": {
                 "url": "https://github.com/charmbracelet/gum/releases/download/v$version/gum_$version_Windows_x86_64.zip",
-                "extract_dir": "gum_0.14.0_Windows_x86_64",
+                "extract_dir": "gum_$version_Windows_x86_64",
                 "hash": {
                     "url": "$baseurl/checksums.txt",
                     "regex": "($sha256)\\s+gum_[\\d.]+_Windows_x86_64\\.zip"


### PR DESCRIPTION
Newer version (updated in https://github.com/ScoopInstaller/Main/commit/340b2b61bfff7942c1038005d036af037830c89f today) of charm-gum has a directory in its archive.

Fixes #5781

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
