### PR TITLE
terraform-switcher: Fix autoupdate urls

### DIFF
--- a/bucket/terraform-switcher.json
+++ b/bucket/terraform-switcher.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.13.1308",
+    "version": "1.2.2",
     "description": "A command line tool to switch between different versions of terraform",
     "homepage": "https://tfswitch.warrensbox.com",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/0.13.1308/terraform-switcher_0.13.1308_windows_386.zip",
-            "hash": "0fb7c7a5b58a6982b3216a0d1a1769577a2232fa3df5c795692c29b71e592bd6"
+            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v1.2.2/terraform-switcher_v1.2.2_windows_386.tar.gz",
+            "hash": "40bd37acf0525c72ede3ce47dc213c025c4db095ee3db6fcbd3ab086b5426852"
         },
         "64bit": {
-            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/0.13.1308/terraform-switcher_0.13.1308_windows_amd64.zip",
-            "hash": "2c20cafbd6be81f6ed675522bbf05abd5e4b763ccefbd6bdd33e15a4604beb82"
+            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v1.2.2/terraform-switcher_v1.2.2_windows_amd64.tar.gz",
+            "hash": "4977150c17f80c5a7dc0607a38c7375965e1cd6f83d1154879f5295481007920"
         }
     },
     "bin": "tfswitch.exe",

--- a/bucket/terraform-switcher.json
+++ b/bucket/terraform-switcher.json
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/$version/terraform-switcher_$version_windows_386.zip"
+                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v$version/terraform-switcher_v$version_windows_386.tar.gz"
             },
             "64bit": {
-                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/$version/terraform-switcher_$version_windows_amd64.zip"
+                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v$version/terraform-switcher_v$version_windows_amd64.tar.gz"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
terraform-switcher changed their packaging format from .zip to .tar.gz at some point in the past, which appears to have broken scoop autoupdate. The latest release is 1.2.2 but scoop still shows 0.13.1308. This PR should fix the autoupdate behavior.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #3910

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
