### PR TITLE
dashlane-cli: Add version 6.2436.0

### DIFF
--- a/bucket/dashlane-cli.json
+++ b/bucket/dashlane-cli.json
@@ -1,0 +1,23 @@
+{
+    "version": "6.2436.0",
+    "description": "Dashlane CLI - Access your secrets in your terminal, servers and CI/CD",
+    "homepage": "https://cli.dashlane.com/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Dashlane/dashlane-cli/releases/download/v6.2436.0/dcli-win-x64-signed.exe#/dcli.exe",
+            "hash": "3c319193cbce38253b50db23ff9e857cf56d25146c97a301cef45c0d8eeac6d0"
+        }
+    },
+    "bin": "dcli.exe",
+    "checkver": {
+        "github": "https://github.com/Dashlane/dashlane-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Dashlane/dashlane-cli/releases/download/v$version/dcli-win-x64-signed.exe#/dcli.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a manifest for dashlane CLI tool: https://cli.dashlane.com/

Closes #5902

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
