### PR TITLE
deno@2.1.2: Add autoupdate hash url

### DIFF
--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -1,27 +1,27 @@
 {
-  "version": "2.1.2",
-  "description": "A secure runtime for JavaScript and TypeScript",
-  "homepage": "https://deno.land",
-  "license": "MIT",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/denoland/deno/releases/download/v2.1.2/deno-x86_64-pc-windows-msvc.zip",
-      "hash": "e107bdd19cd38314c6ec934b7345e3139739c3a1106f951f6f70f8fb04f293e8"
-    }
-  },
-  "bin": "deno.exe",
-  "checkver": {
-    "github": "https://github.com/denoland/deno"
-  },
-  "autoupdate": {
+    "version": "2.1.2",
+    "description": "A secure runtime for JavaScript and TypeScript",
+    "homepage": "https://deno.land",
+    "license": "MIT",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/denoland/deno/releases/download/v$version/deno-x86_64-pc-windows-msvc.zip"
-      }
+        "64bit": {
+            "url": "https://github.com/denoland/deno/releases/download/v2.1.2/deno-x86_64-pc-windows-msvc.zip",
+            "hash": "e107bdd19cd38314c6ec934b7345e3139739c3a1106f951f6f70f8fb04f293e8"
+        }
     },
-    "hash": {
-      "url": "$url.sha256sum",
-      "regex": "([a-fA-F\\d]{64})"
+    "bin": "deno.exe",
+    "checkver": {
+        "github": "https://github.com/denoland/deno"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/denoland/deno/releases/download/v$version/deno-x86_64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256sum",
+            "regex": "([a-fA-F\\d]{64})"
+        }
     }
-  }
 }

--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -18,6 +18,9 @@
             "64bit": {
                 "url": "https://github.com/denoland/deno/releases/download/v$version/deno-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256sum"
         }
     }
 }

--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -1,26 +1,27 @@
 {
-    "version": "2.1.2",
-    "description": "A secure runtime for JavaScript and TypeScript",
-    "homepage": "https://deno.land",
-    "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/denoland/deno/releases/download/v2.1.2/deno-x86_64-pc-windows-msvc.zip",
-            "hash": "e107bdd19cd38314c6ec934b7345e3139739c3a1106f951f6f70f8fb04f293e8"
-        }
-    },
-    "bin": "deno.exe",
-    "checkver": {
-        "github": "https://github.com/denoland/deno"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/denoland/deno/releases/download/v$version/deno-x86_64-pc-windows-msvc.zip"
-            }
-        },
-        "hash": {
-            "url": "$url.sha256sum"
-        }
+  "version": "2.1.2",
+  "description": "A secure runtime for JavaScript and TypeScript",
+  "homepage": "https://deno.land",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/denoland/deno/releases/download/v2.1.2/deno-x86_64-pc-windows-msvc.zip",
+      "hash": "e107bdd19cd38314c6ec934b7345e3139739c3a1106f951f6f70f8fb04f293e8"
     }
+  },
+  "bin": "deno.exe",
+  "checkver": {
+    "github": "https://github.com/denoland/deno"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/denoland/deno/releases/download/v$version/deno-x86_64-pc-windows-msvc.zip"
+      }
+    },
+    "hash": {
+      "url": "$url.sha256sum",
+      "regex": "([a-fA-F\\d]{64})"
+    }
+  }
 }

--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.1.2",
+    "version": "2.1.4",
     "description": "A secure runtime for JavaScript and TypeScript",
     "homepage": "https://deno.land",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/denoland/deno/releases/download/v2.1.2/deno-x86_64-pc-windows-msvc.zip",
-            "hash": "e107bdd19cd38314c6ec934b7345e3139739c3a1106f951f6f70f8fb04f293e8"
+            "url": "https://github.com/denoland/deno/releases/download/v2.1.4/deno-x86_64-pc-windows-msvc.zip",
+            "hash": "d85abec3fc5533c20f1369b9c2fbb5f49348d1f69994779c09f56383bd46aa10"
         }
     },
     "bin": "deno.exe",
@@ -21,7 +21,7 @@
         },
         "hash": {
             "url": "$url.sha256sum",
-            "regex": "([a-fA-F\\d]{64})"
+            "regex": "$sha256"
         }
     }
 }


### PR DESCRIPTION
Adds autoupdate hash URL so Scoop does not have to download the artifact to calculate checksum.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
