### PR TITLE
podman: Fix 'winsymlink' error

### DIFF
--- a/bucket/podman.json
+++ b/bucket/podman.json
@@ -13,8 +13,15 @@
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\podman-$version-setup.exe\" \"$dir\\_tmp\" -Removal",
-            "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\podman.msi\" \"$dir\" -ExtractDir 'PFiles64\\RedHat\\Podman'"
+            "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\podman.msi\" \"$dir\" -ExtractDir 'PFiles64\\RedHat\\Podman'",
+            "if (get_config USE_ISOLATED_PATH) {",
+            "    Add-Path -Path ('%' + $scoopPathEnvVar + '%') -Global:$global",
+            "}",
+            "Add-Path -Path $original_dir -TargetEnvVar $scoopPathEnvVar -Global:$global -Force"
         ]
+    },
+    "uninstaller": {
+        "script": "Remove-Path -Path $dir -TargetEnvVar $scoopPathEnvVar -Global:$global -Force"
     },
     "checkver": {
         "github": "https://github.com/containers/podman"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The change in `filePath.EvalSymlinks()` behavior in Go 1.23 has resulted in Podman versions after 5.3.0 being unable to locate `win-sshagent.exe`. Temporary fix refer to https://github.com/containers/podman/issues/24557#issuecomment-2490996716.

- Closes #6327

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
