### PR TITLE
mise: manifest updated to more portable config

### DIFF
--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -17,12 +17,12 @@
     "bin": "bin/mise.exe",
     "env_set": {
         "MISE_DATA_DIR": "$dir\\mise",
-        "MISE_GLOBAL_CONFIG_ROOT": "$dir\\config"
+        "MISE_GLOBAL_CONFIG_FILE": "$dir\\config.toml"
     },
     "env_add_path": "mise\\shims",
     "persist": [
         "mise",
-        "config"
+        "config.toml"
     ],
     "notes": "See documentation for notes on configuring your shell: https://mise.jdx.dev/installing-mise.html",
     "checkver": {

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -16,7 +16,7 @@
     "extract_dir": "mise",
     "bin": "bin/mise.exe",
     "pre_install": [
-        "if (![IO.File]::Exists(\"$dir\\config.toml\")) {",
+        "if (!(Test-Path \"$persist_dir\\config.toml\") -and !(Test-Path \"$dir\\config.toml\")) {",
         "  New-Item -Path \"$dir\\config.toml\" -ItemType File -ea 0 | Out-Null",
         "}"
     ],

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -1,6 +1,6 @@
 {
     "version": "2025.1.7",
-    "description": "Dev tools, env vars, task runner",
+    "description": "Polyglot tool version manager and task runner",
     "homepage": "https://mise.jdx.dev/",
     "license": "MIT",
     "architecture": {

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -16,10 +16,15 @@
     "extract_dir": "mise",
     "bin": "bin/mise.exe",
     "env_set": {
-        "MISE_DATA_DIR": "$dir\\mise"
+        "MISE_DATA_DIR": "$dir\\mise",
+        "MISE_GLOBAL_CONFIG_ROOT": "$dir\\config"
     },
     "env_add_path": "mise\\shims",
-    "persist": "mise",
+    "persist": [
+        "mise",
+        "config"
+    ],
+    "notes": "See documentation for notes on configuring your shell: https://mise.jdx.dev/installing-mise.html",
     "checkver": {
         "github": "https://github.com/jdx/mise"
     },

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -1,7 +1,7 @@
 {
     "version": "2025.1.6",
-    "description": "Dev tools, env vars, task runner",
-    "homepage": "https://mise.jdx.dev/",
+    "description": "Polyglot tool version manager and task runner",
+    "homepage": "https://mise.jdx.dev",
     "license": "MIT",
     "architecture": {
         "64bit": {
@@ -15,25 +15,11 @@
     },
     "extract_dir": "mise",
     "bin": "bin/mise.exe",
-    "installer": {
-        "script": "Add-Path -Path \"$env:LOCALAPPDATA\\mise\\shims\" -Global:$global"
+    "env_set": {
+        "MISE_DATA_DIR": "$dir\\mise"
     },
-    "uninstaller": {
-        "script": "Remove-Path -Path \"$env:LOCALAPPDATA\\mise\\shims\" -Global:$global"
-    },
-    "post_uninstall": [
-        "if ($purge) {",
-        "    $Directories = [string[]](",
-        "        ('{0}\\mise' -f $env:LOCALAPPDATA),",
-        "        ('{0}\\Temp\\mise' -f $env:LOCALAPPDATA)",
-        "    )",
-        "    $Directories.ForEach{",
-        "        if (Test-Path -Path $_ -PathType 'Container') {",
-        "            $null = Remove-Item -Path $_ -Recurse -Force",
-        "        }",
-        "    }",
-        "}"
-    ],
+    "env_add_path": "mise\\shims",
+    "persist": "mise",
     "checkver": {
         "github": "https://github.com/jdx/mise"
     },

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -17,7 +17,7 @@
     "bin": "bin/mise.exe",
     "pre_install": [
         "if (![IO.File]::Exists(\"$dir\\config.toml\")) {",
-        "  New-Item -ItemType File -Verbose -Path \"$dir\\config.toml\"",
+        "  New-Item -Path \"$dir\\config.toml\" -ItemType File -ea 0 | Out-Null",
         "}"
     ],
     "env_set": {

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -15,6 +15,11 @@
     },
     "extract_dir": "mise",
     "bin": "bin/mise.exe",
+    "pre_install": [
+        "if (![IO.File]::Exists(\"$dir\\config.toml\")) {",
+        "  New-Item -ItemType File -Verbose -Path \"$dir\\config.toml\"",
+        "}"
+    ],
     "env_set": {
         "MISE_DATA_DIR": "$dir\\mise",
         "MISE_GLOBAL_CONFIG_FILE": "$dir\\config.toml"

--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -17,7 +17,7 @@
     "bin": "bin/mise.exe",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\config.toml\") -and !(Test-Path \"$dir\\config.toml\")) {",
-        "  New-Item -Path \"$dir\\config.toml\" -ItemType File -ea 0 | Out-Null",
+        "    New-Item -Path \"$dir\\config.toml\" -ItemType File -ea 0 | Out-Null",
         "}"
     ],
     "env_set": {


### PR DESCRIPTION
Included manifest changes suggested by @chawyehsu in PR comment which sets the internal mise configurable env var MISE_DATA_DIR to a directory that scoop persists

Relates to #6374

- removed install/uninstall scripts
- set env var `MISE_DATA_DIR` to a directory inside scoop and persist it
- add the directory mise places its own shims to the Path env var
- set env var `MISE_GLOBAL_CONFIG_FILE` to file inside app install dir and persist it
- added pre_install script to check mise config.toml exists or is created as a file
- added note about configuring specific shells with link to mise docs