### PR TITLE
fzf: Update to version 0.54.0

### DIFF
--- a/bucket/fzf.json
+++ b/bucket/fzf.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.53.0",
+    "version": "0.54.0",
     "description": "A general-purpose command-line fuzzy finder",
     "homepage": "https://github.com/junegunn/fzf",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/junegunn/fzf/releases/download/0.53.0/fzf-0.53.0-windows_amd64.zip",
-            "hash": "e977de12c1ab80f72e49e2fc8eceb5f5623338200a87b2aafab2e87ebd85efbe"
+            "url": "https://github.com/junegunn/fzf/releases/download/v0.54.0/fzf-0.54.0-windows_amd64.zip",
+            "hash": "fe8fcd71cdff3499d1dcb5f1c5c5a5f0f15d5c8f6259fe94832ae9136bfba8ea"
         },
         "arm64": {
-            "url": "https://github.com/junegunn/fzf/releases/download/0.53.0/fzf-0.53.0-windows_arm64.zip",
-            "hash": "01f9a486f0f79358ae66e30950daabf8e83c47c0c0f8d3b54a130b48839bff22"
+            "url": "https://github.com/junegunn/fzf/releases/download/v0.54.0/fzf-0.54.0-windows_arm64.zip",
+            "hash": "bde2fcf76121b91dbe547c30fa5fb423ca40fba8425d2511adefba80823f8ea0"
         }
     },
     "bin": "fzf.exe",
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/junegunn/fzf/releases/download/$version/fzf-$version-windows_amd64.zip"
+                "url": "https://github.com/junegunn/fzf/releases/download/v$version/fzf-$version-windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/junegunn/fzf/releases/download/$version/fzf-$version-windows_arm64.zip"
+                "url": "https://github.com/junegunn/fzf/releases/download/v$version/fzf-$version-windows_arm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Tag name have changed from 9.9.9 to v9.9.9 in version 0.54.0.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/bb2c09c6-e1c8-46aa-a553-80b22bd66e23">

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6012
Closes #6013 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
