### PR TITLE
git@2.47.1.2: Add arm64 version

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -18,6 +18,10 @@
         "32bit": {
             "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/PortableGit-2.47.1.2-32-bit.7z.exe#/dl.7z",
             "hash": "b1b1715676b1aaf0cdffe7287c70c37a94408fd872d538f4b00834d278a9e02f"
+        },
+        "arm64": {
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.2/PortableGit-2.47.1.2-arm64.7z.exe#/dl.7z",
+            "hash": "6f554b6f0fb9e76448f42c2b0dd9c4c59f0a1d0df0c38c1a9029ebd9c49532b5"
         }
     },
     "post_install": [
@@ -71,6 +75,9 @@
             },
             "32bit": {
                 "url": "https://github.com/git-for-windows/git/releases/download/v$matchTag/PortableGit-$version-32-bit.7z.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/git-for-windows/git/releases/download/v$matchTag/PortableGit-$version-arm64.7z.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
Adds the arm64 version of git

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)