### PR TITLE
jf: Add version 2.71.0

### DIFF
--- a/bucket/jf.json
+++ b/bucket/jf.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.71.0",
+    "description": "Command line interface for Artifactory and Bintray",
+    "homepage": "https://jfrog.com/getcli/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.71.0/jfrog-cli-windows-amd64/jf.exe%20#/jf.exe",
+            "hash": "4782500cf92b985e74f3c534830259a9e3227abb24fcdc77a7416a13ec7b2973"
+        }
+    },
+    "bin": "jf.exe",
+    "checkver": {
+        "url": "https://github.com/jfrog/jfrog-cli/releases",
+        "regex": "tag/v(2\\.[\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://releases.jfrog.io/artifactory/jfrog-cli/v$majorVersion-jf/$version/jfrog-cli-windows-amd64/jf.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/jfrog.json
+++ b/bucket/jfrog.json
@@ -14,6 +14,10 @@
         "url": "https://github.com/jfrog/jfrog-cli/releases",
         "regex": "tag/v(2\\.[\\d.]+)"
     },
+    "notes": [
+        "JFrog has chosen to rename jfrog.exe to jf.exe, which is available in the `jf` package.",
+        "https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/install#installation"
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
JFrog has decided to rename [the existing `jfrog` command line to just `jf`](https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/install#installation) while still continuing to offer `jfrog` CLI.
This package offers the new CLI (which is not just a renamed binary).

This PR also add notes to existing `jfrog` package to let people know `jf` exists, as it is recommended to be used by JFrog.

Closes #6156

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
