### PR TITLE
VencordInstallerCli: Add version `1.4.0`

### DIFF
--- a/bucket/vencord-installer-cli.json
+++ b/bucket/vencord-installer-cli.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.4.0",
+    "description": "A cross platform cli app for installing Vencord",
+    "homepage": "https://github.com/Vencord/Installer",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Vencord/Installer/releases/download/v1.4.0/VencordInstallerCli.exe",
+            "hash": "466d2a0be1f380ddffed052df3cc132125fa34dc1af29312e14f13f358c8d2a2"
+        }
+    },
+    "bin": "VencordInstallerCli.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Vencord/Installer/releases/download/v$version/VencordInstallerCli.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Repo: https://github.com/Vencord/Installer
This is the CLI variant: https://github.com/Vencord/Installer/releases/download/v1.4.0/VencordInstallerCli.exe

VirusTotal Report: https://www.virustotal.com/gui/file/466d2a0be1f380ddffed052df3cc132125fa34dc1af29312e14f13f358c8d2a2

Relates to https://github.com/ScoopInstaller/Extras/issues/13200, https://github.com/ScoopInstaller/Extras/pull/13201, https://github.com/ScoopInstaller/Extras/pull/13201#issuecomment-2295126792, https://github.com/ScoopInstaller/Extras/pull/13748

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
