### PR TITLE
Use the Ninja executable from Meson directory

### DIFF
--- a/bucket/meson.json
+++ b/bucket/meson.json
@@ -3,10 +3,6 @@
     "description": "Open source build system meant to be both extremely fast and user friendly.",
     "homepage": "https://mesonbuild.com",
     "license": "Apache-2.0",
-    "suggest": {
-        "Ninja": "ninja",
-        "Python": "python"
-    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/mesonbuild/meson/releases/download/1.6.0/meson-1.6.0-64.msi",
@@ -14,7 +10,10 @@
         }
     },
     "extract_dir": "PFiles64\\Meson",
-    "bin": "meson.exe",
+    "bin": [
+        "meson.exe",
+        "ninja.exe"
+    ],
     "checkver": {
         "github": "https://github.com/mesonbuild/meson"
     },


### PR DESCRIPTION
Meson's installer includes the Ninja build executable. The manifest should create shim for the embedded ninja instead of suggesting user to install separately.

Python is also not needed at all to use Meson.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
