### PR TITLE
spicetify-cli@2.38.4: Update URLs to organization repo

### DIFF
--- a/bucket/spicetify-cli.json
+++ b/bucket/spicetify-cli.json
@@ -9,25 +9,25 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/khanhas/spicetify-cli/releases/download/v2.38.4/spicetify-2.38.4-windows-x64.zip",
+            "url": "https://github.com/spicetify/cli/releases/download/v2.38.4/spicetify-2.38.4-windows-x64.zip",
             "hash": "85bee312474eed56b0d7a21eae24a5459ce11ae3fb67d703ee476aba5f251df1"
         },
         "32bit": {
-            "url": "https://github.com/khanhas/spicetify-cli/releases/download/v2.38.4/spicetify-2.38.4-windows-x32.zip",
+            "url": "https://github.com/spicetify/cli/releases/download/v2.38.4/spicetify-2.38.4-windows-x32.zip",
             "hash": "29d19f7dc7ec4445f32adc972d0a2b566edbfab65ec62900a5dc30cb95dc092d"
         }
     },
     "bin": "spicetify.exe",
     "checkver": {
-        "github": "https://github.com/khanhas/spicetify-cli"
+        "github": "https://github.com/spicetify/cli"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/khanhas/spicetify-cli/releases/download/v$version/spicetify-$version-windows-x64.zip"
+                "url": "https://github.com/spicetify/cli/releases/download/v$version/spicetify-$version-windows-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/khanhas/spicetify-cli/releases/download/v$version/spicetify-$version-windows-x32.zip"
+                "url": "https://github.com/spicetify/cli/releases/download/v$version/spicetify-$version-windows-x32.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #6319

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
