### PR TITLE
lychee: Update to version 0.16.1, fix checkver & autoupdate

### DIFF
--- a/bucket/lychee.json
+++ b/bucket/lychee.json
@@ -1,20 +1,23 @@
 {
-    "version": "0.15.1",
+    "version": "0.16.1",
     "description": "A command-line link checker",
     "homepage": "https://github.com/lycheeverse/lychee",
     "license": "Apache-2.0|MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/lycheeverse/lychee/releases/download/v0.15.1/lychee-v0.15.1-windows-x86_64.exe#/lychee.exe",
-            "hash": "b75a5ba20d18fcd09b831451111d12501873ae7bdd5054819824f6e818e316f0"
+            "url": "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.16.1/lychee-x86_64-windows.exe#/lychee.exe",
+            "hash": "7c97ce777e49ae6f5f2185805c13abc8e987754fb7246c20f2086871853d4180"
         }
     },
     "bin": "lychee.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/lycheeverse/lychee/releases",
+        "regex": "releases/tag/lychee-v([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lycheeverse/lychee/releases/download/v$version/lychee-v$version-windows-x86_64.exe#/lychee.exe"
+                "url": "https://github.com/lycheeverse/lychee/releases/download/lychee-v$version/lychee-x86_64-windows.exe#/lychee.exe"
             }
         }
     }


### PR DESCRIPTION
- Update to the latest version.
- Fix `checkver` & `autoupdate` in accordance with the new release naming.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
