### PR TITLE
initool: Add version 0.18.0

### DIFF
--- a/bucket/initool.json
+++ b/bucket/initool.json
@@ -1,0 +1,25 @@
+{
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dbohdan/initool/releases/download/v0.18.0/initool-v0.18.0-fc0c3b1-win32.zip",
+            "hash": "b3bcc11faaf1adb708d5cc764a200d9c4247a1efbbb0e68ab23f4115bdc9b71a"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dbohdan/initool/releases/download/v$version/initool-v$version-$matchCommit-win32.zip"
+            }
+        }
+    },
+    "bin": "initool.exe",
+    "checkver": {
+        "url": "https://api.github.com/repos/dbohdan/initool/releases/latest",
+        "jsonpath": "$..browser_download_url",
+        "regex": "download/v(?<tag>[\\d.]+)/initool-v([\\d.]+)-(?<commit>[\\w]{7})-win32.zip"
+    },
+    "description": "Initool lets you manipulate the contents of INI files from the command line",
+    "homepage": "https://github.com/dbohdan/initool",
+    "license": "MIT",
+    "version": "0.18.0"
+}

--- a/bucket/initool.json
+++ b/bucket/initool.json
@@ -1,16 +1,6 @@
 {
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/dbohdan/initool/releases/download/v0.18.0/initool-v0.18.0-fc0c3b1-win32.zip",
-            "hash": "b3bcc11faaf1adb708d5cc764a200d9c4247a1efbbb0e68ab23f4115bdc9b71a"
-        }
-    },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/dbohdan/initool/releases/download/v$version/initool-v$version-$matchCommit-win32.zip"
-            }
-        }
+        "url": "https://github.com/dbohdan/initool/releases/download/v$version/initool-v$version-$matchCommit-win32.zip"
     },
     "bin": "initool.exe",
     "checkver": {
@@ -19,7 +9,9 @@
         "regex": "download/v(?<tag>[\\d.]+)/initool-v([\\d.]+)-(?<commit>[\\w]{7})-win32.zip"
     },
     "description": "Initool lets you manipulate the contents of INI files from the command line",
+    "hash": "b3bcc11faaf1adb708d5cc764a200d9c4247a1efbbb0e68ab23f4115bdc9b71a",
     "homepage": "https://github.com/dbohdan/initool",
     "license": "MIT",
+    "url": "https://github.com/dbohdan/initool/releases/download/v0.18.0/initool-v0.18.0-fc0c3b1-win32.zip",
     "version": "0.18.0"
 }


### PR DESCRIPTION
Closes #6180

Adds a manifest for initool v0.18.0. Tested locally on my own machine and with auto update support.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
