### PR TITLE
Update mysql.json - fixes #5777

### DIFF
--- a/bucket/mysql-lts.json
+++ b/bucket/mysql-lts.json
@@ -56,7 +56,6 @@
         "bin\\mysqlshow.exe",
         "bin\\mysqlslap.exe",
         "bin\\mysql_config_editor.exe",
-        "bin\\mysql_configurator.exe",
         "bin\\mysql_secure_installation.exe",
         "bin\\mysql_tzinfo_to_sql.exe",
         "bin\\my_print_defaults.exe",

--- a/bucket/mysql-lts.json
+++ b/bucket/mysql-lts.json
@@ -1,7 +1,7 @@
 {
-    "version": "8.0.37",
-    "description": "The world's most popular open-source database, supported by an active community. (Long Term Support)",
-    "homepage": "https://dev.mysql.com/downloads/mysql/8.0.html",
+    "version": "8.4.0",
+    "description": "The world's most popular open-source database (Long Term Support)",
+    "homepage": "https://dev.mysql.com/downloads/mysql/#info-tab",
     "license": "GPL-2.0-only",
     "notes": [
         "Run 'mysqld --standalone' or 'mysqld --console' to start the Database,",
@@ -12,13 +12,14 @@
         "To stop and/or delete the Service run 'sc stop MySQL' and 'sc delete MySQL'."
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2022"
+        "vcredist": "extras/vcredist2022",
+        "mysql-shell": "mysql-shell"
     },
     "architecture": {
         "64bit": {
-            "url": "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.37-winx64.zip",
-            "hash": "md5:936fc116f2dd865dc26ef3d71f5730e8",
-            "extract_dir": "mysql-8.0.37-winx64"
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-winx64.msi",
+            "hash": "md5:53c9781e14f106f4551d4d8c06654bc3",
+            "extract_dir": "PFiles64\\MySQL\\MySQL Server 8.4"
         }
     },
     "pre_install": [
@@ -34,14 +35,13 @@
     "post_install": [
         "if (!(Test-Path \"$dir\\data\\auto.cnf\")) {",
         "    warn 'Initializing data directory ...'",
-        "    Invoke-ExternalCommand -FilePath \"$dir\\bin\\mysqld.exe\" -ArgumentList '--initialize-insecure'",
+        "    Invoke-ExternalCommand -FilePath \"$dir\\bin\\mysqld.exe\" -ArgumentList '--initialize-insecure' | Out-Null",
         "    warn 'Database has been initialized (username: root, password: <blank>)'",
         "}"
     ],
     "bin": [
         "bin\\ibd2sdi.exe",
         "bin\\innochecksum.exe",
-        "bin\\lz4_decompress.exe",
         "bin\\myisamchk.exe",
         "bin\\myisamlog.exe",
         "bin\\myisampack.exe",
@@ -53,32 +53,35 @@
         "bin\\mysqld.exe",
         "bin\\mysqldump.exe",
         "bin\\mysqlimport.exe",
-        "bin\\mysqlpump.exe",
         "bin\\mysqlshow.exe",
         "bin\\mysqlslap.exe",
         "bin\\mysql_config_editor.exe",
+        "bin\\mysql_configurator.exe",
         "bin\\mysql_secure_installation.exe",
-        "bin\\mysql_ssl_rsa_setup.exe",
         "bin\\mysql_tzinfo_to_sql.exe",
-        "bin\\mysql_upgrade.exe",
         "bin\\my_print_defaults.exe",
-        "bin\\perror.exe",
-        "bin\\zlib_decompress.exe"
+        "bin\\perror.exe"
+    ],
+    "shortcuts": [
+        [
+            "bin\\mysql_configurator.exe",
+            "MySQL Configurator"
+        ]
     ],
     "persist": [
         "data",
         "my.ini"
     ],
-    "checkver": "<h1>MySQL Community Server ([\\d.]+)",
+    "checkver": ">([\\d.]+) LTS<",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dev.mysql.com/get/Downloads/MySQL-$majorVersion.$minorVersion/mysql-$version-winx64.zip",
+                "url": "https://dev.mysql.com/get/Downloads/MySQL-$majorVersion.$minorVersion/mysql-$version-winx64.msi",
                 "hash": {
-                    "url": "https://dev.mysql.com/downloads/mysql/8.0.html",
-                    "regex": "md5\">$md5"
+                    "url": "https://dev.mysql.com/downloads/mysql/",
+                    "regex": "(?s)$basename.*?$md5"
                 },
-                "extract_dir": "mysql-$version-winx64"
+                "extract_dir": "PFiles64\\MySQL\\MySQL Server $majorVersion.$minorVersion"
             }
         }
     }

--- a/bucket/mysql-shell.json
+++ b/bucket/mysql-shell.json
@@ -1,0 +1,33 @@
+{
+    "version": "8.4.0",
+    "description": "Advanced client and code editor for MySQL",
+    "homepage": "https://dev.mysql.com/downloads/shell/#info-tab",
+    "license": "GPL-2.0-only",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-8.4.0-windows-x86-64bit.msi",
+            "hash": "md5:617655416d75f6889b8f7b8e5bf1a312",
+            "extract_dir": "PFiles64\\MySQL\\MySQL Shell 8.4"
+        }
+    },
+    "bin": [
+        "bin\\mysqlsh.exe",
+        "bin\\mysql-secret-store-windows-credential.exe"
+    ],
+    "checkver": "MySQL Shell ([\\d.]+)",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-$version-windows-x86-64bit.msi",
+                "hash": {
+                    "url": "https://dev.mysql.com/downloads/shell/",
+                    "regex": "(?s)$basename.*?$md5"
+                },
+                "extract_dir": "PFiles64\\MySQL\\MySQL Shell $majorVersion.$minorVersion"
+            }
+        }
+    }
+}

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -1,7 +1,7 @@
 {
     "version": "8.4.0",
-    "description": "The world's most popular open-source database, supported by an active community.",
-    "homepage": "https://dev.mysql.com/downloads/mysql/",
+    "description": "The world's most popular open-source database",
+    "homepage": "https://dev.mysql.com/downloads/mysql/#info-tab",
     "license": "GPL-2.0-only",
     "notes": [
         "Run 'mysqld --standalone' or 'mysqld --console' to start the Database,",
@@ -12,13 +12,14 @@
         "To stop and/or delete the Service run 'sc stop MySQL' and 'sc delete MySQL'."
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2022"
+        "vcredist": "extras/vcredist2022",
+        "mysql-shell": "mysql-shell"
     },
     "architecture": {
         "64bit": {
-            "url": "https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-winx64.zip",
-            "hash": "md5:23fa293db80b5d49f9e97d34c2037a82",
-            "extract_dir": "mysql-8.4.0-winx64"
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-winx64.msi",
+            "hash": "md5:53c9781e14f106f4551d4d8c06654bc3",
+            "extract_dir": "PFiles64\\MySQL\\MySQL Server 8.4"
         }
     },
     "pre_install": [
@@ -34,7 +35,7 @@
     "post_install": [
         "if (!(Test-Path \"$dir\\data\\auto.cnf\")) {",
         "    warn 'Initializing data directory ...'",
-        "    Invoke-ExternalCommand -FilePath \"$dir\\bin\\mysqld.exe\" -ArgumentList '--initialize-insecure'",
+        "    Invoke-ExternalCommand -FilePath \"$dir\\bin\\mysqld.exe\" -ArgumentList '--initialize-insecure' | Out-Null",
         "    warn 'Database has been initialized (username: root, password: <blank>)'",
         "}"
     ],
@@ -55,25 +56,32 @@
         "bin\\mysqlshow.exe",
         "bin\\mysqlslap.exe",
         "bin\\mysql_config_editor.exe",
+        "bin\\mysql_configurator.exe",
         "bin\\mysql_secure_installation.exe",
         "bin\\mysql_tzinfo_to_sql.exe",
         "bin\\my_print_defaults.exe",
         "bin\\perror.exe"
     ],
+    "shortcuts": [
+        [
+            "bin\\mysql_configurator.exe",
+            "MySQL Configurator"
+        ]
+    ],
     "persist": [
         "data",
         "my.ini"
     ],
-    "checkver": "<h1>MySQL Community Server ([\\d.]+)",
+    "checkver": "MySQL Community Server ([\\d.]+)",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dev.mysql.com/get/Downloads/MySQL-$majorVersion.$minorVersion/mysql-$version-winx64.zip",
+                "url": "https://dev.mysql.com/get/Downloads/MySQL-$majorVersion.$minorVersion/mysql-$version-winx64.msi",
                 "hash": {
                     "url": "https://dev.mysql.com/downloads/mysql/",
-                    "regex": "md5\">$md5"
+                    "regex": "(?s)$basename.*?$md5"
                 },
-                "extract_dir": "mysql-$version-winx64"
+                "extract_dir": "PFiles64\\MySQL\\MySQL Server $majorVersion.$minorVersion"
             }
         }
     }

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -56,7 +56,6 @@
         "bin\\mysqlshow.exe",
         "bin\\mysqlslap.exe",
         "bin\\mysql_config_editor.exe",
-        "bin\\mysql_configurator.exe",
         "bin\\mysql_secure_installation.exe",
         "bin\\mysql_tzinfo_to_sql.exe",
         "bin\\my_print_defaults.exe",

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -56,9 +56,7 @@
         "bin\\mysqlslap.exe",
         "bin\\mysql_config_editor.exe",
         "bin\\mysql_secure_installation.exe",
-        "bin\\mysql_ssl_rsa_setup.exe",
         "bin\\mysql_tzinfo_to_sql.exe",
-        "bin\\mysql_upgrade.exe",
         "bin\\my_print_defaults.exe",
         "bin\\perror.exe"
     ],

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -41,7 +41,6 @@
     "bin": [
         "bin\\ibd2sdi.exe",
         "bin\\innochecksum.exe",
-        "bin\\lz4_decompress.exe",
         "bin\\myisamchk.exe",
         "bin\\myisamlog.exe",
         "bin\\myisampack.exe",
@@ -53,7 +52,6 @@
         "bin\\mysqld.exe",
         "bin\\mysqldump.exe",
         "bin\\mysqlimport.exe",
-        "bin\\mysqlpump.exe",
         "bin\\mysqlshow.exe",
         "bin\\mysqlslap.exe",
         "bin\\mysql_config_editor.exe",
@@ -62,8 +60,7 @@
         "bin\\mysql_tzinfo_to_sql.exe",
         "bin\\mysql_upgrade.exe",
         "bin\\my_print_defaults.exe",
-        "bin\\perror.exe",
-        "bin\\zlib_decompress.exe"
+        "bin\\perror.exe"
     ],
     "persist": [
         "data",


### PR DESCRIPTION
> Removed the deprecated mysqlpump utility along with its associated lz4_decompress and zlib_decompress helper utilities.

ref: https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html

- Closes #5777
- Relates to not tested update #5775

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
