### PR TITLE
rustup@1.27.1: Add arm64 binary

### DIFF
--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -20,6 +20,10 @@
         "32bit": {
             "url": "https://static.rust-lang.org/rustup/archive/1.27.1/i686-pc-windows-msvc/rustup-init.exe",
             "hash": "011185bd2bfce79f5389c19247b6e45242d17c697fe135ec6cdd23948445803a"
+        },
+        "arm64": {
+            "url": "https://static.rust-lang.org/rustup/archive/1.27.1/aarch64-pc-windows-msvc/rustup-init.exe",
+            "hash": "5f4697ee3ea5d4592bffdbe9dc32d6a8865762821b14fdd1cf870e585083a2f0"
         }
     },
     "installer": {
@@ -49,6 +53,9 @@
             },
             "32bit": {
                 "url": "https://static.rust-lang.org/rustup/archive/$version/i686-pc-windows-msvc/rustup-init.exe"
+            },
+            "arm64": {
+                "url": "https://static.rust-lang.org/rustup/archive/$version/aarch64-pc-windows-msvc/rustup-init.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
rustup@1.27.1: Add arm64 binary

According to rust-lang/rustup#3406, there is an available arm64 build for rustup.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
