### PR TITLE
vapoursynth: Update to version 69

### DIFF
--- a/bucket/vapoursynth.json
+++ b/bucket/vapoursynth.json
@@ -40,10 +40,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R$version/VapourSynth64-Portable-R$version.7z"
+                "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R$version/VapourSynth64-Portable-R$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R$version/VapourSynth64-Portable-R$version.7z"
+                "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R$version/VapourSynth64-Portable-R$version.zip"
             }
         }
     }

--- a/bucket/vapoursynth.json
+++ b/bucket/vapoursynth.json
@@ -1,5 +1,5 @@
 {
-    "version": "68",
+    "version": "69",
     "description": "A video processing framework with simplicity in mind",
     "homepage": "https://www.vapoursynth.com",
     "suggest": {
@@ -8,12 +8,12 @@
     "license": "LGPL-2.1-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip",
-            "hash": "911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b"
+            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R69/VapourSynth64-Portable-R69.zip",
+            "hash": "f1c3f5e1e6a9f9d9c4c82462a4e6e04cf40aded1346bcef605b39e01c251571b"
         },
         "32bit": {
-            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip",
-            "hash": "911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b"
+            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R69/VapourSynth64-Portable-R69.zip",
+            "hash": "f1c3f5e1e6a9f9d9c4c82462a4e6e04cf40aded1346bcef605b39e01c251571b"
         }
     },
     "pre_install": [

--- a/bucket/vapoursynth.json
+++ b/bucket/vapoursynth.json
@@ -1,5 +1,5 @@
 {
-    "version": "65",
+    "version": "68",
     "description": "A video processing framework with simplicity in mind",
     "homepage": "https://www.vapoursynth.com",
     "suggest": {
@@ -8,12 +8,12 @@
     "license": "LGPL-2.1-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R65/VapourSynth64-Portable-R65.7z",
-            "hash": "e3fca973dc56283289a2f4f73fe0a6908ff270b9c46b65af3f8674be867ca303"
+            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip",
+            "hash": "911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b"
         },
         "32bit": {
-            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R65/VapourSynth64-Portable-R65.7z",
-            "hash": "e3fca973dc56283289a2f4f73fe0a6908ff270b9c46b65af3f8674be867ca303"
+            "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip",
+            "hash": "911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Changes expected file extensions from .7z (used until VapourSynth R65) to .zip (R66-RC1 and later)

~~This does not update the package itself. I'll let the bot do that.~~

Closes #5863

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

---

```
 ScoopInstaller.Main  .\bin\checkver.ps1 vapoursynth
vapoursynth: 68 (scoop version is 65) autoupdate available
```

```
 ScoopInstaller.Main  .\bin\checkver.ps1 vapoursynth -u
vapoursynth: 68 (scoop version is 65) autoupdate available
Autoupdating vapoursynth
Downloading VapourSynth64-Portable-R68.zip to compute hashes!
VapourSynth64-Portable-R68.zip (8.5 MB) [=====================================================================================================] 100%
Computed hash: 911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b
Downloading VapourSynth64-Portable-R68.zip to compute hashes!
Loading VapourSynth64-Portable-R68.zip from cache
Computed hash: 911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b
Writing updated vapoursynth manifest
```

> vapoursynth.json
```diff
{
+    "version": "68",
    "description": "A video processing framework with simplicity in mind",
    "homepage": "https://www.vapoursynth.com",
    "suggest": {
        "vcredist": "extras/vcredist2022"
    },
    "license": "LGPL-2.1-or-later",
    "architecture": {
        "64bit": {
+           "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip",
+           "hash": "911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b"
        },
        "32bit": {
+           "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R68/VapourSynth64-Portable-R68.zip",
+           "hash": "911d22e6c52886b043194bc17f232f4e054f9e76259c72b66dfc679e7409304b"
        }
    },
    "pre_install": [
        "$arch = $architecture.SubString(0,2)",
        "if(Test-Path \"$persist_dir\\vapoursynth$arch\") {Copy-Item \"$persist_dir\\*\" \"$dir\\\" -Force -Recurse}"
    ],
    "uninstaller": {
        "script": [
            "$arch = $architecture.SubString(0,2)",
            "ensure \"$persist_dir\" | Out-Null",
            "Copy-Item \"$dir\\vapoursynth$arch\" \"$persist_dir\\\" -Force -Recurse"
        ]
    },
    "bin": [
        "AVFS.exe",
        "VSPipe.exe",
        "pfm-192-vapoursynth-win.exe",
        "vsrepo.py"
    ],
    "checkver": {
        "github": "https://github.com/vapoursynth/vapoursynth",
        "regex": "tag/R(\\d+)"
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R$version/VapourSynth64-Portable-R$version.zip"
            },
            "32bit": {
                "url": "https://github.com/vapoursynth/vapoursynth/releases/download/R$version/VapourSynth64-Portable-R$version.zip"
            }
        }
    }
}

```