### PR TITLE
pueue@4.0.0: fix autoupdate url

### DIFF
--- a/bucket/pueue.json
+++ b/bucket/pueue.json
@@ -1,17 +1,17 @@
 {
-    "version": "3.4.1",
+    "version": "4.0.0",
     "description": "Command-line task management tool for sequential and parallel execution of long-running tasks.",
     "homepage": "https://github.com/Nukesor/pueue",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/Nukesor/pueue/releases/download/v3.4.1/pueue-windows-x86_64.exe#/pueue.exe",
-                "https://github.com/Nukesor/pueue/releases/download/v3.4.1/pueued-windows-x86_64.exe#/pueued.exe"
+                "https://github.com/Nukesor/pueue/releases/download/v4.0.0/pueue-x86_64-pc-windows-msvc.exe#/pueue.exe",
+                "https://github.com/Nukesor/pueue/releases/download/v4.0.0/pueued-x86_64-pc-windows-msvc.exe#/pueued.exe"
             ],
             "hash": [
-                "ead8780f1c9d39df490d0b85a3d3d6f19bd9f351dc6ec65e3a262dcc6a547d28",
-                "510a45fdfdc86027e7a283ce206618395d424844303bc7861a72af78929c8a85"
+                "bb28093d99b2f38bd387c2b29aaa02d99df423a88dc9cec91a2754bf85e1b3d4",
+                "94b15ac7673d5f61a5a0a055cef4f1037365421e8fcfa702bd4587784f053d0e"
             ]
         }
     },
@@ -24,8 +24,8 @@
         "architecture": {
             "64bit": {
                 "url": [
-                    "https://github.com/Nukesor/pueue/releases/download/v$version/pueue-windows-x86_64.exe#/pueue.exe",
-                    "https://github.com/Nukesor/pueue/releases/download/v$version/pueued-windows-x86_64.exe#/pueued.exe"
+                    "https://github.com/Nukesor/pueue/releases/download/v$version/pueue-x86_64-pc-windows-msvc.exe#/pueue.exe",
+                    "https://github.com/Nukesor/pueue/releases/download/v$version/pueued-x86_64-pc-windows-msvc.exe#/pueued.exe"
                 ]
             }
         }


### PR DESCRIPTION
Updated the auto-update URL.

Closes #6621 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
