### PR TITLE
prqlc: Fix autoupdate and update to version 0.13.2

### DIFF
--- a/bucket/prqlc.json
+++ b/bucket/prqlc.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.11.4",
+    "version": "0.13.2",
     "description": "A simple, powerful, pipelined SQL replacement",
     "homepage": "https://prql-lang.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PRQL/prql/releases/download/0.11.4/prqlc-v0.11.4-x86_64-pc-windows-msvc.zip",
-            "hash": "d9454249afbff07cf2b80093cccdaa79b6a97753759aff8f4dba7dbb9d70c4a3"
+            "url": "https://github.com/PRQL/prql/releases/download/0.13.2/prqlc-0.13.2-x86_64-pc-windows-msvc.zip",
+            "hash": "41ce826c8887fdc37e067478b04279435497e09332fff61746fe895c2f9ce022"
         }
     },
     "bin": "prqlc.exe",
@@ -16,7 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/PRQL/prql/releases/download/$version/prqlc-v$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/PRQL/prql/releases/download/$version/prqlc-$version-x86_64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
Fixes the autoupdate URL since "v" was removed from the version string.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
