### PR TITLE
podman: Fix install (wix archive msi is opaquely named "a0")

### DIFF
--- a/bucket/podman.json
+++ b/bucket/podman.json
@@ -13,6 +13,7 @@
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\podman-$version-setup.exe\" \"$dir\\_tmp\" -Removal",
+            "if (Test-Path \"$dir\\_tmp\\AttachedContainer\\a0\") {Rename-Item \"$dir\\_tmp\\AttachedContainer\\a0\" 'podman.msi'}",
             "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\podman.msi\" \"$dir\" -ExtractDir 'PFiles64\\RedHat\\Podman'"
         ]
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6102

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
