### PR TITLE
zstd@1.5.7: Corrected zstd hashes for v1.5.7 release.

### DIFF
--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -6,12 +6,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-v1.5.7-win64.zip",
-            "hash": "f5d69e0fa1013d7e5014b3f55b55282fcf5ac76b2be8b89601ba039eedad4688",
+            "hash": "6ae72e3d0a5d53c5aaa74638499d3715d25625b71bf3bc9d72c3f4a3ed4d8ca4",
             "extract_dir": "zstd-v1.5.7-win64"
         },
         "32bit": {
             "url": "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-v1.5.7-win32.zip",
-            "hash": "9bc4d51e83286f132c18def6399a3802a8c36260ea02b3dc595fbaa08e65a198",
+            "hash": "58d5ff77b9c578debf3108ec874767a9eebe47f954948c3a56b7c5f538ed3e1c",
             "extract_dir": "zstd-v1.5.7-win32"
         }
     },


### PR DESCRIPTION
Updated the hashes in the zstd v1.5.7 manifest, after they were changed in response to https://github.com/facebook/zstd/issues/4304.

Closes #6557

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)