### PR TITLE
mutagen: Add arm64 build and autoupdate.hash

### DIFF
--- a/bucket/mutagen.json
+++ b/bucket/mutagen.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/mutagen-io/mutagen/releases/download/v0.17.6/mutagen_windows_386_v0.17.6.zip",
             "hash": "4cb8d6afa0de02fb474d39c66b82c7aa79cd9445acd6643ddd76fb2d1a60aef6"
+        },
+        "arm64": {
+            "url": "https://github.com/mutagen-io/mutagen/releases/download/v0.17.6/mutagen_windows_arm64_v0.17.6.zip",
+            "hash": "73fd4204654b260680efddb9a5ae36f86e3ef697a0668416e43817b2e74f3c19"
         }
     },
     "bin": "mutagen.exe",
@@ -24,7 +28,13 @@
             },
             "32bit": {
                 "url": "https://github.com/mutagen-io/mutagen/releases/download/v$version/mutagen_windows_386_v$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/mutagen-io/mutagen/releases/download/v$version/mutagen_windows_arm64_v$version.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
