### PR TITLE
mingw-winlibs: Use UCRT instead of MSVCRT

### DIFF
--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -1,17 +1,17 @@
 {
-    "version": "14.2.0-12.0.0-r1",
+    "version": "14.2.0-12.0.0-r2",
     "description": "GNU Compiler Collection (WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.7z",
-            "hash": "e32e079de3a1c0fd26b844f7350a5f31d7e342e01d01b42df866880b483d3950",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r2.7z",
+            "hash": "e8751bcad522ee112fbc197e6224c67811df6d039cf400269135eff0dad8cf0c",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.7z",
-            "hash": "5b7388a817cec2fb6a7bab93283c8579e483e8c2e950a380c9d08048026694af",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64ucrt-12.0.0-r2.7z",
+            "hash": "8ab19990ba0ca7ac5cbd10cf40f98fa15f9dbb1fbd45dcadacef533d14b7f4d8",
             "extract_dir": "mingw32"
         }
     },

--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -6,12 +6,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.7z",
-            "hash": "daf82b7bb6cb2d6b4cb5e630d3b4d37e75a9de31589aac8ff91f9228e2f97376",
+            "hash": "e32e079de3a1c0fd26b844f7350a5f31d7e342e01d01b42df866880b483d3950",
             "extract_dir": "mingw64"
         },
         "32bit": {
             "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.7z",
-            "hash": "417c914c886a0f08bb18992063bb892aca61e461be3e9ea5ea0f8ff79d96559c",
+            "hash": "5b7388a817cec2fb6a7bab93283c8579e483e8c2e950a380c9d08048026694af",
             "extract_dir": "mingw32"
         }
     },

--- a/bucket/mingw-winlibs.json
+++ b/bucket/mingw-winlibs.json
@@ -5,12 +5,12 @@
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64msvcrt-12.0.0-r1.7z",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.7z",
             "hash": "daf82b7bb6cb2d6b4cb5e630d3b4d37e75a9de31589aac8ff91f9228e2f97376",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-msvcrt-r1/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64msvcrt-12.0.0-r1.7z",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-18.1.8-12.0.0-ucrt-r1/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64ucrt-12.0.0-r1.7z",
             "hash": "417c914c886a0f08bb18992063bb892aca61e461be3e9ea5ea0f8ff79d96559c",
             "extract_dir": "mingw32"
         }
@@ -18,16 +18,16 @@
     "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
     "env_add_path": "bin",
     "checkver": {
-        "regex": "(?<gcc>[\\d.]+)posix-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-msvcrt-r(?<release>\\d+)",
+        "regex": "(?<gcc>[\\d.]+)posix-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
         "replace": "${gcc}-${mingw}-r${release}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-msvcrt-r$matchRelease/winlibs-x86_64-posix-seh-gcc-$matchGcc-mingw-w64msvcrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-posix-seh-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             },
             "32bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-msvcrt-r$matchRelease/winlibs-i686-posix-dwarf-gcc-$matchGcc-mingw-w64msvcrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-i686-posix-dwarf-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

It makes sense to use UCRT instead of MSVCRT in 2024, as suggested on the home page:

> MSVCRT or UCRT runtime library?
> 
> Traditionally the MinGW-w64 compiler used MSVCRT as runtime library, which is available on all versions of Windows.
> 
> Since Windows 10 Universal C Runtime (UCRT) is available as an alternative to MSVCRT.
> Universal C Runtime can also be installed on earlier versions of Windows (see: [Update for Universal C Runtime in Windows](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c)).
> 
> Unless you are targetting older versions of Windows, UCRT as runtime library is the better choice, as it was written to better support recent Windows versions as well as provide better standards conformance (see also: [Upgrade your code to the Universal CRT](https://docs.microsoft.com/en-us/cpp/porting/upgrade-your-code-to-the-universal-crt?view=msvc-160)).

It is also the default choice for other mingw distributions in this bucket, including [mingw](https://github.com/ScoopInstaller/Main/blob/master/bucket/mingw.json) and [mingw-mstorsjo-llvm-ucrt](https://github.com/ScoopInstaller/Main/blob/master/bucket/mingw-mstorsjo-llvm-ucrt.json).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
