### PR TITLE
clink-completions@0.6.2: fix clink script path

### DIFF
--- a/bucket/clink-completions.json
+++ b/bucket/clink-completions.json
@@ -11,8 +11,9 @@
     "extract_dir": "clink-completions-0.6.2",
     "installer": {
         "script": [
+            "$luapath = Join-Path (Split-Path -Path \"$dir\" -Parent) \"current\"",
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink installscripts \"$dir\"",
+            "   clink installscripts \"$luapath\"",
             "} else {",
             "   warn 'Clink installation not found. Please manually install these scripts.'",
             "}"
@@ -20,8 +21,9 @@
     },
     "uninstaller": {
         "script": [
+            "$luapath = Join-Path (Split-Path -Path \"$dir\" -Parent) \"current\"",
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink uninstallscripts \"$dir\"",
+            "   clink uninstallscripts \"$luapath\"",
             "}"
         ]
     },


### PR DESCRIPTION
The path installed via `clink installscripts` was different for each
version of clink-completions, creating issues as the same script was
loaded multiple times (with different version).

 This change makes the path consistent across versions, making sure only
 the latest one is loaded.

Closes #6576

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
