### PR TITLE
git-town@16.4.1: Add arm64 version & hash autoupdate

### DIFF
--- a/bucket/git-town.json
+++ b/bucket/git-town.json
@@ -10,6 +10,10 @@
         "64bit": {
             "url": "https://github.com/git-town/git-town/releases/download/v16.4.1/git-town_windows_intel_64.zip",
             "hash": "cb3aa373fe933ceb378e43fd9a2cc11a76a48e3f015b458b949752911df02aa2"
+        },
+        "arm64": {
+            "url": "https://github.com/git-town/git-town/releases/download/v16.4.1/git-town_windows_arm_64.zip",
+            "hash": "8475b76e3bac689f6abd20682be51b6e946465cf2031eb1f2bce19cbc922c18c"
         }
     },
     "bin": "git-town.exe",
@@ -20,7 +24,13 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/git-town/git-town/releases/download/v$version/git-town_windows_intel_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/git-town/git-town/releases/download/v$version/git-town_windows_arm_64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
- Add arm64 version.
- Add hash autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
