### PR TITLE
doggo: Update to version 1.0.4

### DIFF
--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_x86_64.zip",
             "hash": "45ee5a6971f4523ec72068ad584d0d46271b26431d361d422c2f156640cba5a3"
+        },
+        "32bit": {
+            "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_i386.zip",
+            "hash": "bf7ea30195cdd1e83300311bd73a255dc70bf98a4005305ac6287355a6fb9a09"
         }
     },
     "bin": "doggo.exe",
@@ -17,6 +21,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_i386.zip"
             }
         },
         "hash": {

--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -1,16 +1,12 @@
 {
-    "version": "0.5.7",
+    "version": "1.0.4",
     "description": "Command-line DNS Client for Humans",
     "homepage": "https://doggo.mrkaran.dev/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mr-karan/doggo/releases/download/v0.5.7/doggo_0.5.7_windows_amd64.tar.gz",
-            "hash": "a4207a13b1b1d7c8640ead9fefaa98d2b6c6c273711c779e2c9c021189e20bbe"
-        },
-        "arm64": {
-            "url": "https://github.com/mr-karan/doggo/releases/download/v0.5.7/doggo_0.5.7_windows_arm64.tar.gz",
-            "hash": "8fb0d985c83b6c91950349947c89ffaebc9e7f70836722ffd3551883bb54075f"
+            "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_x86_64.zip",
+            "hash": "45ee5a6971f4523ec72068ad584d0d46271b26431d361d422c2f156640cba5a3"
         }
     },
     "bin": "doggo.exe",
@@ -20,10 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_windows_amd64.tar.gz"
-            },
-            "arm64": {
-                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_windows_arm64.tar.gz"
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_x86_64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
They changed the URLs and dropped the arm64 build.



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
