### PR TITLE
tealdeer@1.7.2: fix homepage url

### DIFF
--- a/bucket/tealdeer.json
+++ b/bucket/tealdeer.json
@@ -1,7 +1,7 @@
 {
     "version": "1.7.2",
     "description": "A very fast implementation of tldr in Rust.",
-    "homepage": "https://dbrgn.github.io/tealdeer",
+    "homepage": "https://tealdeer-rs.github.io/tealdeer/",
     "license": "Apache-2.0|MIT",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Homepage and documentation page has changed to https://tealdeer-rs.github.io/tealdeer/

- [ x ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ x ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
