### PR TITLE
azure-cli: Use zip archive

### DIFF
--- a/bucket/azure-cli.json
+++ b/bucket/azure-cli.json
@@ -9,20 +9,15 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://azcliprod.blob.core.windows.net/msi/azure-cli-2.61.0-x64.msi",
-            "hash": "e6906997110d6acfb51a934b1d18b21fb2f314dab6b653644fd7d769e72e668c"
-        },
-        "32bit": {
-            "url": "https://azcliprod.blob.core.windows.net/msi/azure-cli-2.61.0.msi",
-            "hash": "f765b484f8279fdd909d884539ada5baf2aaf897e30c2ef3de33cdae42180956"
+            "url": "https://azcliprod.blob.core.windows.net/zip/azure-cli-2.61.0-x64.zip",
+            "hash": "8b5f12064aaf40eeccd17c5043df9cb5676a3845ea1bce4adde33261f4af05cd"
         }
     },
-    "extract_dir": "Microsoft SDKs\\Azure\\CLI2",
     "env_set": {
-        "AZURE_CLI_PATH": "$dir\\wbin",
-        "AzureCLIPath": "$dir\\wbin"
+        "AZURE_CLI_PATH": "$dir\\bin",
+        "AzureCLIPath": "$dir\\bin"
     },
-    "bin": "wbin\\az.cmd",
+    "bin": "bin\\az.cmd",
     "checkver": {
         "github": "https://github.com/Azure/azure-cli",
         "regex": "/releases/tag/azure-cli-([\\d.]+)"
@@ -30,10 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://azcliprod.blob.core.windows.net/msi/azure-cli-$version-x64.msi"
-            },
-            "32bit": {
-                "url": "https://azcliprod.blob.core.windows.net/msi/azure-cli-$version.msi"
+                "url": "https://azcliprod.blob.core.windows.net/zip/azure-cli-$version-x64.zip"
             }
         }
     }


### PR DESCRIPTION
Switch Azure CLI to use ZIP instead of MSI.

Seems ZIP has been available since 2024-01-30, ref <https://github.com/Azure/azure-cli/pull/27911>.

Benefits:

* Should be faster to install and should create shorter paths which might help with #5300.
* Less complex to extract a ZIP vs. MSI.

~~Cons:~~ Edit: No cons as I see it.

* Only x64 is available as ZIP, not x86.
  * Related feature request: <https://github.com/Azure/azure-cli/issues/29104>
  * Edit: Not a problem, Azure CLI authors recommends against using x86.
* Download is much slower because Azure CLI ZIP is not available through a CDN, but an Azure Storage Account in US West only.
  * Related feature request: <https://github.com/Azure/azure-cli/issues/28856>
  * Edit: Not a con because ScoopInstaller/Main points to the same Azure Storage Account for MSI.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Most relevant issue: #5300. Other open issues:

* #5860
* #5832
* #5744
* #5637
* #5623

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
