### PR TITLE
tenv: Add version 3.1.0

### DIFF
--- a/bucket/tenv.json
+++ b/bucket/tenv.json
@@ -1,0 +1,40 @@
+{
+    "version": "3.1.0",
+    "description": "OpenTofu, Terraform, Terragrunt, and Atmos version manager, written in Go.",
+    "homepage": "https://tofuutils.github.io/tenv/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tofuutils/tenv/releases/download/v3.1.0/tenv_v3.1.0_Windows_x86_64.zip",
+            "hash": "c67ec1899691eb70f229afec6578308db0cf4e3c31cd213c210fe4c3507b5d21"
+        },
+        "arm64": {
+            "url": "https://github.com/tofuutils/tenv/releases/download/v3.1.0/tenv_v3.1.0_Windows_arm64.zip",
+            "hash": "8459f164b86ca447d5f246e1a60d2d7ddbb1b5951625a49d1622efa2875545d7"
+        }
+    },
+    "bin": [
+        "atmos.exe",
+        "tenv.exe",
+        "terraform.exe",
+        "terragrunt.exe",
+        "tf.exe",
+        "tofu.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/tofuutils/tenv"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tofuutils/tenv/releases/download/v$version/tenv_v$version_Windows_x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/tofuutils/tenv/releases/download/v$version/tenv_v$version_Windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/tenv_v$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR adds [tenv](https://github.com/tofuutils/tenv); a versatile version manager for [OpenTofu](https://opentofu.org/), [Terraform](https://www.terraform.io/), [Terragrunt](https://terragrunt.gruntwork.io/) and [Atmos](https://atmos.tools/), written in Go.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
