### PR TITLE
git-absorb@0.6.17: Bump

### DIFF
--- a/bucket/git-absorb.json
+++ b/bucket/git-absorb.json
@@ -11,6 +11,7 @@
         }
     },
     "bin": "git-absorb.exe",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/git-absorb.json
+++ b/bucket/git-absorb.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.6.15",
+    "version": "0.6.17",
     "description": "git commit --fixup, but automatic",
     "homepage": "https://github.com/tummychow/git-absorb",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tummychow/git-absorb/releases/download/0.6.15/git-absorb-0.6.15-x86_64-pc-windows-msvc.zip",
-            "hash": "fa8b3a0890c17322e0ed33ee14a8b8c222e36df138cdce2986070f47fd56b429",
-            "extract_dir": "git-absorb-0.6.15-x86_64-pc-windows-msvc"
+            "url": "https://github.com/tummychow/git-absorb/releases/download/0.6.17/git-absorb-0.6.17-x86_64-pc-windows-msvc.zip",
+            "hash": "7ed320976daf99d7c47f74b6ceae9c8cee572f2e93181377d9b410326fd83acd",
+            "extract_dir": "git-absorb-0.6.17-x86_64-pc-windows-msvc"
         }
     },
     "bin": "git-absorb.exe",


### PR DESCRIPTION
Update git-absorb to 0.6.17

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
