### PR TITLE
pomsky@0.11: Add manifest

### DIFF
--- a/bucket/pomsky.json
+++ b/bucket/pomsky.json
@@ -1,0 +1,24 @@
+{
+    "version": "0.11",
+    "description": "Pomsky is a new, portable, regular expression language",
+    "homepage": "https://pomsky-lang.org",
+    "license": "MIT|Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/pomsky-lang/pomsky/releases/download/v0.11/pomsky_windows_v0.11.exe#/pomsky.exe",
+            "hash": "7cecff97b5b53deed8df4cdd861f5ef781273f6cd2571ba4c2f42f8b741dfe05"
+        }
+    },
+    "bin": "pomsky.exe",
+    "checkver": {
+        "url": "https://github.com/pomsky-lang/pomsky/releases",
+        "regex": "tag/v?([\\d.-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/pomsky-lang/pomsky/releases/download/v$version/pomsky_windows_v$version.exe#/pomsky.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pomsky is a portable, modern regular expression language, see more info at [here](https://pomsky-lang.org/).

And pomsky is dual-licensed under the [MIT license](https://opensource.org/licenses/MIT) or the [Apache 2.0 license](https://opensource.org/licenses/Apache-2.0).

This is a clean pr with commit history pruned, and closed #6227 as mentioned.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
