### PR TITLE
glab: Update to version 1.48.0, fix autoupdate

### DIFF
--- a/bucket/glab.json
+++ b/bucket/glab.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.46.1",
+    "version": "1.47.0",
     "description": "GitLab CLI",
     "homepage": "https://gitlab.com/gitlab-org/cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Windows_x86_64.zip",
-            "hash": "8e75f8320b3f04050ea1d56ec0c06039055d061d75a9b15ef2c77458d8aa99ca"
+            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.47.0/downloads/glab_1.47.0_windows_amd64.zip",
+            "hash": "a8ba0960c8907e5bd6aa5885165d76a404ed8d5a153b6b189676fca50ef41540"
         },
         "32bit": {
-            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.46.1/downloads/glab_1.46.1_Windows_i386.zip",
-            "hash": "4fe6feec8ae68f06e1f631d30b892cfb332967d1a42c3b314a606a2853d8fded"
+            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.47.0/downloads/glab_1.47.0_windows_386.zip",
+            "hash": "d3c60d366135ac9dfa828b5b33b9b50e04decbfd9a345a587fb24973cc5b0ae6"
         }
     },
     "bin": "bin\\glab.exe",
@@ -21,10 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitlab.com/gitlab-org/cli/-/releases/v$version/downloads/glab_$version_Windows_x86_64.zip"
+                "url": "https://gitlab.com/gitlab-org/cli/-/releases/v$version/downloads/glab_$version_windows_amd64.zip"
             },
             "32bit": {
-                "url": "https://gitlab.com/gitlab-org/cli/-/releases/v$version/downloads/glab_$version_Windows_i386.zip"
+                "url": "https://gitlab.com/gitlab-org/cli/-/releases/v$version/downloads/glab_$version_windows_386.zip"
             }
         },
         "hash": {

--- a/bucket/glab.json
+++ b/bucket/glab.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.47.0",
+    "version": "1.48.0",
     "description": "GitLab CLI",
     "homepage": "https://gitlab.com/gitlab-org/cli",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.47.0/downloads/glab_1.47.0_windows_amd64.zip",
-            "hash": "a8ba0960c8907e5bd6aa5885165d76a404ed8d5a153b6b189676fca50ef41540"
+            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_windows_amd64.zip",
+            "hash": "b31e04e165f6e0875d48499dd0138738ad9e30a5e2c1af6f929f984a9b2bc791"
         },
         "32bit": {
-            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.47.0/downloads/glab_1.47.0_windows_386.zip",
-            "hash": "d3c60d366135ac9dfa828b5b33b9b50e04decbfd9a345a587fb24973cc5b0ae6"
+            "url": "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_windows_386.zip",
+            "hash": "fe92cd884fd793dad41c4f5c5b83895ad670239b6ffdf106916429203aa45a97"
         }
     },
     "bin": "bin\\glab.exe",


### PR DESCRIPTION
- Fix `autoupdate` in accordance with the changed binaries naming.
- Update to the latest version.

Closes #6240

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
