### PR TITLE
fastfetch: drop 32bit support

### DIFF
--- a/bucket/fastfetch.json
+++ b/bucket/fastfetch.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.28.0",
+    "version": "2.30.0",
     "description": "A neofetch-like tool for fetching system information and displaying them in a pretty way",
     "homepage": "https://github.com/fastfetch-cli/fastfetch",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-amd64.7z",
-            "hash": "766f743730dfc2a79e1060ead7879a09966527ac350f33458636a1d3f26d2337"
+            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.30.0/fastfetch-windows-amd64.7z",
+            "hash": "9eeae8c7c21e3eaa8fa3964b72ee7f5a16c6832de70b897663a748a2cfc16320"
         },
         "arm64": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-aarch64.7z",
-            "hash": "c16d08eca689dfac0d8529c11f5c2c0364929549708a17312d77d2ce484a8af3"
+            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.30.0/fastfetch-windows-aarch64.7z",
+            "hash": "4954eb490845d184d1472b979f62504580dd804f220a405a23ca2508e0860c2e"
         }
     },
     "bin": [

--- a/bucket/fastfetch.json
+++ b/bucket/fastfetch.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.30.0",
-    "description": "A neofetch-like tool for fetching system information and displaying them in a pretty way",
+    "version": "2.30.1",
+    "description": "A maintained, feature-rich and performance oriented, neofetch like system information tool",
     "homepage": "https://github.com/fastfetch-cli/fastfetch",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.30.0/fastfetch-windows-amd64.7z",
-            "hash": "9eeae8c7c21e3eaa8fa3964b72ee7f5a16c6832de70b897663a748a2cfc16320"
+            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.30.1/fastfetch-windows-amd64.7z",
+            "hash": "c62f855fd1877848bcb5ca4ab9fca444dd85fb2c569e532a25b73d28c367b4b9"
         },
         "arm64": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.30.0/fastfetch-windows-aarch64.7z",
-            "hash": "4954eb490845d184d1472b979f62504580dd804f220a405a23ca2508e0860c2e"
+            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.30.1/fastfetch-windows-aarch64.7z",
+            "hash": "89159b608cf9ca7dbde0f33544654e6adddf490e43af5e46cf9ddfb7ffa0efc5"
         }
     },
     "bin": [

--- a/bucket/fastfetch.json
+++ b/bucket/fastfetch.json
@@ -8,10 +8,6 @@
             "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-amd64.7z",
             "hash": "766f743730dfc2a79e1060ead7879a09966527ac350f33458636a1d3f26d2337"
         },
-        "32bit": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-i686.7z",
-            "hash": "287e00d760d16095257d7a4bcce6de58363383622990ee97f84f88d8979a3899"
-        },
         "arm64": {
             "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-aarch64.7z",
             "hash": "c16d08eca689dfac0d8529c11f5c2c0364929549708a17312d77d2ce484a8af3"
@@ -26,9 +22,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/$version/fastfetch-windows-amd64.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/$version/fastfetch-windows-i686.7z"
             },
             "arm64": {
                 "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/$version/fastfetch-windows-aarch64.7z"


### PR DESCRIPTION
Newer version of fastfetch no longer provides 32bit binaries.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6372
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
