### PR TITLE
mergiraf: Add version 0.2.0

### DIFF
--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.2.0",
+    "description": "A syntax-aware git merge driver for a growing collection of programming languages and file formats.",
+    "homepage": "https://mergiraf.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "hash": "b3205197942bfec67b07b36532972196407db26095641a61fcb1b2bf698966c0",
+            "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.2.0/mergiraf_x86_64-pc-windows-gnu.zip"
+        }
+    },
+    "bin": "mergiraf.exe",
+    "checkver": {
+        "url": "https://codeberg.org/api/v1/repos/mergiraf/mergiraf/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "v([\\\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v$version/mergiraf_x86_64-pc-windows-gnu.zip"
+            }
+        }
+    }
+}

--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.0",
+    "version": "0.3.1",
     "description": "A syntax-aware git merge driver for a growing collection of programming languages and file formats.",
     "homepage": "https://mergiraf.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "hash": "b3205197942bfec67b07b36532972196407db26095641a61fcb1b2bf698966c0",
-            "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.2.0/mergiraf_x86_64-pc-windows-gnu.zip"
+            "hash": "63c11782036c4748ba368e7440e755088f8c2866d5d04d25f796de1e7858d266",
+            "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.3.1/mergiraf_x86_64-pc-windows-gnu.zip"
         }
     },
     "bin": "mergiraf.exe",

--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -13,7 +13,7 @@
     "checkver": {
         "url": "https://codeberg.org/api/v1/repos/mergiraf/mergiraf/releases/latest",
         "jsonpath": "$.tag_name",
-        "regex": "v([\\\\d.]+)"
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.3.1",
-    "description": "A syntax-aware git merge driver for a growing collection of programming languages and file formats.",
-    "homepage": "https://mergiraf.org/",
+    "version": "0.5.1",
+    "description": "A syntax-aware git merge driver",
+    "homepage": "https://mergiraf.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "hash": "63c11782036c4748ba368e7440e755088f8c2866d5d04d25f796de1e7858d266",
-            "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.3.1/mergiraf_x86_64-pc-windows-gnu.zip"
+            "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.5.1/mergiraf_x86_64-pc-windows-gnu.zip",
+            "hash": "c990aeb409d6b2c9187ba244bb08c893b5f30b51214b31d0a5a5b97ef67376e0"
         }
     },
     "bin": "mergiraf.exe",


### PR DESCRIPTION
Add [mergiraf](https://mergiraf.org/) 0.2.0: A syntax-aware git merge driver for a growing collection of programming languages and file formats.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
