### PR TITLE
gdrive: Update to version 3.9.1

### DIFF
--- a/bucket/gdrive.json
+++ b/bucket/gdrive.json
@@ -1,16 +1,12 @@
 {
-    "version": "2.1.1",
-    "description": "Command line utility for interacting with Google Drive.",
-    "homepage": "https://github.com/prasmussen/gdrive",
+    "version": "3.9.1",
+    "description": "Google Drive CLI Client",
+    "homepage": "https://github.com/glotlabs/gdrive",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/prasmussen/gdrive/releases/download/2.1.1/gdrive_2.1.1_windows_amd64.tar.gz",
-            "hash": "md5:14226cb66d7f6c1b84a5be911ff193f6"
-        },
-        "32bit": {
-            "url": "https://github.com/prasmussen/gdrive/releases/download/2.1.1/gdrive_2.1.1_windows_386.tar.gz",
-            "hash": "md5:e03346f9ec72225872d0e32b41abf192"
+            "url": "https://github.com/glotlabs/gdrive/releases/download/3.9.1/gdrive_windows-x64.zip",
+            "hash": "md5:84d76a8e5546977ad174809f5720301d"
         }
     },
     "bin": "gdrive.exe",
@@ -18,16 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/prasmussen/gdrive/releases/download/$version/gdrive_$version_windows_amd64.tar.gz",
-                "hash": {
-                    "url": "$baseurl/gdrive_$version_windows_amd64_checksum.txt"
-                }
-            },
-            "32bit": {
-                "url": "https://github.com/prasmussen/gdrive/releases/download/$version/gdrive_$version_windows_386.tar.gz",
-                "hash": {
-                    "url": "$baseurl/gdrive_$version_windows_386_checksum.txt"
-                }
+                "url": "https://github.com/glotlabs/gdrive/releases/download/$version/gdrive_windows_x64.zip"
             }
         }
     }

--- a/bucket/gdrive.json
+++ b/bucket/gdrive.json
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/glotlabs/gdrive/releases/download/$version/gdrive_windows_x64.zip"
+                "url": "https://github.com/glotlabs/gdrive/releases/download/$version/gdrive_windows-x64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Updates gdrive CLI from v2 to v3

v2 repo: https://github.com/prasmussen/gdrive
v3 repo: https://github.com/glotlabs/gdrive

Technically speaking it's a major change and a new manifest should be used. However gdrive2 isn't really functional anymore and doesn't seem to be breaking changes if updated directly from v2 to v3. 

**Major change:** x64 version only, no more 32-bit version

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5764

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
