### PR TITLE
dirx: Add version 0.19

### DIFF
--- a/bucket/dirx.json
+++ b/bucket/dirx.json
@@ -1,15 +1,22 @@
 {
-    "version":  "v0.17",
+    "version": "0.19",
     "description": "the dir command, extended",
-    "license":  "MIT",
+    "license": "MIT",
     "architecture": {
         "64bit": {
-            "url":  "https://github.com/chrisant996/dirx/releases/download/v0.17/dirx-v0.17.zip",
-            "hash": ""
+            "url": "https://github.com/chrisant996/dirx/releases/download/v0.19/dirx-v0.19.zip",
+            "hash": "46bcf52376a737c163ddf5c381949248bad897cac8d032035ad6d860403994f3"
         }
     },
-    "homepage":  "https://github.com/chrisant996/dirx",
-    "hash":  "",
-    "bin":  "dirx.exe"
+    "homepage": "https://github.com/chrisant996/dirx",
+    "hash": "",
+    "bin": "dirx.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/chrisant996/dirx/releases/download/v$version/dirx-v$version.zip"
+            }
+        }
+    }
 }
-

--- a/bucket/dirx.json
+++ b/bucket/dirx.json
@@ -1,22 +1,21 @@
 {
-    "version": "0.19",
-    "description": "the dir command, extended",
-    "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/chrisant996/dirx/releases/download/v0.19/dirx-v0.19.zip",
-            "hash": "46bcf52376a737c163ddf5c381949248bad897cac8d032035ad6d860403994f3"
-        }
-    },
-    "homepage": "https://github.com/chrisant996/dirx",
-    "hash": "",
-    "bin": "dirx.exe",
-    "checkver": "github",
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/chrisant996/dirx/releases/download/v$version/dirx-v$version.zip"
-            }
-        }
-    }
+	"version": "0.19",
+	"description": "the dir command, extended",
+	"homepage": "https://github.com/chrisant996/dirx",
+	"license": "MIT",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/chrisant996/dirx/releases/download/v0.19/dirx-v0.19.zip",
+			"hash": "46bcf52376a737c163ddf5c381949248bad897cac8d032035ad6d860403994f3"
+		}
+	},
+	"bin": "dirx.exe",
+	"checkver": "github",
+	"autoupdate": {
+		"architecture": {
+			"64bit": {
+				"url": "https://github.com/chrisant996/dirx/releases/download/v$version/dirx-v$version.zip"
+			}
+		}
+	}
 }

--- a/bucket/dirx.json
+++ b/bucket/dirx.json
@@ -1,21 +1,21 @@
 {
-	"version": "0.19",
-	"description": "the dir command, extended",
-	"homepage": "https://github.com/chrisant996/dirx",
-	"license": "MIT",
-	"architecture": {
-		"64bit": {
-			"url": "https://github.com/chrisant996/dirx/releases/download/v0.19/dirx-v0.19.zip",
-			"hash": "46bcf52376a737c163ddf5c381949248bad897cac8d032035ad6d860403994f3"
-		}
-	},
-	"bin": "dirx.exe",
-	"checkver": "github",
-	"autoupdate": {
-		"architecture": {
-			"64bit": {
-				"url": "https://github.com/chrisant996/dirx/releases/download/v$version/dirx-v$version.zip"
-			}
-		}
-	}
+    "version": "0.19",
+    "description": "the dir command, extended",
+    "homepage": "https://github.com/chrisant996/dirx",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/chrisant996/dirx/releases/download/v0.19/dirx-v0.19.zip",
+            "hash": "46bcf52376a737c163ddf5c381949248bad897cac8d032035ad6d860403994f3"
+        }
+    },
+    "bin": "dirx.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/chrisant996/dirx/releases/download/v$version/dirx-v$version.zip"
+            }
+        }
+    }
 }

--- a/bucket/dirx.json
+++ b/bucket/dirx.json
@@ -1,0 +1,15 @@
+{
+    "version":  "v0.17",
+    "description": "the dir command, extended",
+    "license":  "MIT",
+    "architecture": {
+        "64bit": {
+            "url":  "https://github.com/chrisant996/dirx/releases/download/v0.17/dirx-v0.17.zip",
+            "hash": ""
+        }
+    },
+    "homepage":  "https://github.com/chrisant996/dirx",
+    "hash":  "",
+    "bin":  "dirx.exe"
+}
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Add `dirx` v0.17

https://github.com/chrisant996/dirx

> DirX is designed so that most command line options from the CMD dir command work the same, to make DirX mostly a drop-in replacement for dir.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


Closes #5822

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
