### PR TITLE
scala: Update repo link

### DIFF
--- a/bucket/scala.json
+++ b/bucket/scala.json
@@ -10,7 +10,7 @@
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://github.com/lampepfl/dotty/releases/download/3.4.2/scala3-3.4.2.zip",
+    "url": "https://github.com/scala/scala3/releases/download/3.4.2/scala3-3.4.2.zip",
     "hash": "87562da187d24a2e53043679152017506226eddadec81391248444b8bf8b3610",
     "extract_dir": "scala3-3.4.2",
     "bin": [
@@ -22,10 +22,10 @@
         "SCALA_HOME": "$dir"
     },
     "checkver": {
-        "github": "https://github.com/lampepfl/dotty/"
+        "github": "https://github.com/scala/scala3/"
     },
     "autoupdate": {
-        "url": "https://github.com/lampepfl/dotty/releases/download/$version/scala3-$version.zip",
+        "url": "https://github.com/scala/scala3/releases/download/$version/scala3-$version.zip",
         "hash": {
             "url": "$baseurl/sha256sum.txt"
         },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The repository for Scala 3 has been transfered to the [`scala`](https://github.com/scala/) organisation under the [`scala3`](https://github.com/scala/scala3) name.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
