### PR TITLE
lua-language-server@3.13.3: releases are now stored under the organization LuaLS instead of sumneko

### DIFF
--- a/bucket/lua-language-server.json
+++ b/bucket/lua-language-server.json
@@ -1,15 +1,15 @@
 {
     "version": "3.13.3",
-    "homepage": "https://github.com/sumneko/lua-language-server",
+    "homepage": "https://github.com/LuaLS/lua-language-server",
     "description": "A language server written in Lua that offers Lua language support.",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sumneko/lua-language-server/releases/download/3.13.3/lua-language-server-3.13.3-win32-x64.zip",
+            "url": "https://github.com/LuaLS/lua-language-server/releases/download/3.13.3/lua-language-server-3.13.3-win32-x64.zip",
             "hash": "5c13e77561df4cef217da6ad0b735458122efd552868d18b887271fa4678460b"
         },
         "32bit": {
-            "url": "https://github.com/sumneko/lua-language-server/releases/download/3.13.3/lua-language-server-3.13.3-win32-ia32.zip",
+            "url": "https://github.com/LuaLS/lua-language-server/releases/download/3.13.3/lua-language-server-3.13.3-win32-ia32.zip",
             "hash": "868fe120df020dbce7176e9bca1c536da8a4ccbbeda4d07f4ab3cab5db16581d"
         }
     },
@@ -19,10 +19,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sumneko/lua-language-server/releases/download/$version/lua-language-server-$version-win32-x64.zip"
+                "url": "https://github.com/LuaLS/lua-language-server/releases/download/$version/lua-language-server-$version-win32-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/sumneko/lua-language-server/releases/download/$version/lua-language-server-$version-win32-ia32.zip"
+                "url": "https://github.com/LuaLS/lua-language-server/releases/download/$version/lua-language-server-$version-win32-ia32.zip"
             }
         }
     }


### PR DESCRIPTION
retrieve lua-language-server releases under the organization LuaLS instead of sumneko
- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
