### PR TITLE
Update mongodb.json Set-Content command

### DIFF
--- a/bucket/mongodb.json
+++ b/bucket/mongodb.json
@@ -31,7 +31,7 @@
         "    $cfg = Get-Content \"$dir\\bin\\mongod.cfg\"",
         "    $cfg = $cfg -replace '%MONGO_DATA_PATH%', \"$dir\\data\"",
         "    $cfg = $cfg -replace '%MONGO_LOG_PATH%', \"$dir\\log\"",
-        "    Set-Content \"$dir\\bin\\mongod.cfg\" $cfg -Encoding Ascii -Force",
+        "    Set-Content -Path \"$dir\\bin\\mongod.cfg\" -Value \"$cfg\" -Encoding Ascii -Force",
         "}"
     ],
     "bin": [


### PR DESCRIPTION
scoop.cmd cannot execute Set-Content command in mongodb.json's pre_install script properly.

See https://github.com/ScoopInstaller/Scoop/issues/6289