### PR TITLE
pacparser: update to v1.4.5 & fix autoupdate

### DIFF
--- a/bucket/pacparser.json
+++ b/bucket/pacparser.json
@@ -1,13 +1,12 @@
 {
-    "version": "1.4.3",
+    "version": "1.4.5",
     "description": "A library to parse proxy auto-config (PAC) files",
     "homepage": "https://github.com/manugarg/pacparser",
     "license": "LGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/manugarg/pacparser/releases/download/v1.4.3/pacparser-v1.4.3-windows.zip",
-            "hash": "460b25bd1b95c552349b2600981815be92887b1061c782a6752ed348f9189dc4",
-            "extract_dir": "pacparser-v1.4.3-windows"
+            "url": "https://github.com/manugarg/pacparser/releases/download/v1.4.5/pacparser-v1.4.5-windows-x86_64.zip",
+            "hash": "9c657c363a7a5d2e1c07f7c3ce1277df0cd4a12b1c6fd47bd35194e80cb84b7f"
         }
     },
     "bin": "pactester.exe",
@@ -15,8 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/manugarg/pacparser/releases/download/v$version/pacparser-v$version-windows.zip",
-                "extract_dir": "pacparser-v$version-windows"
+                "url": "https://github.com/manugarg/pacparser/releases/download/v$version/pacparser-v$version-windows-x86_64.zip"
             }
         }
     }


### PR DESCRIPTION
Update `pacparser` to its latest version (v1.4.5), fix `extract_dir` issue and fix autoupdate.

Closes #6526

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)