### PR TITLE
nodejs: Deprecate 32bit & Update to version 23.0.0

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,23 +1,18 @@
 {
-    "version": "22.9.0",
+    "version": "23.0.0",
     "description": "An asynchronous event driven JavaScript runtime designed to build scalable network applications.",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-x64.7z",
-            "hash": "805d4f842b2f85907fc28d1d631971bac5c1df691d7040cfa5e46d02534f98df",
-            "extract_dir": "node-v22.9.0-win-x64"
-        },
-        "32bit": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-x86.7z",
-            "hash": "3a6b798464794a0ac2452cf51e55df6f60f09598f724dd3eb890d64d99d81e5b",
-            "extract_dir": "node-v22.9.0-win-x86"
+            "url": "https://nodejs.org/dist/v23.0.0/node-v23.0.0-win-x64.7z",
+            "hash": "3978724c1ca71e18e0f2791c29ea8429a8586d253f41f503d71539294316c2ea",
+            "extract_dir": "node-v23.0.0-win-x64"
         },
         "arm64": {
-            "url": "https://nodejs.org/dist/v22.9.0/node-v22.9.0-win-arm64.7z",
-            "hash": "7a0a0a3998d989fe117f358e17ae0542ba264d2ae5c5681fc9d9ce8a666ce7b2",
-            "extract_dir": "node-v22.9.0-win-arm64"
+            "url": "https://nodejs.org/dist/v23.0.0/node-v23.0.0-win-arm64.7z",
+            "hash": "d384f7792812fdfdbbcce22da17684a65b21012e9644aec8eac986503723be57",
+            "extract_dir": "node-v23.0.0-win-arm64"
         }
     },
     "persist": [
@@ -34,7 +29,7 @@
     ],
     "checkver": {
         "url": "https://nodejs.org/dist/index.json",
-        "jsonpath": "$..version",
+        "jsonpath": "$[0].version",
         "regex": "v([\\d.]+)"
     },
     "autoupdate": {
@@ -42,10 +37,6 @@
             "64bit": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x64.7z",
                 "extract_dir": "node-v$version-win-x64"
-            },
-            "32bit": {
-                "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
-                "extract_dir": "node-v$version-win-x86"
             },
             "arm64": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",


### PR DESCRIPTION
Relates to https://github.com/ScoopInstaller/Versions/pull/1997
Closes #6257
- [Removing support for Windows 32-bit systems](https://github.com/nodejs/node/releases/tag/v23.0.0)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).