### PR TITLE
mutagen-compose: Add v0.17.6

### DIFF
--- a/bucket/mutagen-compose.json
+++ b/bucket/mutagen-compose.json
@@ -14,9 +14,7 @@
         }
     },
     "bin": "mutagen-compose.exe",
-    "checkver": {
-        "github": "https://github.com/mutagen-io/mutagen-compose"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/mutagen-compose.json
+++ b/bucket/mutagen-compose.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.17.6",
+    "description": "Compose with Mutagen integration",
+    "homepage": "https://mutagen.io/documentation/orchestration/compose",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v0.17.6/mutagen-compose_windows_amd64_v0.17.6.zip",
+            "hash": "56544f93fa1a6e956bf41312a3a63784fa98ec9914e75fca25059754c4bf19ba"
+        },
+        "32bit": {
+            "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v0.17.6/mutagen-compose_windows_386_v0.17.6.zip",
+            "hash": "bd949e3abaed7249d997df45af009b834be24e7a971b0bc5a6fd6c79e560273f"
+        }
+    },
+    "bin": "mutagen-compose.exe",
+    "checkver": {
+        "github": "https://github.com/mutagen-io/mutagen-compose"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mutagen-io/mutagen/releases/download/v$version/mutagen-compose_windows_amd64_v$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/mutagen-io/mutagen/releases/download/v$version/mutagen-compose_windows_386_v$version.zip"
+            }
+        }
+    }
+}

--- a/bucket/mutagen-compose.json
+++ b/bucket/mutagen-compose.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v0.17.6/mutagen-compose_windows_386_v0.17.6.zip",
             "hash": "bd949e3abaed7249d997df45af009b834be24e7a971b0bc5a6fd6c79e560273f"
+        },
+        "arm64": {
+            "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v0.17.6/mutagen-compose_windows_arm64_v0.17.6.zip",
+            "hash": "e3861bd84bfa55223545abb82fdc91b1fe9b932b7c50fe2802c62da477ac13a1"
         }
     },
     "bin": "mutagen-compose.exe",
@@ -24,7 +28,13 @@
             },
             "32bit": {
                 "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v$version/mutagen-compose_windows_386_v$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v$version/mutagen-compose_windows_arm64_v$version.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }

--- a/bucket/mutagen-compose.json
+++ b/bucket/mutagen-compose.json
@@ -14,14 +14,16 @@
         }
     },
     "bin": "mutagen-compose.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/mutagen-io/mutagen-compose"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mutagen-io/mutagen/releases/download/v$version/mutagen-compose_windows_amd64_v$version.zip"
+                "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v$version/mutagen-compose_windows_amd64_v$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/mutagen-io/mutagen/releases/download/v$version/mutagen-compose_windows_386_v$version.zip"
+                "url": "https://github.com/mutagen-io/mutagen-compose/releases/download/v$version/mutagen-compose_windows_386_v$version.zip"
             }
         }
     }


### PR DESCRIPTION
This adds the mutagen-compose CLI. Mutagen CLI already exists, so I used the same app manifest config.

https://github.com/mutagen-io/mutagen-compose
https://mutagen.io/documentation/orchestration/compose

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
