### PR TITLE
wildfly: Add version 33.0.1.Final

### DIFF
--- a/bucket/wildfly.json
+++ b/bucket/wildfly.json
@@ -5,6 +5,17 @@
     "license": "Apache-2.0",
     "url": "https://github.com/wildfly/wildfly/releases/download/33.0.1.Final/wildfly-33.0.1.Final.zip",
     "hash": "564d3c7fce9476ea0977da778c3299fd39b8ec36de694b4d318c9aa060a14d9f",
+    "post_install": [
+        "Write-Host ''",
+        "if (-not $env:JAVA_HOME -or -not (Test-Path \"$env:JAVA_HOME\\bin\\java.exe\")) {",
+        "    Write-Host -ForegroundColor Yellow \"WildFly has been installed, but no Java Development Kit (JDK) was found at JAVA_HOME.\"",
+        "    Write-Host -ForegroundColor Yellow \"The WildFly application server requires a JDK to run. Please install a JDK (e.g. 'scoop install openjdk') before running WildFly.\"",
+        "    Write-Host -ForegroundColor Yellow \"You can also use 'scoop search openjdk' to find other JDK distributions.\"",
+        "}",
+        "else {",
+        "    Write-Host -ForegroundColor Green \"WildFly has been installed and a JDK was found at JAVA_HOME.`nYou can start the server by running '`$env:JBOSS_HOME\\bin\\standalone.bat'.\"",
+        "}"
+    ],
     "extract_dir": "wildfly-33.0.1.Final",
     "env_set": {
         "JBOSS_HOME": "$dir"

--- a/bucket/wildfly.json
+++ b/bucket/wildfly.json
@@ -1,0 +1,20 @@
+{
+    "version": "33.0.1.Final",
+    "description": "WildFly Application Server. A Java EE 8 certified application server for developing and testing enterprise applications.",
+    "homepage": "https://github.com/wildfly/wildfly",
+    "license": "Apache-2.0",
+    "url": "https://github.com/wildfly/wildfly/releases/download/33.0.1.Final/wildfly-33.0.1.Final.zip",
+    "hash": "564d3c7fce9476ea0977da778c3299fd39b8ec36de694b4d318c9aa060a14d9f",
+    "extract_dir": "wildfly-33.0.1.Final",
+    "env_set": {
+        "JBOSS_HOME": "$dir"
+    },
+    "checkver": {
+        "github": "https://github.com/wildfly/wildfly",
+        "regex": "([\\d.]+\\.(?:Final|Beta\\d+|Alpha\\d+))"
+    },
+    "autoupdate": {
+        "url": "https://github.com/wildfly/wildfly/releases/download/$version/wildfly-$version.zip",
+        "extract_dir": "wildfly-$version"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

This PR adds WildFly Application Server, a Java EE 8 certified application server for developing and testing enterprise applications.

For more, check out the repo [_wildfly/wildfly_](/wildfly/wildfly).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
