### PR TITLE
git-bug: change upstream source to git-bug/git-bug

### DIFF
--- a/bucket/git-bug.json
+++ b/bucket/git-bug.json
@@ -1,15 +1,15 @@
 {
     "version": "0.8.0",
     "description": "Distributed, offline-first bug tracker embedded in git, with bridges",
-    "homepage": "https://github.com/MichaelMure/git-bug",
+    "homepage": "https://github.com/git-bug/git-bug",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/MichaelMure/git-bug/releases/download/v0.8.0/git-bug_windows_amd64.exe#/git-bug.exe",
+            "url": "https://github.com/git-bug/git-bug/releases/download/v0.8.0/git-bug_windows_amd64.exe#/git-bug.exe",
             "hash": "a6ab463c9cae012b819a1d50b2ba4dd14c6f4e6a917a3d7515a187c90d8f4207"
         },
         "32bit": {
-            "url": "https://github.com/MichaelMure/git-bug/releases/download/v0.8.0/git-bug_windows_386.exe#/git-bug.exe",
+            "url": "https://github.com/git-bug/git-bug/releases/download/v0.8.0/git-bug_windows_386.exe#/git-bug.exe",
             "hash": "7ba12dbbfd915f71f8384715a53e70652e1e89d8c705fa472cc26ff02fd01b63"
         }
     },
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/MichaelMure/git-bug/releases/download/v$version/git-bug_windows_amd64.exe#/git-bug.exe"
+                "url": "https://github.com/git-bug/git-bug/releases/download/v$version/git-bug_windows_amd64.exe#/git-bug.exe"
             },
             "32bit": {
-                "url": "https://github.com/MichaelMure/git-bug/releases/download/v$version/git-bug_windows_386.exe#/git-bug.exe"
+                "url": "https://github.com/git-bug/git-bug/releases/download/v$version/git-bug_windows_386.exe#/git-bug.exe"
             }
         }
     }


### PR DESCRIPTION
git-bug: change upstream source to git-bug/git-bug

git-bug has moved into [the git-bug organization][0]. This change
updates the package to fetch directly from git-bug/git-bug instead of
relying on what is now a 301 redirection (that lives only at GitHub's
discretion).

[0]: https://github.com/git-bug/git-bug

Closes: ScoopInstaller/Main#6134
Closes: git-bug/git-bug#1255