### PR TITLE
mise: Add version 2024.9.0

### DIFF
--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -1,0 +1,22 @@
+{
+    "version": "2024.9.0",
+    "description": "dev tools, env vars, task runner. mise (pronounced \"meez\") or \"mise-en-place\" is a development environment setup tool.",
+    "homepage": "https://github.com/jdx/mise",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jdx/mise/releases/download/v2024.9.0/mise-v2024.9.0-win-x64.zip",
+            "hash": "4fc826110a960d043bc4421fb7a4f533b5e78f2bf35990b55db65c2a14c31103"
+        }
+    },
+    "extract_dir": "mise\\bin",
+    "bin": "mise.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jdx/mise/releases/download/v$version/mise-v$version-win-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This PR adds `mise`, a command-line tool for managing your development environment. It is a drop-in replacement for [`asdf`](/asdf-vm/asdf) built in Rust.

For more on this tool, check out the repo [_jdx/mise_](/jdx/mise).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
