### PR TITLE
doggo: Fix bin path

### DIFF
--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -6,14 +6,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_x86_64.zip",
-            "hash": "45ee5a6971f4523ec72068ad584d0d46271b26431d361d422c2f156640cba5a3"
+            "hash": "45ee5a6971f4523ec72068ad584d0d46271b26431d361d422c2f156640cba5a3",
+            "bin": "doggo_1.0.4_Windows_x86_64\\doggo.exe"
         },
         "32bit": {
             "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_i386.zip",
-            "hash": "bf7ea30195cdd1e83300311bd73a255dc70bf98a4005305ac6287355a6fb9a09"
+            "hash": "bf7ea30195cdd1e83300311bd73a255dc70bf98a4005305ac6287355a6fb9a09",
+            "bin": "doggo_1.0.4_Windows_i386\\doggo.exe"
         }
     },
-    "bin": "doggo.exe",
     "checkver": {
         "github": "https://github.com/mr-karan/doggo"
     },

--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -7,24 +7,27 @@
         "64bit": {
             "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_x86_64.zip",
             "hash": "45ee5a6971f4523ec72068ad584d0d46271b26431d361d422c2f156640cba5a3",
-            "bin": "doggo_1.0.4_Windows_x86_64\\doggo.exe"
+            "extract_dir": "doggo_1.0.4_Windows_x86_64"
         },
         "32bit": {
             "url": "https://github.com/mr-karan/doggo/releases/download/v1.0.4/doggo_1.0.4_Windows_i386.zip",
             "hash": "bf7ea30195cdd1e83300311bd73a255dc70bf98a4005305ac6287355a6fb9a09",
-            "bin": "doggo_1.0.4_Windows_i386\\doggo.exe"
+            "extract_dir": "doggo_1.0.4_Windows_i386"
         }
     },
+    "bin": "doggo.exe",
     "checkver": {
         "github": "https://github.com/mr-karan/doggo"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_x86_64.zip"
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_x86_64.zip",
+                "extract_dir": "doggo_$version_Windows_x86_64"
             },
             "32bit": {
-                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_i386.zip"
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_i386.zip",
+                "extract_dir": "doggo_$version_Windows_i386"
             }
         },
         "hash": {


### PR DESCRIPTION
the bin path depends on the zip file name


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
