### PR TITLE
dotnet-core-uninstall: Add version 1.7.521001

### DIFF
--- a/bucket/dotnet-core-uninstall.json
+++ b/bucket/dotnet-core-uninstall.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "1.7.521001",
+    "homepage": "https://learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
+            "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+        },
+        "64bit": {
+            "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi",
+            "hash": "eca900bb813daafd915d453f99135b9f5fc15db84c384b90fb820aaea12ddb3c"
+        }
+    },
+    "extract_dir": "dotnet-core-uninstall",
+    "bin": "dotnet-core-uninstall.exe",
+    "checkver": {
+        "github": "https://github.com/dotnet/cli-lab"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/dotnet/cli-lab/releases/download/$version/dotnet-core-uninstall-$version.msi"
+            },
+            "64bit": {
+                "url": "https://github.com/dotnet/cli-lab/releases/download/$version/dotnet-core-uninstall-$version.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The MSI ( <https://github.com/dotnet/cli-lab/releases/download/1.7.521001/dotnet-core-uninstall-1.7.521001.msi> ) says it's for x86 when opened in Orca, but it works fine on x64 too. I'm unsure how to say that it works for x86 and x64, but not ARM64, thus I added both `32bit` and `64bit` with the same content.

Closes #6094

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
