### PR TITLE
Update git.json. Fix instructions for context menu and file association setup - add 'reg import'

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -6,9 +6,9 @@
     "notes": [
         "Set Git Credential Manager Core by running: \"git config --global credential.helper manager\"",
         "",
-        "To add context menu entries, run '$dir\\install-context.reg'",
+        "To add context menu entries, run 'reg import \"$dir\\install-context.reg\"'",
         "",
-        "To create file-associations for .git* and .sh files, run '$dir\\install-file-associations.reg'"
+        "To create file-associations for .git* and .sh files, run 'reg import \"$dir\\install-file-associations.reg\"'"
     ],
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Fix instructions for context menu and file association setup - add 'reg import'

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
