### PR TITLE
git-filter-repo: Fix decompress error

### DIFF
--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -7,12 +7,18 @@
         "Git": "git",
         "Python 3": "python"
     },
-    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.7z",
+    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.bin",
     "hash": "8f3d099bf91ceac6cae60d79aac701e9bc08fd0eed67c601cc5dd401d5788871",
-    "pre_install": "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
+    "installer": {
+        "script": [
+            "Expand-ZipArchive -Path \"$dir\\dl.bin\" -DestinationPath \"$dir\" -Removal",
+            "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
+            "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null"
+        ]
+    },
     "bin": "git-filter-repo",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.7z"
+        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.bin"
     }
 }

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -7,18 +7,12 @@
         "Git": "git",
         "Python 3": "python"
     },
-    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.bin",
+    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.7z",
     "hash": "8f3d099bf91ceac6cae60d79aac701e9bc08fd0eed67c601cc5dd401d5788871",
-    "installer": {
-        "script": [
-            "Expand-ZipArchive -Path \"$dir\\dl.bin\" -DestinationPath \"$dir\" -Removal",
-            "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
-            "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null"
-        ]
-    },
+    "pre_install": "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
     "bin": "git-filter-repo",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.bin"
+        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.7z"
     }
 }

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -7,11 +7,11 @@
         "Git": "git",
         "Python 3": "python"
     },
-    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.bin",
+    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.zip_",
     "hash": "8f3d099bf91ceac6cae60d79aac701e9bc08fd0eed67c601cc5dd401d5788871",
     "installer": {
         "script": [
-            "Expand-ZipArchive -Path \"$dir\\dl.bin\" -DestinationPath \"$dir\" -Removal",
+            "Expand-ZipArchive -Path \"$dir\\dl.zip_\" -DestinationPath \"$dir\" -Removal",
             "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
             "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null"
         ]
@@ -19,6 +19,6 @@
     "bin": "git-filter-repo",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.bin"
+        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.zip_"
     }
 }

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -12,8 +12,7 @@
     "installer": {
         "script": [
             "Expand-ZipArchive -Path \"$dir\\dl.zip_\" -DestinationPath \"$dir\" -Removal",
-            "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
-            "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null"
+            "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\""
         ]
     },
     "bin": "git-filter-repo",

--- a/bucket/git-filter-repo.json
+++ b/bucket/git-filter-repo.json
@@ -7,13 +7,18 @@
         "Git": "git",
         "Python 3": "python"
     },
-    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip",
+    "url": "https://github.com/newren/git-filter-repo/archive/v2.47.0.zip#/dl.bin",
     "hash": "8f3d099bf91ceac6cae60d79aac701e9bc08fd0eed67c601cc5dd401d5788871",
-    "pre_install": "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
-    "post_install": "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null",
+    "installer": {
+        "script": [
+            "Expand-ZipArchive -Path \"$dir\\dl.bin\" -DestinationPath \"$dir\" -Removal",
+            "Move-Item \"$dir\\git-filter-repo-*\\*\" \"$dir\"; Remove-Item \"$dir\\git-filter-repo-*\"",
+            "Copy-Item \"$dir\\git-filter-repo\" \"$dir\\contrib\\filter-repo-demos\" | Out-Null"
+        ]
+    },
     "bin": "git-filter-repo",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip"
+        "url": "https://github.com/newren/git-filter-repo/archive/v$version.zip#/dl.bin"
     }
 }


### PR DESCRIPTION
Use `Expand-ZipArchive` instead of `Expand-7zArchive` to resolve #6451.

Closes #6451
Relates to #6519 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)