### PR TITLE
qpdf: Use GitHub as download URLs

### DIFF
--- a/bucket/qpdf.json
+++ b/bucket/qpdf.json
@@ -1,18 +1,18 @@
 {
     "version": "11.9.1",
     "description": "A command-line program that does structural, content-preserving transformations on PDF files.",
-    "homepage": "https://qpdf.sourceforge.net/",
+    "homepage": "https://qpdf.sourceforge.io",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/qpdf/qpdf/11.9.1/qpdf-11.9.1-mingw64.zip",
-            "hash": "sha1:568f76295408b6772bb16f18129342348e708f86",
-            "extract_dir": "qpdf-11.9.1-mingw64"
+            "url": "https://github.com/qpdf/qpdf/releases/download/v11.9.1/qpdf-11.9.1-msvc64.zip",
+            "hash": "b5061e09aa45b63a36200c130b4cce15dc322338ea91f698760c3b8732fc41ef",
+            "extract_dir": "qpdf-11.9.1-msvc64"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/qpdf/qpdf/11.9.1/qpdf-11.9.1-mingw32.zip",
-            "hash": "sha1:eab59e265d35f0278120c92cc45d9ef1bcbb024a",
-            "extract_dir": "qpdf-11.9.1-mingw32"
+            "url": "https://github.com/qpdf/qpdf/releases/download/v11.9.1/qpdf-11.9.1-msvc32.zip",
+            "hash": "08e077a8c9c923eac2033dd4d5f35acc2ae8fc31d1b6c95402ec17dde0064c2f",
+            "extract_dir": "qpdf-11.9.1-msvc32"
         }
     },
     "bin": [
@@ -20,19 +20,21 @@
         "bin\\fix-qdf.exe"
     ],
     "checkver": {
-        "github": "https://github.com/qpdf/qpdf",
-        "regex": "qpdf-([\\d.]+)-"
+        "github": "https://github.com/qpdf/qpdf"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/qpdf/qpdf/$version/qpdf-$version-mingw64.zip",
-                "extract_dir": "qpdf-$version-mingw64"
+                "url": "https://github.com/qpdf/qpdf/releases/download/v$version/qpdf-$version-msvc64.zip",
+                "extract_dir": "qpdf-$version-msvc64"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/qpdf/qpdf/$version/qpdf-$version-mingw32.zip",
-                "extract_dir": "qpdf-$version-mingw32"
+                "url": "https://github.com/qpdf/qpdf/releases/download/v$version/qpdf-$version-msvc32.zip",
+                "extract_dir": "qpdf-$version-msvc32"
             }
+        },
+        "hash": {
+            "url": "$baseurl/qpdf-$version.sha256"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Change download URL to GitHub, as it's more robust.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
