### PR TITLE
fnm: Remove leftovers when `uninstall --purge`

### DIFF
--- a/bucket/fnm.json
+++ b/bucket/fnm.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
     "version": "1.37.1",
     "description": "Cross-platform Node.js version switcher",
     "homepage": "https://github.com/Schniz/fnm",
@@ -11,6 +12,19 @@
         }
     },
     "bin": "fnm.exe",
+    "post_uninstall": [
+        "if ($purge) {",
+        "    $Directories = [string[]](",
+        "        ('{0}\\fnm_multishells' -f $env:LOCALAPPDATA),",
+        "        ('{0}\\fnm' -f $env:APPDATA)",
+        "    )",
+        "    $Directories.ForEach{",
+        "        if ([System.IO.Directory]::Exists($_)) {",
+        "            $null = Remove-Item -Path $_ -Recurse -Force",
+        "        }",
+        "    }",
+        "}"
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/fnm.json
+++ b/bucket/fnm.json
@@ -19,7 +19,7 @@
         "        ('{0}\\fnm' -f $env:APPDATA)",
         "    )",
         "    $Directories.ForEach{",
-        "        if ([System.IO.Directory]::Exists($_)) {",
+        "        if (Test-Path -Path $_ -PathType 'Container') {",
         "            $null = Remove-Item -Path $_ -Recurse -Force",
         "        }",
         "    }",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

fnm leaves behind two paths when uninstalled:

* `%LOCALAPPDATA%\fnm_multishells`
* `%APPDATA%\fnm`

Added ability to have them nuked when uninstalling with `--purge`.

Note: For some reason `[System.IO.Directory]::Delete()` failed to delete one of the directories with an error about access denied, but `Remove-Item -Recurse` worked. So using that.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
