### PR TITLE
chore: Replace deprecated `env` function with `(Set|Get)-EnvVar`

### DIFF
--- a/bucket/gradle-bin.json
+++ b/bucket/gradle-bin.json
@@ -10,10 +10,10 @@
     "hash": "544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d",
     "extract_dir": "gradle-8.7",
     "post_install": [
-        "$current_env = env GRADLE_USER_HOME $global",
+        "$current_env = Get-EnvVar -Name GRADLE_USER_HOME -Global:$global",
         "If ($null -eq $current_env) {",
         "    $path = \"$dir\\.gradle\"",
-        "    env GRADLE_USER_HOME $global $path",
+        "    Set-EnvVar -Name GRADLE_USER_HOME -Value $path -Global:$global",
         "    $Env:GRADLE_USER_HOME = $path",
         "    Write-Host \"Environment variable 'GRADLE_USER_HOME' set to '$path'\"",
         "}"

--- a/bucket/gradle.json
+++ b/bucket/gradle.json
@@ -10,10 +10,10 @@
     "hash": "194717442575a6f96e1c1befa2c30e9a4fc90f701d7aee33eb879b79e7ff05c0",
     "extract_dir": "gradle-8.7",
     "post_install": [
-        "$current_env = env GRADLE_USER_HOME $global",
+        "$current_env = Get-EnvVar -Name GRADLE_USER_HOME -Global:$global",
         "If ($null -eq $current_env) {",
         "    $path = \"$dir\\.gradle\"",
-        "    env GRADLE_USER_HOME $global $path",
+        "    Set-EnvVar -Name GRADLE_USER_HOME -Value $path -Global:$global",
         "    $Env:GRADLE_USER_HOME = $path",
         "    Write-Host \"Environment variable 'GRADLE_USER_HOME' set to '$path'\"",
         "}"

--- a/bucket/python.json
+++ b/bucket/python.json
@@ -55,8 +55,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -67,8 +67,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/tesseract.json
+++ b/bucket/tesseract.json
@@ -20,7 +20,7 @@
     "post_install": [
         "$langdir = versiondir tesseract-languages current $global",
         "if (Test-Path $langdir) {",
-        "   env \"TESSDATA_PREFIX\" $global $langdir",
+        "   Set-EnvVar -Name TESSDATA_PREFIX -Value $langdir -Global:$global",
         "}"
     ],
     "env_set": {


### PR DESCRIPTION
```
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).