### PR TITLE
naiveproxy@v128.0.6613.40-1: add win-arm64 support

### DIFF
--- a/bucket/naiveproxy.json
+++ b/bucket/naiveproxy.json
@@ -13,6 +13,11 @@
             "url": "https://github.com/klzgrad/naiveproxy/releases/download/v128.0.6613.40-1/naiveproxy-v128.0.6613.40-1-win-x86.zip",
             "hash": "a0ac0aab80528d2b6be3946197c423d5316b7d327ebf09cbb2c3865a01d7ffbb",
             "extract_dir": "naiveproxy-v128.0.6613.40-1-win-x86"
+        },
+        "arm64": {
+            "url": "https://github.com/klzgrad/naiveproxy/releases/download/v128.0.6613.40-1/naiveproxy-v128.0.6613.40-1-win-arm64.zip",
+            "hash": "c7dc2664df2ce75d0bb72a9bb14df25b040a772a3946f33fa454b5dbdd8b1ba9",
+            "extract_dir": "naiveproxy-v128.0.6613.40-1-win-arm64"
         }
     },
     "bin": "naive.exe",
@@ -30,6 +35,10 @@
             "32bit": {
                 "url": "https://github.com/klzgrad/naiveproxy/releases/download/v$version/naiveproxy-v$version-win-x86.zip",
                 "extract_dir": "naiveproxy-v$version-win-x86"
+            },
+            "arm64": {
+                "url": "https://github.com/klzgrad/naiveproxy/releases/download/v$version/naiveproxy-v$version-win-arm64.zip",
+                "extract_dir": "naiveproxy-v$version-win-arm64"
             }
         }
     }


### PR DESCRIPTION
naiveproxy: add win-arm64 support

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
