### PR TITLE
colorscript@1.0: add initial manifest for Scoop installation

### DIFF
--- a/bucket/colorscript.json
+++ b/bucket/colorscript.json
@@ -6,7 +6,6 @@
     "homepage": "https://github.com/theamallalgi/colorscripts",
     "license": "MIT",
     "bin": ["colorscript"],
-    "man": ["colorscript.1"],
     "checkver": {
         "url": "https://github.com/theamallalgi/colorscripts/releases/latest",
         "regex": "/tag/(v[\\d.]+)"

--- a/bucket/colorscript.json
+++ b/bucket/colorscript.json
@@ -9,9 +9,13 @@
     "man": ["colorscript.1"],
     "checkver": {
         "url": "https://github.com/theamallalgi/colorscripts/releases/latest",
-        "regex": "tag/v([\\d.]+)"
+        "regex": "/tag/(v[\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/theamallalgi/colorscripts/archive/v$version.tar.gz"
+        "url": "https://github.com/theamallalgi/colorscripts/archive/refs/heads/main.zip",
+        "hash": {
+            "url": "https://github.com/theamallalgi/colorscripts/releases/latest",
+            "regex": "SHA256: ([a-f0-9]+)"
+        }
     }
 }

--- a/bucket/colorscript.json
+++ b/bucket/colorscript.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0",
+    "url": "https://github.com/theamallalgi/colorscripts/archive/refs/heads/main.zip",
+    "hash": "67d50b735d60049339e7d55c16f20a6bbfc4adeec0421bc0eb3b56b65d2dad74",
+    "description": "A CLI tool to run beautiful shell color scripts.",
+    "homepage": "https://github.com/theamallalgi/colorscripts",
+    "license": "MIT",
+    "bin": ["colorscript"],
+    "man": ["colorscript.1"],
+    "checkver": {
+        "url": "https://github.com/theamallalgi/colorscripts/releases/latest",
+        "regex": "tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/theamallalgi/colorscripts/archive/v$version.tar.gz"
+    }
+}


### PR DESCRIPTION
colorscript is a cli tool that displays ansi art on shells

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
