### PR TITLE
tesseract: Fix extraction

### DIFF
--- a/bucket/tesseract.json
+++ b/bucket/tesseract.json
@@ -12,7 +12,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://digi.bib.uni-mannheim.de/tesseract/tesseract-ocr-w64-setup-5.3.4.20240503.exe#/dl.7z_",
+            "url": "https://digi.bib.uni-mannheim.de/tesseract/tesseract-ocr-w64-setup-5.3.4.20240503.exe#/dl.7z",
             "hash": "ee6ce936333cff7bc19ff637f7fd9ea5b5ff2fb14d25105509c4f8618acea26e"
         }
     },
@@ -53,7 +53,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://digi.bib.uni-mannheim.de/tesseract/tesseract-ocr-w64-setup-$version.exe#/dl.7z_"
+                "url": "https://digi.bib.uni-mannheim.de/tesseract/tesseract-ocr-w64-setup-$version.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
```
❯ ls (scoop prefix tesseract)

        Directory: ~\scoop\apps\tesseract\current


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a---        2024-05-03  12:06 PM       50790128   dl.7z_
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).