### PR TITLE
pulumi@3.148.0: 🐛 Add pulumi exe files to bin

### DIFF
--- a/bucket/pulumi.json
+++ b/bucket/pulumi.json
@@ -10,7 +10,16 @@
         }
     },
     "extract_dir": "Pulumi\\bin",
-    "bin": "pulumi.exe",
+    "bin": [
+        "pulumi.exe",
+        "pulumi-language-dotnet.exe",
+        "pulumi-language-go.exe",
+        "pulumi-language-java.exe",
+        "pulumi-language-nodejs.exe",
+        "pulumi-language-python.exe",
+        "pulumi-language-yaml.exe",
+        "pulumi-watch.exe"
+    ],
     "checkver": {
         "url": "https://www.pulumi.com/docs/get-started/install/versions",
         "regex": "<strong>([\\d.]+)"

--- a/bucket/pulumi.json
+++ b/bucket/pulumi.json
@@ -12,12 +12,19 @@
     "extract_dir": "Pulumi\\bin",
     "bin": [
         "pulumi.exe",
+        "pulumi-analyzer-policy-python.cmd",
+        "pulumi-analyzer-policy.cmd",
         "pulumi-language-dotnet.exe",
         "pulumi-language-go.exe",
         "pulumi-language-java.exe",
         "pulumi-language-nodejs.exe",
+        "pulumi-language-python-exec",
         "pulumi-language-python.exe",
         "pulumi-language-yaml.exe",
+        "pulumi-python-shim.cmd",
+        "pulumi-python3-shim.cmd",
+        "pulumi-resource-pulumi-nodejs.cmd",
+        "pulumi-resource-pulumi-python.cmd",
         "pulumi-watch.exe"
     ],
     "checkver": {


### PR DESCRIPTION
Pulumi depends on additional exe files to perform certain tasks.  If these files are not in the PATH, pulumi is unable to find them and throws errors.

Closes #6511 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
