### PR TITLE
azure-functions-core-tools: Add ARM64

### DIFF
--- a/bucket/azure-functions-core-tools.json
+++ b/bucket/azure-functions-core-tools.json
@@ -1,28 +1,36 @@
 {
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
     "##": "Rename download file because 7-zip can't decompress it as zip file.",
     "version": "4.0.6280",
     "description": "Microsoft Azure Functions Core Tools",
     "homepage": "https://github.com/Azure/azure-functions-core-tools",
     "license": "MIT",
     "architecture": {
-        "64bit": {
-            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.win-x64.4.0.6280.zip#/dl.7z",
-            "hash": "5264a302624b0173c155ec3b0baa20d7ce71fc94ce61c3b5509d5e882505c2a3"
+        "arm64": {
+            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.win-arm64.4.0.6280.zip#/dl.7z",
+            "hash": "69c533a8d9d6d3286eaa2fc62fb33f3e50a1d49bb085dc6a5b6f705836c34486"
         },
         "32bit": {
             "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.win-x86.4.0.6280.zip#/dl.7z",
             "hash": "8cfd9397c80fe1063084f67d64190027359320123ea96c69ab86641cead76135"
+        },
+        "64bit": {
+            "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/4.0.6280/Azure.Functions.Cli.win-x64.4.0.6280.zip#/dl.7z",
+            "hash": "5264a302624b0173c155ec3b0baa20d7ce71fc94ce61c3b5509d5e882505c2a3"
         }
     },
     "bin": "func.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "64bit": {
-                "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/$version/Azure.Functions.Cli.win-x64.$version.zip#/dl.7z"
+            "arm64": {
+                "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/$version/Azure.Functions.Cli.win-arm64.$version.zip#/dl.7z"
             },
             "32bit": {
                 "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/$version/Azure.Functions.Cli.win-x86.$version.zip#/dl.7z"
+            },
+            "64bit": {
+                "url": "https://github.com/Azure/azure-functions-core-tools/releases/download/$version/Azure.Functions.Cli.win-x64.$version.zip#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Saw that ARM64 is available, but not yet added to Scoop manifest.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
