### PR TITLE
crystal: add package manager `shards.exe` to the system path

### DIFF
--- a/bucket/crystal.json
+++ b/bucket/crystal.json
@@ -9,7 +9,10 @@
             "hash": "743e08b86e41051985fa0e85375eeebc62efcccbce05bf5944be6a15f849f369"
         }
     },
-    "bin": "crystal.exe",
+    "bin": [
+        "crystal.exe",
+        "shards.exe"
+    ],
     "shortcuts": [
         [
             "crystal.exe",


### PR DESCRIPTION
Adds the crystal language package manager `shards.exe` to the system path, closes #6447.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
