### PR TITLE
podman: revert workaround needed for v5.3

### DIFF
--- a/bucket/podman.json
+++ b/bucket/podman.json
@@ -13,15 +13,8 @@
     "installer": {
         "script": [
             "Expand-DarkArchive \"$dir\\podman-$version-setup.exe\" \"$dir\\_tmp\" -Removal",
-            "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\podman.msi\" \"$dir\" -ExtractDir 'PFiles64\\RedHat\\Podman'",
-            "if (get_config USE_ISOLATED_PATH) {",
-            "    Add-Path -Path ('%' + $scoopPathEnvVar + '%') -Global:$global",
-            "}",
-            "Add-Path -Path $original_dir -TargetEnvVar $scoopPathEnvVar -Global:$global -Force"
+            "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\podman.msi\" \"$dir\" -ExtractDir 'PFiles64\\RedHat\\Podman'"
         ]
-    },
-    "uninstaller": {
-        "script": "Remove-Path -Path $dir -TargetEnvVar $scoopPathEnvVar -Global:$global -Force"
     },
     "checkver": {
         "github": "https://github.com/containers/podman"


### PR DESCRIPTION
Podman 5.4 includes a proper fix for #6327
and the workaround introduced in #6335 can
be reverted

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
