### PR TITLE
git-cliff@2.6.1: Add arm64 version

### DIFF
--- a/bucket/git-cliff.json
+++ b/bucket/git-cliff.json
@@ -11,6 +11,10 @@
         "64bit": {
             "url": "https://github.com/orhun/git-cliff/releases/download/v2.6.1/git-cliff-2.6.1-x86_64-pc-windows-msvc.zip",
             "hash": "519f7cd9e5f43f1c11f323cddcb1e77b5ca7317a6ff72297be2f41975d45febe"
+        },
+        "arm64": {
+            "url": "https://github.com/orhun/git-cliff/releases/download/v2.6.1/git-cliff-2.6.1-aarch64-pc-windows-msvc.zip",
+            "hash": "ad2b600909927b0b5e6e0b593f54e69c5370b3fa969f7fda761638ff6f0d49f5"
         }
     },
     "extract_dir": "git-cliff-2.6.1",
@@ -25,6 +29,9 @@
             },
             "64bit": {
                 "url": "https://github.com/orhun/git-cliff/releases/download/v$version/git-cliff-$version-x86_64-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/orhun/git-cliff/releases/download/v$version/git-cliff-$version-aarch64-pc-windows-msvc.zip"
             }
         },
         "extract_dir": "git-cliff-$version"


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
