### PR TITLE
Update clink-completions.json

### DIFF
--- a/bucket/clink-completions.json
+++ b/bucket/clink-completions.json
@@ -1,14 +1,14 @@
 {
-    "version": "0.5.4",
+    "version": "0.6.0",
     "description": "Completions for various commands through Clink",
     "homepage": "https://github.com/vladimir-kotikov/clink-completions",
     "license": "MIT",
     "suggest": {
         "Clink": "clink"
     },
-    "url": "https://github.com/vladimir-kotikov/clink-completions/archive/v0.5.4.zip",
-    "hash": "33a32f1bb403c449d263c150710d693d84241dbcdbcacfb8d7d558f41346abbe",
-    "extract_dir": "clink-completions-0.5.4",
+    "url": "https://github.com/vladimir-kotikov/clink-completions/archive/v0.6.0.zip",
+    "hash": "a3668c6960a41abd2a07101791ec34c32d09dedec699b3dfd360a6bdd0de5ef6",
+    "extract_dir": "clink-completions-0.6.0",
     "installer": {
         "script": [
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",


### PR DESCRIPTION
This will fetch latest version of clink-completions (v0.6.0)

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
