### PR TITLE
stylua@v2.0.2: update to version 2.0.2, fix autoupdate

### DIFF
--- a/bucket/stylua.json
+++ b/bucket/stylua.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.20.0",
+    "version": "2.0.2",
     "description": "An opinionated Lua code formatter",
     "homepage": "https://github.com/JohnnyMorganz/StyLua",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v0.20.0/stylua-win64.zip",
-            "hash": "1623af48183bbdda9a03c39ef35c1888ced8d4d14c9730f8b92783a7ebe3b3b6"
+            "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v2.0.2/stylua-windows-x86_64.zip",
+            "hash": "b88b32417a37af623698fa4ba0bed9abf3a777a2cbf532b4c4313d7ec9679aee"
         }
     },
     "bin": "stylua.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v$version/stylua-win64.zip"
+                "url": "https://github.com/JohnnyMorganz/StyLua/releases/download/v$version/stylua-windows-x86_64.zip"
             }
         }
     }


### PR DESCRIPTION
Relates to scoop being unable to find the latest versions of stylua due to a file name change introduced in [v2.0.0](https://github.com/JohnnyMorganz/StyLua/releases/tag/v2.0.0).

Fixes #6550.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
