### PR TITLE
go-size-analyzer: Add version 1.1.0

### DIFF
--- a/bucket/go-size-analyzer.json
+++ b/bucket/go-size-analyzer.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.1.0",
+    "description": "A tool for analyzing the dependencies in compiled Golang binaries.",
+    "homepage": "https://github.com/Zxilly/go-size-analyzer",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Zxilly/go-size-analyzer/releases/download/v1.1.0/go-size-analyzer_windows_amd64.zip",
+            "hash": "a09a01506a3042cffbcac5de2d681a8bba0dc9afcce845f036cd4636eb1743d4"
+        },
+        "arm64": {
+            "url": "https://github.com/Zxilly/go-size-analyzer/releases/download/v1.1.0/go-size-analyzer_windows_arm64.zip",
+            "hash": "fef3fb439fd5acf875e80ab07ec2b4a56c3e99225b18eafe4b17a5214a4eac86"
+        }
+    },
+    "bin": "gsa.exe",
+    "checkver": {
+        "github": "https://github.com/Zxilly/go-size-analyzer/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Zxilly/go-size-analyzer/releases/download/v$version/go-size-analyzer_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Zxilly/go-size-analyzer/releases/download/v$version/go-size-analyzer_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}

--- a/bucket/go-size-analyzer.json
+++ b/bucket/go-size-analyzer.json
@@ -14,9 +14,7 @@
         }
     },
     "bin": "gsa.exe",
-    "checkver": {
-        "github": "https://github.com/Zxilly/go-size-analyzer/"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
go-size-analyzer is a tool for analyzing the dependencies in compiled Golang binaries, providing insight into their impact on the final build.

See https://github.com/Zxilly/go-size-analyzer for details.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
