### PR TITLE
ruff: Update to version 0.5.4

### DIFF
--- a/bucket/ruff.json
+++ b/bucket/ruff.json
@@ -1,20 +1,20 @@
 {
-    "version": "0.5.1",
+    "version": "0.5.4",
     "description": "An extremely fast Python linter and code formatter, written in Rust.",
     "homepage": "https://github.com/astral-sh/ruff",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/astral-sh/ruff/releases/download/0.5.1/ruff-x86_64-pc-windows-msvc.zip",
-            "hash": "85a17d333edf667450fa873f3fa89c430b54b77ed0823e83ddc9dfd272a52187"
+            "url": "https://github.com/astral-sh/ruff/releases/download/0.5.4/ruff-x86_64-pc-windows-msvc.zip",
+            "hash": "c5cd39373397efc0de80790fbd4695e5a47b5f204b6e9278dddbc84413730d42"
         },
         "32bit": {
-            "url": "https://github.com/astral-sh/ruff/releases/download/0.5.1/ruff-i686-pc-windows-msvc.zip",
-            "hash": "50b036460c1065a0355b2b70eb1fbc70eafc4d8123ab9a46a5d752e396480883"
+            "url": "https://github.com/astral-sh/ruff/releases/download/0.5.4/ruff-i686-pc-windows-msvc.zip",
+            "hash": "bf9549c14821c1cf3ecc65c7ddffd8b821b60e788d0fd5408ddd47a651b79e40"
         },
         "arm64": {
-            "url": "https://github.com/astral-sh/ruff/releases/download/0.5.1/ruff-aarch64-pc-windows-msvc.zip",
-            "hash": "4b1914f7dc169fb07d705d289a388236e16ebc6a9c26d9eb8d69bf27687a8213"
+            "url": "https://github.com/astral-sh/ruff/releases/download/0.5.4/ruff-aarch64-pc-windows-msvc.zip",
+            "hash": "17453d6205bc19b13c0a745ae1310e95582a6d310d7ffed7d36ed126e8c6fd85"
         }
     },
     "bin": "ruff.exe",


### PR DESCRIPTION
- Fix autoupdate URLs
- Update to version 0.5.1

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
