### PR TITLE
azure-cli - Add uninstall purge logic for proper nuke on `uninstall --purge`

### DIFF
--- a/bucket/azure-cli.json
+++ b/bucket/azure-cli.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "notes": [
         "* Known issue:",
-        "  - Cannot be extracted due to long path: https://github.com/ScoopInstaller/Main/issues/5300"
+        "  - Extracted can fail due to long path: https://github.com/ScoopInstaller/Main/issues/5300"
     ],
     "architecture": {
         "64bit": {
@@ -18,6 +18,28 @@
         "AzureCLIPath": "$dir\\bin"
     },
     "bin": "bin\\az.cmd",
+    "post_uninstall": [
+        "if ($purge) {",
+        "    $Directories = [string[]](",
+        "        ('{0}\\.azure\\cliextensions' -f $env:USERPROFILE)",
+        "    )",
+        "    $Directories.ForEach{",
+        "        if ([System.IO.Directory]::Exists($_)) {",
+        "            $null = [System.IO.Directory]::Delete($_,$true)",
+        "        }",
+        "    }",
+        "    $Files = [string[]](",
+        "        ('{0}\\.azure\\config' -f $env:USERPROFILE),",
+        "        ('{0}\\.azure\\extensionCommandTree.json' -f $env:USERPROFILE),",
+        "        ('{0}\\.azure\\versionCheck.json' -f $env:USERPROFILE)",
+        "    )",
+        "    $Files.ForEach{",
+        "       if ([System.IO.File]::Exists($_)) {",
+        "           $null = [System.IO.File]::Delete($_)",
+        "       }",
+        "    }",
+        "}"
+    ],
     "checkver": {
         "github": "https://github.com/Azure/azure-cli",
         "regex": "/releases/tag/azure-cli-([\\d.]+)"

--- a/bucket/azure-cli.json
+++ b/bucket/azure-cli.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "notes": [
         "* Known issue:",
-        "  - Extracted can fail due to long path: https://github.com/ScoopInstaller/Main/issues/5300"
+        "  - Extraction can fail due to long path: https://github.com/ScoopInstaller/Main/issues/5300"
     ],
     "architecture": {
         "64bit": {

--- a/bucket/azure-cli.json
+++ b/bucket/azure-cli.json
@@ -18,10 +18,16 @@
         "AzureCLIPath": "$dir\\bin"
     },
     "bin": "bin\\az.cmd",
+    "pre_uninstall": [
+        "if ($purge -and [bool]$(Try{$null = Get-Command -Name 'az' 2>$null; $?}Catch{$false})) {",
+        "    Start-Process -FilePath 'az' -ArgumentList 'account', 'clear' -NoNewWindow -Wait",
+        "}"
+    ],
     "post_uninstall": [
         "if ($purge) {",
         "    $Directories = [string[]](",
-        "        ('{0}\\.azure\\cliextensions' -f $env:USERPROFILE)",
+        "        ('{0}\\.azure\\cliextensions' -f $env:USERPROFILE),",
+        "        ('{0}\\.azure\\commands' -f $env:USERPROFILE)",
         "    )",
         "    $Directories.ForEach{",
         "        if ([System.IO.Directory]::Exists($_)) {",
@@ -29,6 +35,7 @@
         "        }",
         "    }",
         "    $Files = [string[]](",
+        "        ('{0}\\.azure\\commandIndex.json' -f $env:USERPROFILE),",
         "        ('{0}\\.azure\\config' -f $env:USERPROFILE),",
         "        ('{0}\\.azure\\extensionCommandTree.json' -f $env:USERPROFILE),",
         "        ('{0}\\.azure\\versionCheck.json' -f $env:USERPROFILE)",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

`scoop uninstall azure-cli` and `scoop uninstall --purge azure-cli` currently leaves a lot behind.

This PR adds `pre_uninstall` to clear account cache using `az account clear`, and `post_uninstall` to remove known files and directories, if `--purge` was specified.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
