### PR TITLE
lazydocker@0.24.1: Add arm64 version

### DIFF
--- a/bucket/lazydocker.json
+++ b/bucket/lazydocker.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/jesseduffield/lazydocker/releases/download/v0.24.1/lazydocker_0.24.1_Windows_x86.zip",
             "hash": "406244e71e0e63749d0e908d5a10da4d1a3033efc4d737068bf78506ef236171"
+        },
+        "arm64": {
+            "url": "https://github.com/jesseduffield/lazydocker/releases/download/v0.24.1/lazydocker_0.24.1_Windows_arm64.zip",
+            "hash": "8d965ff79409802ff620f744f91cb932be52b25c2a5ed7aa5131387645151eb8"
         }
     },
     "bin": "lazydocker.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://github.com/jesseduffield/lazydocker/releases/download/v$version/lazydocker_$version_Windows_x86.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/jesseduffield/lazydocker/releases/download/v$version/lazydocker_$version_Windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Add arm64 version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
