### PR TITLE
Fix regex patterns `checkver` field for rustup

### DIFF
--- a/bucket/rustup-gnu.json
+++ b/bucket/rustup-gnu.json
@@ -32,8 +32,8 @@
         ".rustup"
     ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/rust-lang-nursery/rustup.rs/master/Cargo.toml",
-        "regex": "version = \"([\\d.]+)\""
+        "url": "https://raw.githubusercontent.com/rust-lang/rustup.rs/master/Cargo.toml",
+        "regex": "version = \"([\\d.]+)\"\nedition"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/rustup-msvc.json
+++ b/bucket/rustup-msvc.json
@@ -39,8 +39,8 @@
         ".rustup"
     ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/rust-lang-nursery/rustup.rs/master/Cargo.toml",
-        "regex": "version = \"([\\d.]+)\""
+        "url": "https://raw.githubusercontent.com/rust-lang/rustup.rs/master/Cargo.toml",
+        "regex": "version = \"([\\d.]+)\"\nedition"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -43,8 +43,8 @@
         ".rustup"
     ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/rust-lang-nursery/rustup.rs/master/Cargo.toml",
-        "regex": "version = \"([\\d.]+)\""
+        "url": "https://raw.githubusercontent.com/rust-lang/rustup.rs/master/Cargo.toml",
+        "regex": "version = \"([\\d.]+)\"\nedition"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Updated the `rustup` URLs to point to the new repository location.
- Modified the regex pattern `checkver` field to match rustup version.

---

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
