### PR TITLE
kotlin@2.1.0: Remove deprecated binaries from manifest

### DIFF
--- a/bucket/kotlin.json
+++ b/bucket/kotlin.json
@@ -14,8 +14,7 @@
         "bin\\kotlin.bat",
         "bin\\kotlinc.bat",
         "bin\\kotlinc-js.bat",
-        "bin\\kotlinc-jvm.bat",
-        "bin\\kotlin-dce-js.bat"
+        "bin\\kotlinc-jvm.bat"
     ],
     "env_set": {
         "KOTLIN_HOME": "$dir"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Remove `kotlin-dce-js.bat` from manifest as it is [deprecated in 2.1.0](https://youtrack.jetbrains.com/issue/KT-70231).  
This fixes the error `Can't shim 'bin\kotlin-dce-js.bat': File doesn't exist.` while installing.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
