### PR TITLE
Erlang: Add version 27.1.1

### DIFF
--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -1,5 +1,5 @@
 {
-    "version": "27.0.1",
+    "version": "27.1.1",
     "description": "A programming language used to build massively scalable soft real-time systems with requirements on high availability.",
     "homepage": "https://www.erlang.org",
     "license": "Apache-2.0",

--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/erlang/otp/releases/download/OTP-27.0.1/otp_win64_27.0.1.exe#/dl.7z",
-            "hash": "f200e09df15706c202d6e1a504056fd10130289fe4dd54b9ae0ce0fbe24cdb4b"
+            "url": "https://github.com/erlang/otp/releases/download/OTP-27.1.1/otp_win64_27.1.1.exe#/dl.7z",
+            "hash": "2de136ea83a747860faf76387d0d27210ebb3463f633deec6b78c4f4fab25a71"
         },
         "32bit": {
-            "url": "https://github.com/erlang/otp/releases/download/OTP-27.0.1/otp_win32_27.0.1.exe#/dl.7z",
-            "hash": "68fcb88a0bde4b6bccfe90fc0a72ff0f631a8ab177d0ee20691062ee79f15d4a"
+            "url": "https://github.com/erlang/otp/releases/download/OTP-27.1.1/otp_win32_27.1.1.exe#/dl.7z",
+            "hash": "c9676ae4203fd81a84623e663bf9bed06ca042c71d247c20557bd2196cced273"
         }
     },
     "installer": {


### PR DESCRIPTION
Adding erlang 27.1.1 release https://github.com/erlang/otp/releases/tag/OTP-27.1.1

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6231

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
