### PR TITLE
dafny: Remove `DafnyLanguageServer` bin

### DIFF
--- a/bucket/dafny.json
+++ b/bucket/dafny.json
@@ -12,7 +12,6 @@
     },
     "bin": [
         "Dafny.exe",
-        "DafnyLanguageServer.exe",
         "DafnyServer.exe"
     ],
     "checkver": {


### PR DESCRIPTION
dafny has removed DafnyLanguageServer.exe since 4.4.0, currently installing dafny will fail with the message:
```
Installing 'dafny' (4.6.0) [64bit] from 'main' bucket
Loading dafny-4.6.0-x64-windows-2019.zip from cache.
Checking hash of dafny-4.6.0-x64-windows-2019.zip ... ok.
Extracting dafny-4.6.0-x64-windows-2019.zip ... done.
Linking ~\scoop\apps\dafny\current => ~\scoop\apps\dafny\4.6.0
Creating shim for 'Dafny'.
Creating shim for 'DafnyLanguageServer'.
Get-Command: C:\Users\(user)\scoop\apps\scoop\current\lib\install.ps1:783
Line |
 783 |              $bin = (Get-Command $target).Source
     |                      ~~~~~~~~~~~~~~~~~~~
     | The term 'DafnyLanguageServer.exe' is not recognized as a name of a cmdlet, function, script file, or executable
     | program. Check the spelling of the name, or if a path was included, verify that the path is correct and try
     | again.
Can't shim 'DafnyLanguageServer.exe': File doesn't exist.
```

Removing `DafnyLanguageServer.exe` fixes the problem

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
