### PR TITLE
neovim: Remove nvim-qt

### DIFF
--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -17,14 +17,7 @@
     },
     "extract_dir": "nvim-win64",
     "bin": [
-        "bin\\nvim.exe",
-        "bin\\nvim-qt.exe"
-    ],
-    "shortcuts": [
-        [
-            "bin\\nvim-qt.exe",
-            "Neovim"
-        ]
+        "bin\\nvim.exe"
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/16408992/releases/latest",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Remove nvim-qt.exe from nvim-win64.zip from json as it has been removed.
https://github.com/neovim/neovim/pull/23668

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5835 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
