### PR TITLE
shadowsocks-rust: Add missing bins

### DIFF
--- a/bucket/shadowsocks-rust.json
+++ b/bucket/shadowsocks-rust.json
@@ -13,6 +13,8 @@
         "sslocal.exe",
         "ssmanager.exe",
         "ssserver.exe",
+        "ssservice.exe",
+        "sswinservice.exe",
         "ssurl.exe"
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Release includes 6 binaries but only 4 of them are linked, this PR adds missing `ssservice.exe` and `sswinservice.exe` to `bin`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
