### PR TITLE
confluent-cli@4.16.0: fix checksum url

### DIFF
--- a/bucket/confluent-cli.json
+++ b/bucket/confluent-cli.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.48.0",
+    "version": "4.16.0",
     "description": "The Confluent command-line interface (CLI)",
     "license": "https://github.com/confluentinc/cli/blob/main/LICENSE",
     "homepage": "https://docs.confluent.io/confluent-cli/current/overview.html",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/confluentinc/cli/releases/download/v3.48.0/confluent_3.48.0_windows_amd64.zip",
-            "hash": "c3180a27d2b6f4f62af24a8444ce40e7a5621305828d2d15acf0ebe93731ec48"
+            "url": "https://github.com/confluentinc/cli/releases/download/v4.16.0/confluent_4.16.0_windows_amd64.zip",
+            "hash": "d0e665706101236b51945c3484803726d1dbb67889b897e2e90e5c388f9178a0"
         }
     },
     "extract_dir": "confluent",

--- a/bucket/confluent-cli.json
+++ b/bucket/confluent-cli.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.16.0",
+    "version": "4.24.0",
     "description": "The Confluent command-line interface (CLI)",
     "license": "https://github.com/confluentinc/cli/blob/main/LICENSE",
     "homepage": "https://docs.confluent.io/confluent-cli/current/overview.html",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/confluentinc/cli/releases/download/v4.16.0/confluent_4.16.0_windows_amd64.zip",
-            "hash": "d0e665706101236b51945c3484803726d1dbb67889b897e2e90e5c388f9178a0"
+            "url": "https://github.com/confluentinc/cli/releases/download/v4.24.0/confluent_4.24.0_windows_amd64.zip",
+            "hash": "8acc60fb64b509dd3120ff600bbdd3534a9614738efd1394e23f977a485fa2e2"
         }
     },
     "extract_dir": "confluent",

--- a/bucket/confluent-cli.json
+++ b/bucket/confluent-cli.json
@@ -21,7 +21,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/confluent_$version_checksums.txt"
+            "url": "$baseurl/confluent_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Confluent changed the filename of the checksum txt file.

![grafik](https://github.com/user-attachments/assets/402e45b7-bf67-4e30-8a35-c1524bf6e548)


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
