### PR TITLE
nodejs: Update to 22.10.0

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,22 +1,22 @@
 {
-    "version": "22.9.0",
+    "version": "22.10.0",
     "description": "An asynchronous event driven JavaScript runtime designed to build scalable network applications.",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-x64.7z",
-            "hash": "805d4f842b2f85907fc28d1d631971bac5c1df691d7040cfa5e46d02534f98df",
+            "url": "https://nodejs.org/dist/v22.10.0/node-v22.10.0-win-x64.7z",
+            "hash": "c5105910002a7cf89eaacc27fb85cb2f8551c0f7797ac52118f2398210d6135e",
             "extract_dir": "node-v22.9.0-win-x64"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-x86.7z",
-            "hash": "3a6b798464794a0ac2452cf51e55df6f60f09598f724dd3eb890d64d99d81e5b",
+            "url": "https://nodejs.org/dist/v22.10.0/node-v22.10.0-win-x86.7z",
+            "hash": "b0149ff0fa094cc765c2e373b1010776bab18a2eac6a7d3800e0599f11da1aa3",
             "extract_dir": "node-v22.9.0-win-x86"
         },
         "arm64": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-arm64.7z",
-            "hash": "7a0a0a3998d989fe117f358e17ae0542ba264d2ae5c5681fc9d9ce8a666ce7b2",
+            "url": "https://nodejs.org/dist/v22.10.0/node-v22.10.0-win-arm64.7z",
+            "hash": "afc49ad90023d7809e7ed0d6b86167e476c21e6482c202e71b49a369302bcedf",
             "extract_dir": "node-v22.9.0-win-arm64"
         }
     },


### PR DESCRIPTION
For some reason, autoupdate didn't pick up this version

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
