### PR TITLE
Remove kotlin-dce-js.bat from Kotlin 2.1.0

### DIFF
--- a/bucket/kotlin.json
+++ b/bucket/kotlin.json
@@ -15,7 +15,6 @@
         "bin\\kotlinc.bat",
         "bin\\kotlinc-js.bat",
         "bin\\kotlinc-jvm.bat",
-        "bin\\kotlin-dce-js.bat"
     ],
     "env_set": {
         "KOTLIN_HOME": "$dir"

--- a/bucket/kotlin.json
+++ b/bucket/kotlin.json
@@ -14,7 +14,7 @@
         "bin\\kotlin.bat",
         "bin\\kotlinc.bat",
         "bin\\kotlinc-js.bat",
-        "bin\\kotlinc-jvm.bat",
+        "bin\\kotlinc-jvm.bat"
     ],
     "env_set": {
         "KOTLIN_HOME": "$dir"


### PR DESCRIPTION
This file is not present in the bin folder

![image](https://github.com/user-attachments/assets/6b6aa1ae-7d09-42ca-86aa-fe4bc4b58e68)

- Fix #6344
- Close #6350 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
