### PR TITLE
mergiraf: Correct license

### DIFF
--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -2,7 +2,7 @@
     "version": "0.5.1",
     "description": "A syntax-aware git merge driver",
     "homepage": "https://mergiraf.org",
-    "license": "MIT",
+    "license": "GPLv3",
     "architecture": {
         "64bit": {
             "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.5.1/mergiraf_x86_64-pc-windows-gnu.zip",

--- a/bucket/mergiraf.json
+++ b/bucket/mergiraf.json
@@ -2,7 +2,7 @@
     "version": "0.5.1",
     "description": "A syntax-aware git merge driver",
     "homepage": "https://mergiraf.org",
-    "license": "GPLv3",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://codeberg.org/mergiraf/mergiraf/releases/download/v0.5.1/mergiraf_x86_64-pc-windows-gnu.zip",


### PR DESCRIPTION
Thanks for packaging Mergiraf!

I noticed that the license is wrong (see https://codeberg.org/mergiraf/mergiraf/src/branch/main/LICENSE.txt), so here is a PR to fix that.

Follow up to #6312 by @nithinphilips.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
