### PR TITLE
Update mingw-winlibs to version 14.1.0-11.0.1-r1

### DIFF
--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -1,17 +1,17 @@
 {
-    "version": "13.2.0-11.0.1-r2",
+    "version": "14.1.0-11.0.1-r1",
     "description": "GNU Compiler Collection (WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-17.0.4-11.0.1-msvcrt-r2/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64msvcrt-11.0.1-r2.7z",
-            "hash": "823bcacca1e91d9b469805f409550b1be9194b944dc6697d3c12f76fae6e9101",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.1.0posix-18.1.5-11.0.1-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-14.1.0-mingw-w64msvcrt-11.0.1-r1.7z",
+            "hash": "4271f4324dcd16f2abb78c5966f49068435d2512e1ab8a7d006d3f082a73a4ea",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-17.0.4-11.0.1-msvcrt-r2/winlibs-i686-posix-dwarf-gcc-13.2.0-mingw-w64msvcrt-11.0.1-r2.7z",
-            "hash": "e106dac0f9fab7d72e62d5c29abd16275bfe08fd9fc7f7af5d3c0a974aa6afb9",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.1.0posix-18.1.5-11.0.1-msvcrt-r1/winlibs-i686-posix-dwarf-gcc-14.1.0-mingw-w64msvcrt-11.0.1-r1.7z",
+            "hash": "be012a7fc95b31a61c5e419ea2aeabd2efa8d70f323dddf0bed5e5e1098dd4f4",
             "extract_dir": "mingw32"
         }
     },


### PR DESCRIPTION
updates the mingw-winlibs package to version 14.1.0-11.0.1-r1. 