### PR TITLE
Nim: Add atlas to the list of registered bins.

### DIFF
--- a/bucket/nim.json
+++ b/bucket/nim.json
@@ -22,6 +22,7 @@
         "Copy-Item -Recurse \"$dir\\dist\\nimble\\src\\nimblepkg\" \"$dir\\bin\""
     ],
     "bin": [
+        "bin\\atlas.exe",
         "bin\\nim.exe",
         "bin\\nimble.exe",
         "bin\\nimgrab.exe",


### PR DESCRIPTION
Atlas is a package cloner that ships with Nim. It's missing in the package `bin` section.

Closes #6032

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
