### PR TITLE
exiftool: Update to version 12.89

### DIFF
--- a/bucket/exiftool.json
+++ b/bucket/exiftool.json
@@ -1,10 +1,20 @@
 {
-    "version": "12.87",
+    "version": "12.89",
     "description": "A command-line application for reading, writing and editing meta information in a wide variety of files.",
     "homepage": "https://exiftool.org",
     "license": "GPL-1.0-or-later|Artistic-1.0-Perl",
-    "url": "https://exiftool.org/exiftool-12.87.zip",
-    "hash": "sha1:598676c13d424b35a9e74d3a6a91770612c9fd14",
+    "architecture": {
+        "64bit": {
+            "url": "https://exiftool.org/exiftool-12.89_64.zip",
+            "hash": "344dd534c5cfcb46658151774a0762eff59501f84a26057a68dd48019bed789e",
+            "extract_dir": "exiftool-12.89_64"
+        },
+        "32bit": {
+            "url": "https://exiftool.org/exiftool-12.89_32.zip",
+            "hash": "424a5d1ac442c804f5cc5cf6e37c889b6097acecffc5778a42d7dbabd4df5558",
+            "extract_dir": "exiftool-12.89_32"
+        }
+    },
     "pre_install": "Copy-Item \"$dir\\exiftool(-k).exe\" \"$dir\\exiftool.exe\"",
     "bin": [
         "exiftool.exe",
@@ -15,10 +25,19 @@
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://exiftool.org/exiftool-$version.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://exiftool.org/exiftool-$version_64.zip",
+                "extract_dir": "exiftool-$version_64"
+            },
+            "32bit": {
+                "url": "https://exiftool.org/exiftool-$version_32.zip",
+                "extract_dir": "exiftool-$version_32"
+            }
+        },
         "hash": {
             "url": "$baseurl/checksums.txt",
-            "regex": "SHA1\\($basename\\)=\\s*$sha1"
+            "regex": "(?s)$basename.*?$sha256"
         }
     }
 }

--- a/bucket/exiftool.json
+++ b/bucket/exiftool.json
@@ -37,7 +37,7 @@
         },
         "hash": {
             "url": "$baseurl/checksums.txt",
-            "regex": "(?s)$basename.*?$sha256"
+            "regex": "$basename.*?$sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

Updates the manifest to version 12.89, which is the latest version,
but I don't know how to verify the file with sha1...
so I changed the hashing method to sha256 which I copy from the "extras/office-tool-plus" manifest...

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
