### PR TITLE
openssh: Update to version 9.8.0.0p1

### DIFF
--- a/bucket/openssh.json
+++ b/bucket/openssh.json
@@ -1,17 +1,17 @@
 {
-    "version": "9.5.0.0p1",
+    "version": "9.8.0.0p1",
     "description": "The premier connectivity tool for remote login with the SSH protocol. (Microsoft build)",
     "homepage": "https://www.openssh.com",
     "license": "SSH-OpenSSH",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64.zip",
-            "hash": "bd48fe985d400402c278c485db20e6a82bc4c7f7d8e0ef5a81128f523096530c",
+            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.0.0p1-Preview/OpenSSH-Win64.zip",
+            "hash": "b0c6dad41d2db38b38356ac2b8b05454b2cb73b0381086ecec7df4cf5870c77b",
             "extract_dir": "OpenSSH-Win64"
         },
         "32bit": {
-            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win32.zip",
-            "hash": "9245c9ff62d6d11708cb3125097f8cd5627e995c225d0469cf2c3c6be4014952",
+            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.8.0.0p1-Preview/OpenSSH-Win32.zip",
+            "hash": "278d61dc30dda98f91dda27c2835b6bffb3831b9187fc4048b8c1431216ed624",
             "extract_dir": "OpenSSH-Win32"
         }
     },
@@ -29,15 +29,15 @@
     ],
     "checkver": {
         "github": "https://github.com/PowerShell/Win32-OpenSSH",
-        "regex": "tag/v([\\d.]+p\\d)-Beta"
+        "regex": "tag/v([\\d.]+p\\d)-Preview"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v$version-Beta/OpenSSH-Win64.zip"
+                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v$version-Preview/OpenSSH-Win64.zip"
             },
             "32bit": {
-                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v$version-Beta/OpenSSH-Win32.zip"
+                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v$version-Preview/OpenSSH-Win32.zip"
             }
         }
     },


### PR DESCRIPTION
Fix autoupdate URLs for v9.8

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
