### PR TITLE
lua: Add version 5.4.6-2

### DIFF
--- a/bucket/lua.json
+++ b/bucket/lua.json
@@ -1,28 +1,16 @@
 {
-    "version": "5.4.2",
+    "version": "5.4.6-2",
     "description": "A powerful, efficient, lightweight, embeddable scripting language",
     "homepage": "https://www.lua.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://downloads.sourceforge.net/project/luabinaries/5.4.2/Tools%20Executables/lua-5.4.2_Win64_bin.zip",
-                "https://downloads.sourceforge.net/project/luabinaries/5.4.2/Windows%20Libraries/Dynamic/lua-5.4.2_Win64_dllw6_lib.zip"
-            ],
-            "hash": [
-                "sha1:31f5380006244e045c9aa2119feed8d353be72cb",
-                "sha1:e313a05e498b77b5e259737fe4ec851fe2b9d23e"
-            ]
+            "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-lua-5.4.6-2-any.pkg.tar.zst",
+            "hash": "adffa6a29188dd4715c493e47a575bcd28e898c6d2c1300e48d3a7e14d12f101"
         },
         "32bit": {
-            "url": [
-                "https://downloads.sourceforge.net/project/luabinaries/5.4.2/Tools%20Executables/lua-5.4.2_Win32_bin.zip",
-                "https://downloads.sourceforge.net/project/luabinaries/5.4.2/Windows%20Libraries/Dynamic/lua-5.4.2_Win32_dllw6_lib.zip"
-            ],
-            "hash": [
-                "sha1:d5cb6359710413a71ba517617654f1c15229d61f",
-                "sha1:c13d772ebe44157d55279b04b93b67b5f8805a4f"
-            ]
+            "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-5.4.6-2-any.pkg.tar.zst",
+            "hash": "29423bbe672606230e03ef9b9a73574123491f5fe535fcf1c4f18b7263a8e453"
         }
     },
     "bin": [
@@ -42,22 +30,16 @@
         "LUA_CPATH": "$dir"
     },
     "checkver": {
-        "url": "http://luabinaries.sourceforge.net/download.html",
-        "regex": "LuaBinaries ([\\d.]+)"
+        "url": "https://packages.msys2.org/api/search?query=mingw-w64-x86_64-lua&qtype=binpkg",
+        "jsonpath": "$.results.exact.version"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": [
-                    "https://downloads.sourceforge.net/project/luabinaries/$version/Tools%20Executables/lua-$version_Win64_bin.zip",
-                    "https://downloads.sourceforge.net/project/luabinaries/$version/Windows%20Libraries/Dynamic/lua-$version_Win64_dllw6_lib.zip"
-                ]
+                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-lua-$version-any.pkg.tar.zst"
             },
             "32bit": {
-                "url": [
-                    "https://downloads.sourceforge.net/project/luabinaries/$version/Tools%20Executables/lua-$version_Win32_bin.zip",
-                    "https://downloads.sourceforge.net/project/luabinaries/$version/Windows%20Libraries/Dynamic/lua-$version_Win32_dllw6_lib.zip"
-                ]
+                "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-$version-any.pkg.tar.zst"
             }
         },
         "bin": [

--- a/bucket/lua.json
+++ b/bucket/lua.json
@@ -9,8 +9,8 @@
             "hash": "452b718d9c5bdccc910f58e3cb8037244fca9241ba8ff86b4f07e21531980ce1"
         },
         "32bit": {
-            "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-5.4.6-2-any.pkg.tar.zst",
-            "hash": "29423bbe672606230e03ef9b9a73574123491f5fe535fcf1c4f18b7263a8e453"
+            "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-5.4.6-2-any.pkg.tar.zst",
+            "hash": "4c4efe75295feb611f885e5b9096a88c943543fdf27ca3b9ae6a73c103d62043"
         },
         "arm64": {
             "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-5.4.6-2-any.pkg.tar.zst",
@@ -43,7 +43,7 @@
                 "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-$version-any.pkg.tar.zst"
             },
             "32bit": {
-                "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-$version-any.pkg.tar.zst"
+                "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-$version-any.pkg.tar.zst"
             },
             "arm64": {
                 "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-$version-any.pkg.tar.zst"

--- a/bucket/lua.json
+++ b/bucket/lua.json
@@ -5,12 +5,16 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-lua-5.4.6-2-any.pkg.tar.zst",
-            "hash": "adffa6a29188dd4715c493e47a575bcd28e898c6d2c1300e48d3a7e14d12f101"
+            "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-5.4.6-2-any.pkg.tar.zst",
+            "hash": "452b718d9c5bdccc910f58e3cb8037244fca9241ba8ff86b4f07e21531980ce1"
         },
         "32bit": {
             "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-5.4.6-2-any.pkg.tar.zst",
             "hash": "29423bbe672606230e03ef9b9a73574123491f5fe535fcf1c4f18b7263a8e453"
+        },
+        "arm64": {
+            "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-5.4.6-2-any.pkg.tar.zst",
+            "hash": "bf02707e0e3331e1dc8cfb902929eaf22ded35626df42931c2f350b1b695bce1"
         }
     },
     "bin": [
@@ -36,10 +40,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-lua-$version-any.pkg.tar.zst"
+                "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-$version-any.pkg.tar.zst"
             },
             "32bit": {
                 "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-$version-any.pkg.tar.zst"
+            },
+            "arm64": {
+                "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-$version-any.pkg.tar.zst"
             }
         },
         "bin": [

--- a/bucket/lua.json
+++ b/bucket/lua.json
@@ -6,15 +6,18 @@
     "architecture": {
         "64bit": {
             "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-5.4.6-2-any.pkg.tar.zst",
-            "hash": "452b718d9c5bdccc910f58e3cb8037244fca9241ba8ff86b4f07e21531980ce1"
+            "hash": "452b718d9c5bdccc910f58e3cb8037244fca9241ba8ff86b4f07e21531980ce1",
+            "extract_dir": "clang64"
         },
         "32bit": {
             "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-5.4.6-2-any.pkg.tar.zst",
-            "hash": "4c4efe75295feb611f885e5b9096a88c943543fdf27ca3b9ae6a73c103d62043"
+            "hash": "4c4efe75295feb611f885e5b9096a88c943543fdf27ca3b9ae6a73c103d62043",
+            "extract_dir": "clang32"
         },
         "arm64": {
             "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-5.4.6-2-any.pkg.tar.zst",
-            "hash": "bf02707e0e3331e1dc8cfb902929eaf22ded35626df42931c2f350b1b695bce1"
+            "hash": "bf02707e0e3331e1dc8cfb902929eaf22ded35626df42931c2f350b1b695bce1",
+            "extract_dir": "clangarm64"
         }
     },
     "bin": [
@@ -40,13 +43,16 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-$version-any.pkg.tar.zst"
+                "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-$version-any.pkg.tar.zst",
+                "extract_dir": "clang64"
             },
             "32bit": {
-                "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-$version-any.pkg.tar.zst"
+                "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-$version-any.pkg.tar.zst",
+                "extract_dir": "clang32"
             },
             "arm64": {
-                "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-$version-any.pkg.tar.zst"
+                "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-$version-any.pkg.tar.zst",
+                "extract_dir": "clangarm64"
             }
         },
         "bin": [


### PR DESCRIPTION
The original Sourceforge project is no longer building the binaries. I have updated the manifest to pull from msys2 and to autoupdate.

This moves Lua from version 5.4.2 to 5.4.6-2

relates to #3511

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
