### PR TITLE
Fix OpenSSL Light URL

### DIFF
--- a/bucket/lynx.json
+++ b/bucket/lynx.json
@@ -12,7 +12,7 @@
     "innosetup": true,
     "url": [
         "https://invisible-island.net/archives/lynx/current/lynx-newssl2.9.2-setup.exe",
-        "https://slproweb.com/download/Win32OpenSSL_Light-3_0_14.exe"
+        "https://slproweb.com/download/Win32OpenSSL_Light-3_3_2.exe"
     ],
     "hash": [
         "12165dfb4e0608a7cd25a088e439a64b6573fff07c32757e989211a04d3b20d7",

--- a/bucket/lynx.json
+++ b/bucket/lynx.json
@@ -16,7 +16,7 @@
     ],
     "hash": [
         "12165dfb4e0608a7cd25a088e439a64b6573fff07c32757e989211a04d3b20d7",
-        "75ebba9e835c28343c3fdfecca82c5a46089c1f14b6c182f5ef03170f2735c00"
+        "2268495548aba27dca42f6544c3b6765d1e31bcc759789649034788482b17ce1"
     ],
     "pre_install": "if (!(Test-Path \"$persist_dir\\lynx.cfg\")) { Add-Content \"$dir\\lynx.cfg\" -Value @(\"SSL_CERT_FILE:`\"$(appdir cacert $global)\\current\\cacert.pem`\"\", \"FORCE_SSL_PROMPT:PROMPT\") -Encoding Ascii }",
     "bin": [

--- a/bucket/lynx.json
+++ b/bucket/lynx.json
@@ -12,11 +12,11 @@
     "innosetup": true,
     "url": [
         "https://invisible-island.net/archives/lynx/current/lynx-newssl2.9.2-setup.exe",
-        "https://slproweb.com/download/Win32OpenSSL_Light-3_3_2.exe"
+        "https://slproweb.com/download/Win32OpenSSL_Light-3_0_15.exe"
     ],
     "hash": [
         "12165dfb4e0608a7cd25a088e439a64b6573fff07c32757e989211a04d3b20d7",
-        "2268495548aba27dca42f6544c3b6765d1e31bcc759789649034788482b17ce1"
+        "8ec1cad86c78e5474b0ac0c41c2231f0e8ffac21ec35c0d1c209337e6983495f"
     ],
     "pre_install": "if (!(Test-Path \"$persist_dir\\lynx.cfg\")) { Add-Content \"$dir\\lynx.cfg\" -Value @(\"SSL_CERT_FILE:`\"$(appdir cacert $global)\\current\\cacert.pem`\"\", \"FORCE_SSL_PROMPT:PROMPT\") -Encoding Ascii }",
     "bin": [


### PR DESCRIPTION
Current URL 404s

Updates to latest working URL from https://slproweb.com which is v3.3.2:
https://slproweb.com/download/Win32OpenSSL_Light-3_3_2.exe

