### PR TITLE
git-with-openssh@2.46.0.windows.1: Remove sshd.exe

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -21,7 +21,6 @@
         "usr\\bin\\gpg.exe",
         "usr\\bin\\gpgconf.exe",
         "usr\\bin\\ssh.exe",
-        "usr\\bin\\sshd.exe",
         "usr\\bin\\scp.exe",
         "usr\\bin\\sftp.exe",
         "usr\\bin\\ssh-add.exe",


### PR DESCRIPTION
As per the release notes for https://github.com/git-for-windows/git/releases/tag/v2.46.0.windows.1:

> The server-side component of OpenSSH, which had been shipped with Git for Windows for historical reasons only, is [now no longer distributed with it](https://github.com/git-for-windows/build-extra/pull/571).

I have confirmed locally that I can update from 2.45.2.windows.1 when removing the shim for `sshd.exe`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
