### PR TITLE
xcaddy@0.4.4: Add xcaddy

### DIFF
--- a/bucket/xcaddy.json
+++ b/bucket/xcaddy.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.4.4",
+    "description": "Command line tool and associated Go package makes it easy to make custom builds of the Caddy Web Server.",
+    "homepage": "https://caddyserver.com",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/caddyserver/xcaddy/releases/download/v0.4.4/xcaddy_0.4.4_windows_amd64.zip",
+            "hash": "sha512:cbc63529fd591742d67d68ca21c4cdb70a288cb91b20f2d9c711c34b4674d7beccd3aa774e5a6a4b7ea2c8fa92434911288c872b67fe56b8979eedd19130c041"
+        },
+        "arm64": {
+            "url": "https://github.com/caddyserver/xcaddy/releases/download/v0.4.4/xcaddy_0.4.4_windows_arm64.zip",
+            "hash": "sha512:f8ecb810f1ebe6afbd30c673d4fd8246a808a97c7f0be1544ebeccfc5beca91ad80dec2bdc0ccb9911db39ced648e3e8fe54f11c3abcb028c468858c08e3ce9f"
+        }
+    },
+    "bin": "xcaddy.exe",
+    "checkver": {
+        "github": "https://github.com/caddyserver/xcaddy"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/caddyserver/xcaddy/releases/download/v$version/xcaddy_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/caddyserver/xcaddy/releases/download/v$version/xcaddy_$version_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/xcaddy_$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Add [xcaddy](https://github.com/caddyserver/xcaddy).

Command line tool and associated Go package makes it easy to make custom builds of the Caddy Web Server.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
