### PR TITLE
nak: Add version 0.7.5

### DIFF
--- a/bucket/nak.json
+++ b/bucket/nak.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.7.5",
+    "description": "Nostr command line tool for doing all things",
+    "homepage": "https://github.com/fiatjaf/nak",
+    "license": "Unlicense",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fiatjaf/nak/releases/download/v0.7.5/nak-v0.7.5-windows-amd64.exe#/nak.exe",
+            "hash": "b1a458c611bdfe4a36933b6d6b65812326832753d30e90dd8735e37bb342d031"
+        }
+    },
+    "bin": "nak.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fiatjaf/nak/releases/download/v$version/nak-v$version-windows-amd64.exe#/nak.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Nak is a command line tool for doing all things nostr.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
