### PR TITLE
Added Microsoft Win32 Content Prep Tool

### DIFF
--- a/bucket/microsoft-win32-content-prep-tool.json
+++ b/bucket/microsoft-win32-content-prep-tool.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.8.6",
+    "description": "A tool to wrap Win32 App and then it can be uploaded to Intune.",
+    "homepage": "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool",
+    "license": "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/blob/master/Microsoft%20License%20Terms%20For%20Win32%20Content%20Prep%20Tool.pdf",
+    "url": "https://raw.githubusercontent.com/microsoft/Microsoft-Win32-Content-Prep-Tool/master/IntuneWinAppUtil.exe",
+    "hash": "25ccfcfbaf959a6a44f6ad3f3549ca3b3899f588a3cdd4dfeca5bb03d95edb3d",
+    "bin": "IntuneWinAppUtil.exe",
+    "checkver": {
+        "github": "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/microsoft/Microsoft-Win32-Content-Prep-Tool/master/IntuneWinAppUtil.exe"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Adds "Microsoft Win32 Content Prep Tool" to Scoop/Main.

The artifact is just hosted in the master branch, so DL link is static. But Microsoft publishes new versions in GitHub releases. I hope autoupdate can cope with that.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5788

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
