### PR TITLE
osslsigncode: Update to version 2.9, drop 32bit support

### DIFF
--- a/bucket/osslsigncode.json
+++ b/bucket/osslsigncode.json
@@ -1,16 +1,12 @@
 {
-    "version": "2.7",
+    "version": "2.9",
     "description": "OpenSSL based Authenticode signing for PE/MSI/Java CAB files",
     "homepage": "https://github.com/mtrojnar/osslsigncode",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mtrojnar/osslsigncode/releases/download/2.7/osslsigncode-2.7-windows-x64-vs.zip",
-            "hash": "b85003c4dcd0ae4696386cdbae8bb32b80fff46a92648173bc380cb6e30c4a0f"
-        },
-        "32bit": {
-            "url": "https://github.com/mtrojnar/osslsigncode/releases/download/2.7/osslsigncode-2.7-windows-x86-vs.zip",
-            "hash": "6565f1a7fe1e24aff3fdfa3b04d2da1032f808c487958e2258aab2b67f2244b3"
+            "url": "https://github.com/mtrojnar/osslsigncode/releases/download/2.9/osslsigncode-2.9-windows-x64-mingw.zip",
+            "hash": "2b7662a2a9072095906df80ba6e1d5aa29f2a288f4a7aa1f2190c5cdf7805d73"
         }
     },
     "bin": "bin\\osslsigncode.exe",
@@ -18,11 +14,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mtrojnar/osslsigncode/releases/download/$version/osslsigncode-$version-windows-x64-vs.zip"
+                "url": "https://github.com/mtrojnar/osslsigncode/releases/download/$version/osslsigncode-$version-windows-x64-mingw.zip"
             },
-            "32bit": {
-                "url": "https://github.com/mtrojnar/osslsigncode/releases/download/$version/osslsigncode-$version-windows-x86-vs.zip"
-            }
         }
     }
 }

--- a/bucket/osslsigncode.json
+++ b/bucket/osslsigncode.json
@@ -15,7 +15,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/mtrojnar/osslsigncode/releases/download/$version/osslsigncode-$version-windows-x64-mingw.zip"
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
As the URL changed

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
