### PR TITLE
innounp@0.50: switch to maintained fork and update to v1.75

### DIFF
--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,16 +1,13 @@
 {
     "version": "1.75",
-    "description": "Inno Setup Unpacker",
-    "homepage": "https://www.rathlev-home.de/index-e.html?tools/prog-e.html#unpack",
-    "license": "LGPL",
+    "description": "Inno Setup Unpacker (Unicode)",
+    "homepage": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
+    "license": "GPL-3.0-only",
     "url": "https://www.rathlev-home.de/tools/download/innounp-1.zip",
     "hash": "4d7be8e6fadd4561d96158bbe4f45d4ca3439e258622ed97c161cb4f40ef49ab",
     "bin": "innounp.exe",
-    "checkver": {
-        "url": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
-        "regex": "executable - version ([\\d.]+)"
-    },
+    "checkver": "executable - version ([\\d.]+)",
     "autoupdate": {
-        "url": "https://www.rathlev-home.de/tools/download/innounp-$majorVersion.zip"
+        "url": "https://www.rathlev-home.de/tools/download/innounp-1.zip"
     }
 }

--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,15 +1,16 @@
 {
-    "version": "0.50",
+    "version": "1.73",
+    "url": "https://www.rathlev-home.de/tools/download/innounp-1.zip",
+    "bin": ["innounp.exe"],
+    "license": "LGPL",
     "description": "Inno Setup Unpacker",
-    "homepage": "https://innounp.sourceforge.net",
-    "license": "GPL-3.0-only",
-    "url": "https://downloads.sourceforge.net/project/innounp/innounp/innounp%200.50/innounp050.rar",
-    "hash": "sha1:6300e083d3560bc5d3eb4eb771c6aa57c6691d9b",
-    "bin": "innounp.exe",
+    "homepage": "https://www.rathlev-home.de/index-e.html?tools/prog-e.html#unpack",
+    "hash": "sha256:db670ce576bb89467358b6104be528a006b2e850a215703aadc485592cfc96ad",
     "checkver": {
-        "sourceforge": "innounp/innounp"
+        "url": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
+        "regex": "executable - version ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/innounp/innounp/innounp%20$version/innounp$cleanVersion.rar"
+        "url": "https://www.rathlev-home.de/tools/download/innounp-$majorVersion.zip"
     }
 }

--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,11 +1,11 @@
 {
-    "version": "1.73",
-    "url": "https://www.rathlev-home.de/tools/download/innounp-1.zip",
-    "bin": ["innounp.exe"],
-    "license": "LGPL",
+    "version": "1.75",
     "description": "Inno Setup Unpacker",
     "homepage": "https://www.rathlev-home.de/index-e.html?tools/prog-e.html#unpack",
-    "hash": "sha256:db670ce576bb89467358b6104be528a006b2e850a215703aadc485592cfc96ad",
+    "license": "LGPL",
+    "url": "https://www.rathlev-home.de/tools/download/innounp-1.zip",
+    "hash": "4d7be8e6fadd4561d96158bbe4f45d4ca3439e258622ed97c161cb4f40ef49ab",
+    "bin": "innounp.exe",
     "checkver": {
         "url": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
         "regex": "executable - version ([\\d.]+)"


### PR DESCRIPTION
# About this PR
<!-- Provide a general summary of your changes in the title above -->
Original version [Innounp](http://sourceforge.net/projects/innounp) (can be used up to InnoSetup 6.1)
    Updated Unicode version [Innounp-1](https://github.com/jrathlev/InnoUnpacker-Windows-GUI/blob/master/innounp-1) (can be used up to InnoSetup 6.3)

Innounp-1 supports Inno Setup versions 2.0.7 to 6.3.1

In my opinion, the new version should be used by default, and the old version should be placed in the versions repository.

# How to solve decompress errors for inno installers
To fix install/decompress errors for inno installers, use this until PR merge:
```
scoop bucket add versions
scoop install versions/innounp-unicode
```

# This PR fixes these issues:

### Extras

fix ScoopInstaller/Extras#14242, fix ScoopInstaller/Extras#14235, fix ScoopInstaller/Extras#14126, fix ScoopInstaller/Extras#14255, fix ScoopInstaller/Extras#14256, fix ScoopInstaller/Extras#14120, fix ScoopInstaller/Extras#14115, fix ScoopInstaller/Extras#14259, fix ScoopInstaller/Extras#14264, fix ScoopInstaller/Extras#14265, fix ScoopInstaller/Extras#14271, fix ScoopInstaller/Extras#14272, fix ScoopInstaller/Extras#14281, fix ScoopInstaller/Extras#14285, fix ScoopInstaller/Extras#14289, fix ScoopInstaller/Extras#14290, fix ScoopInstaller/Extras#14292, fix  ScoopInstaller/Extras#14296, fix ScoopInstaller/Extras#14306, fix ScoopInstaller/Extras#14310, fix ScoopInstaller/Extras#14317, fix ScoopInstaller/Extras#14318, fix ScoopInstaller/Extras#14321, fix ScoopInstaller/Extras#14329,  fix ScoopInstaller/Extras#14335, fix ScoopInstaller/Extras#14338

### Main

fix #6201, fix #6147, fix #6158, fix #6141, fix #6291, fix #6294, fix #6295, fix #6296



- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
