### PR TITLE
sqldef: Remove obsolete 32bit architecture

### DIFF
--- a/bucket/sqldef.json
+++ b/bucket/sqldef.json
@@ -15,18 +15,6 @@
                 "0ad78bb27e09b045fc86414779f9fa237d7a7a8a831f164869cb7bd74e6c7d58",
                 "e27c486967e051abaf40a5cffb9cdf504c461e714445f22da38304e7733e5c76"
             ]
-        },
-        "32bit": {
-            "url": [
-                "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/mssqldef_windows_386.zip",
-                "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/mysqldef_windows_386.zip",
-                "https://github.com/k0kubun/sqldef/releases/download/v0.13.23/sqlite3def_windows_386.zip"
-            ],
-            "hash": [
-                "",
-                "f06f29dc3e7683f55bdb1adc90224ce9b5bf46b0ae2e9ed23cada8e5f21958b7",
-                "6e24bc4a66075bda5a75158b5318a5e333af876f5f1d3882841d1ac45b1f3c98"
-            ]
         }
     },
     "bin": [


### PR DESCRIPTION
* Upstream dropped support for i386 with v0.14.0 ; See https://github.com/sqldef/sqldef/blob/master/CHANGELOG.md#v0140

* Distributing v0.13.23 for x86 when the manifest claims v0.17.20 is bad UX and wrong

* `scoop info` currently fails to parse the manifest with the error: `data did not match any variant of untagged enum TOrArrayOfTs at line 30 column 9`

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
