### PR TITLE
nu@0.101.0: Add 1) shortcut 2) uninstall `--purge` logic

### DIFF
--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -14,6 +14,26 @@
         }
     },
     "bin": "nu.exe",
+    "shortcuts": [
+        [
+            "nu.exe",
+            "Nushell",
+            "--execute \"cd ~\""
+        ]
+    ],
+    "post_uninstall": [
+        "if ($purge) {",
+        "    $Directories = [string[]](",
+        "        [System.IO.Path]::Combine($env:APPDATA,'nushell'),",
+        "        [System.IO.Path]::Combine($env:LOCALAPPDATA,'nushell')",
+        "    )",
+        "    $Directories.ForEach{",
+        "        if ([System.IO.Directory]::Exists($_)) {",
+        "            $null = [System.IO.Directory]::Delete($_,$true)",
+        "        }",
+        "    }",
+        "}"
+    ],
     "checkver": {
         "github": "https://github.com/nushell/nushell"
     },

--- a/bucket/nu.json
+++ b/bucket/nu.json
@@ -45,6 +45,9 @@
             "arm64": {
                 "url": "https://github.com/nushell/nushell/releases/download/$version/nu-$version-aarch64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }


### PR DESCRIPTION
This PR adds:

* Shortcut "Nushell" that opens to `~`
  * Similar to <https://github.com/ScoopInstaller/Main/blob/master/bucket/pwsh.json>.
* Logic for `scoop uninstall --purge` that remove leftovers.

Nushell maintainers did not oppose these changes:

* <https://github.com/nushell/nushell/issues/14787>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
