### PR TITLE
jj: add project name to description for discoverability

### DIFF
--- a/bucket/jj.json
+++ b/bucket/jj.json
@@ -1,6 +1,6 @@
 {
     "version": "0.21.0",
-    "description": "A Git-compatible DVCS that is both simple and powerful",
+    "description": "Jujutsu is a Git-compatible DVCS that is both simple and powerful",
     "homepage": "https://github.com/martinvonz/jj",
     "license": "Apache-2.0",
     "architecture": {


### PR DESCRIPTION
While the CLI tool/command is JJ, currently attempting to search by the project name of Jujutsu with "scoop search" or on the scoop.sh homepage will not surface JJ in the main repo. This will help avoid redundant packages/requests for some users of the tool.

Looking at other manifests, did not see a preferred format for adding a name this way (since typically manifest/package aliases are handled differently than this case).

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
