### PR TITLE
jnv: Add version 0.4.0

### DIFF
--- a/bucket/jnv.json
+++ b/bucket/jnv.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Interactive JSON filter using jq",
     "homepage": "https://github.com/ynqa/jnv",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ynqa/jnv/releases/download/v0.4.0/jnv-x86_64-pc-windows-msvc.zip",
-            "hash": "85fdf833526300ff254d8da26b6a8d835e5d28dc4d10a7e5a3fe4c3ee16cb7a9"
+            "url": "https://github.com/ynqa/jnv/releases/download/v0.4.1/jnv-x86_64-pc-windows-msvc.zip",
+            "hash": "fb44d9eb01fb29391f04d27f28ea9590adbb116c0b22c8816b8fc3801addcbbf"
         }
     },
     "bin": "jnv.exe",

--- a/bucket/jnv.json
+++ b/bucket/jnv.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.4.0",
+    "description": "Interactive JSON filter using jq",
+    "homepage": "https://github.com/ynqa/jnv",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ynqa/jnv/releases/download/v0.4.0/jnv-x86_64-pc-windows-msvc.zip",
+            "hash": "85fdf833526300ff254d8da26b6a8d835e5d28dc4d10a7e5a3fe4c3ee16cb7a9"
+        }
+    },
+    "bin": "jnv.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ynqa/jnv/releases/download/v$version/jnv-x86_64-pc-windows-msvc.zip",
+                "hash": {
+                    "url": "$baseurl/jnv-x86_64-pc-windows-msvc.zip.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/jnv.json
+++ b/bucket/jnv.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "Interactive JSON filter using jq",
     "homepage": "https://github.com/ynqa/jnv",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ynqa/jnv/releases/download/v0.4.1/jnv-x86_64-pc-windows-msvc.zip",
-            "hash": "fb44d9eb01fb29391f04d27f28ea9590adbb116c0b22c8816b8fc3801addcbbf"
+            "url": "https://github.com/ynqa/jnv/releases/download/v0.5.0/jnv-x86_64-pc-windows-msvc.zip",
+            "hash": "71a1736348a2ddfe6af48c757125d4b55b567fbc123ce10652caeab6a9173acb"
         }
     },
     "bin": "jnv.exe",


### PR DESCRIPTION
Add a manifest for the `jnv` cli tool.

Closes #6183 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
