### PR TITLE
Jprq.io support

### DIFF
--- a/bucket/jprq.json
+++ b/bucket/jprq.json
@@ -1,0 +1,37 @@
+{
+    "version": "2.4",
+    "description": "jprq - Secure public URLs for local servers",
+    "homepage": "https://github.com/azimjohn/jprq",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/azimjohn/jprq/releases/download/2.4/jprq-windows-amd64.exe",
+            "hash": "4BAF20EB564946AF3CE0D6A33BDA1A08036728E24E8024388B5595AF6859BCC1"
+        },
+        "32bit": {
+            "url": "https://github.com/azimjohn/jprq/releases/download/2.4/jprq-windows-386.exe",
+            "hash": "3EEF9C81B6B0B71E6F3A0C0DC6488052F864FE2074CA0B6F18054471D423364A"
+        }
+    },
+    "bin": [
+        ["jprq-windows-amd64.exe", "jprq"],
+        ["jprq-windows-386.exe", "jprq"]
+    ],
+    "shortcuts": [
+        ["jprq-windows-amd64.exe", "jprq"],
+        ["jprq-windows-386.exe", "jprq"]
+    ],
+    "checkver": {
+        "github": "https://github.com/azimjohn/jprq"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/azimjohn/jprq/releases/download/$version/jprq-windows-amd64.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/azimjohn/jprq/releases/download/$version/jprq-windows-386.exe"
+            }
+        }
+    }
+}

--- a/bucket/jprq.json
+++ b/bucket/jprq.json
@@ -1,36 +1,29 @@
 {
     "version": "2.4",
-    "description": "jprq - Secure public URLs for local servers",
-    "homepage": "https://github.com/azimjohn/jprq",
-    "license": "MIT",
+    "description": "join public router. quickly.",
+    "homepage": "https://jprq.io",
+    "license": "Shareware",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/azimjohn/jprq/releases/download/2.4/jprq-windows-amd64.exe",
-            "hash": "4BAF20EB564946AF3CE0D6A33BDA1A08036728E24E8024388B5595AF6859BCC1"
+            "url": "https://github.com/azimjohn/jprq/releases/download/2.4/jprq-windows-amd64.exe#/jprq.exe",
+            "hash": "4baf20eb564946af3ce0d6a33bda1a08036728e24e8024388b5595af6859bcc1"
         },
         "32bit": {
-            "url": "https://github.com/azimjohn/jprq/releases/download/2.4/jprq-windows-386.exe",
-            "hash": "3EEF9C81B6B0B71E6F3A0C0DC6488052F864FE2074CA0B6F18054471D423364A"
+            "url": "https://github.com/azimjohn/jprq/releases/download/2.4/jprq-windows-386.exe#/jprq.exe",
+            "hash": "3eef9c81b6b0b71e6f3a0c0dc6488052f864fe2074ca0b6f18054471d423364a"
         }
     },
-    "bin": [
-        ["jprq-windows-amd64.exe", "jprq"],
-        ["jprq-windows-386.exe", "jprq"]
-    ],
-    "shortcuts": [
-        ["jprq-windows-amd64.exe", "jprq"],
-        ["jprq-windows-386.exe", "jprq"]
-    ],
+    "bin": "jprq.exe",
     "checkver": {
         "github": "https://github.com/azimjohn/jprq"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/azimjohn/jprq/releases/download/$version/jprq-windows-amd64.exe"
+                "url": "https://github.com/azimjohn/jprq/releases/download/$version/jprq-windows-amd64.exe#/jprq.exe"
             },
             "32bit": {
-                "url": "https://github.com/azimjohn/jprq/releases/download/$version/jprq-windows-386.exe"
+                "url": "https://github.com/azimjohn/jprq/releases/download/$version/jprq-windows-386.exe#/jprq.exe"
             }
         }
     }


### PR DESCRIPTION
## Add jprq 2.4

This PR adds a new manifest for `jprq` version 2.4.

**Project URL:** [jprq GitHub Repository](https://github.com/azimjohn/jprq)  
**Supersedes:** [#6593](https://github.com/ScoopInstaller/Main/pull/6593) (old PR)

### Changes:
- Added a new manifest file for `jprq`.
- Ensured proper JSON formatting.
- Included proper binary shims.

### Checklist:
- [x] Ran `bin/checkver.ps1 -f` to validate manifest format.
- [x] Used a new branch other than `master` to commit this PR.
- [x] Followed conventional PR title format: `<manifest-name[@version]|chore>: <summary>`.
- [x] Verified hash integrity to prevent mismatched binaries.

### Notes:
- Supersedes the previous broken PR: [#6593](https://github.com/ScoopInstaller/Main/pull/6593).
