### PR TITLE
(chore): update osv-scanner.json to fit new binary naming scheme

### DIFF
--- a/bucket/osv-scanner.json
+++ b/bucket/osv-scanner.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.6.2",
+    "version": "1.8.3",
     "description": "Find existing vulnerabilities affecting your project's dependencies.",
     "homepage": "https://github.com/google/osv-scanner",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/google/osv-scanner/releases/download/v1.6.2/osv-scanner_1.6.2_windows_amd64.exe#/osv-scanner.exe",
-            "hash": "2bccba4c1b97906ec9dab4307d2ec701c5636f786e073707880ba91e57a71923"
+            "url": "https://github.com/google/osv-scanner/releases/download/v1.8.3/osv-scanner_windows_amd64.exe#/osv-scanner.exe",
+            "hash": "96a3a312ce02ffed2694b532a7d8047bf6ddeab58179a794755aeddda5f9c1ce"
         }
     },
     "bin": "osv-scanner.exe",
@@ -14,11 +14,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/google/osv-scanner/releases/download/v$version/osv-scanner_$version_windows_amd64.exe#/osv-scanner.exe"
+                "url": "https://github.com/google/osv-scanner/releases/download/v$version/osv-scanner_windows_amd64.exe#/osv-scanner.exe"
             }
         },
         "hash": {
-            "url": "$baseurl/osv-scanner_$version_SHA256SUMS"
+            "url": "$baseurl/osv-scanner_SHA256SUMS"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

OSV-Scanner changed the binary naming to remove the version number from the binary name in the GitHub release. This updates the autoupdate rules to also follow that. I also updated it manually to the latest version 1.8.3.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #5580


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
