### PR TITLE
go: Fix (un)install warnings

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -23,7 +23,7 @@
             "$envgopath = \"$env:USERPROFILE\\go\"",
             "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
             "info \"Adding '$envgopath\\bin' to PATH...\"",
-            "add_first_in_path \"$envgopath\\bin\" $global"
+            "Add-Path \"$envgopath\\bin\" $global"
         ]
     },
     "uninstaller": {
@@ -31,7 +31,7 @@
             "$envgopath = \"$env:USERPROFILE\\go\"",
             "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
             "info \"Removing '$envgopath\\bin' from PATH...\"",
-            "remove_from_path \"$envgopath\\bin\" $global"
+            "Remove-Path \"$envgopath\\bin\" $global"
         ]
     },
     "bin": [


### PR DESCRIPTION
```
Updating 'go' (1.22.2 -> 1.22.3)
Downloading new version
Starting download with aria2 ...
Download: 05/07 20:49:22 [WARN] --file-allocation=falloc will use SetFileValidData() API, and aria2 uses uninitialized disk space which may contain confidential data as the download file space. If it is undesirable, --file-allocation=preallocDownload: ). File will be allocated by filling zero, which blocks whole aria2 execution. Run aria2 as an administrator orDownload: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 07f2c6|OK  |    19MiB/s|~/scoop/cache/go#1.22.3#da5209a.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of go1.22.3.windows-amd64.zip ... ok.
Uninstalling 'go' (1.22.2)
Running uninstaller script...
INFO  Removing '~\go\bin' from PATH...
WARN  "remove_from_path" will be deprecated. Please change your code/manifest to use "Remove-Path"
      -> :4:1
Removing ~\go\bin from your path.
Removing shim 'go.shim'.
Removing shim 'go.exe'.
Removing shim 'gofmt.shim'.
Removing shim 'gofmt.exe'.
Unlinking ~\scoop\apps\go\current
Installing 'go' (1.22.3) [64bit] from 'main' bucket
Loading go1.22.3.windows-amd64.zip from cache.
Extracting go1.22.3.windows-amd64.zip ... done.
Running installer script...
INFO  Adding '~\go\bin' to PATH...
WARN  "add_first_in_path" will be deprecated. Please change your code/manifest to use "Add-Path"
      -> :4:1
Adding ~\go\bin to your path.
Linking ~\scoop\apps\go\current => ~\scoop\apps\go\1.22.3
Creating shim for 'go'.
Creating shim for 'gofmt'.
'go' (1.22.3) was installed successfully!
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).