### PR TITLE
fastfetch: Update to version 2.31.0

### DIFF
--- a/bucket/fastfetch.json
+++ b/bucket/fastfetch.json
@@ -1,19 +1,15 @@
 {
-    "version": "2.28.0",
+    "version": "2.31.0",
     "description": "A neofetch-like tool for fetching system information and displaying them in a pretty way",
     "homepage": "https://github.com/fastfetch-cli/fastfetch",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-amd64.7z",
+            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.31.0/fastfetch-windows-amd64.7z",
             "hash": "766f743730dfc2a79e1060ead7879a09966527ac350f33458636a1d3f26d2337"
         },
-        "32bit": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-i686.7z",
-            "hash": "287e00d760d16095257d7a4bcce6de58363383622990ee97f84f88d8979a3899"
-        },
         "arm64": {
-            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.28.0/fastfetch-windows-aarch64.7z",
+            "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.31.0/fastfetch-windows-aarch64.7z",
             "hash": "c16d08eca689dfac0d8529c11f5c2c0364929549708a17312d77d2ce484a8af3"
         }
     },
@@ -26,9 +22,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/$version/fastfetch-windows-amd64.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/$version/fastfetch-windows-i686.7z"
             },
             "arm64": {
                 "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/$version/fastfetch-windows-aarch64.7z"

--- a/bucket/fastfetch.json
+++ b/bucket/fastfetch.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.31.0/fastfetch-windows-amd64.7z",
-            "hash": "766f743730dfc2a79e1060ead7879a09966527ac350f33458636a1d3f26d2337"
+            "hash": "BC0878E218CDF519DD22E53881B728A2F5DA446CECC8BC921A0EABEE5E642799"
         },
         "arm64": {
             "url": "https://github.com/fastfetch-cli/fastfetch/releases/download/2.31.0/fastfetch-windows-aarch64.7z",
-            "hash": "c16d08eca689dfac0d8529c11f5c2c0364929549708a17312d77d2ce484a8af3"
+            "hash": "E8E428CBF1CF0211F0DEA27F25B6FE44C589E92865A3E610065C9CC7751845D5"
         }
     },
     "bin": [


### PR DESCRIPTION
Apparently the 32-bit version has been removed — hence why the manifest has failed to update automatically.


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
