### PR TITLE
Update gnuplot to 6.0.0

### DIFF
--- a/bucket/gnuplot.json
+++ b/bucket/gnuplot.json
@@ -5,7 +5,7 @@
     "license": "gnuplot",
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/gnuplot/files/gnuplot/6.0.0/gp600-win64-mingw.7z",
+            "url": "https://downloads.sourceforge.net/project/gnuplot/gnuplot/6.0.0/gp600-win64-mingw.7z",
             "hash": "sha1:3977f8b0b48bd11232f6562781054e100e6b1449"
         }
     },
@@ -17,7 +17,7 @@
             "GNUPlot"
         ]
     ],
-    "checkver": "(?sm)Version [\\d.]+ \\(current\\).*?Release ([\\d.]+)",
+    "checkver": "(?s)\\(current stable\\).*?Release ([\\d.]+)",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/gnuplot.json
+++ b/bucket/gnuplot.json
@@ -1,12 +1,12 @@
 {
-    "version": "5.4.8",
+    "version": "6.0.0",
     "description": "Interactive function plotting utility",
     "homepage": "http://www.gnuplot.info",
     "license": "gnuplot",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.4.8/gp548-win64-mingw.7z",
-            "hash": "sha1:bcfec8059feb31cee3bbdaed19ca16e572f820b6"
+            "url": "https://sourceforge.net/projects/gnuplot/files/gnuplot/6.0.0/gp600-win64-mingw.7z",
+            "hash": "sha1:3977f8b0b48bd11232f6562781054e100e6b1449"
         }
     },
     "extract_dir": "gnuplot",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This pull request can fix [[Bug]: The gnuplot in the main bucket has not been updated to 6.0.0.](https://github.com/ScoopInstaller/Main/issues/5403)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #5403

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
