### PR TITLE
mariadb@11.5.2: Fix download url & autoupdate

### DIFF
--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -13,7 +13,7 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://downloads.mariadb.com/MariaDB/mariadb-11.5.2/winx64-packages/mariadb-11.5.2-winx64.zip",
+            "url": "https://archive.mariadb.org/mariadb-11.5.2/winx64-packages/mariadb-11.5.2-winx64.zip",
             "hash": "e800794421dfb82699af24b47ecf9efe4add7439b5e5eec33bffa569615c3f3f",
             "extract_dir": "mariadb-11.5.2-winx64"
         }
@@ -61,7 +61,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.mariadb.com/MariaDB/mariadb-$version/winx64-packages/mariadb-$version-winx64.zip",
+                "url": "https://archive.mariadb.org/mariadb-$version/winx64-packages/mariadb-$version-winx64.zip",
                 "extract_dir": "mariadb-$version-winx64"
             }
         },


### PR DESCRIPTION
Closes #6263.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
