### PR TITLE
wazero: Add version 1.9.0

### DIFF
--- a/bucket/wazero.json
+++ b/bucket/wazero.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.9.0",
+    "description": "wazero: the zero dependency WebAssembly runtime for Go developers",
+    "homepage": "https://github.com/tetratelabs/wazero",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tetratelabs/wazero/releases/download/v1.9.0/wazero_1.9.0_windows_amd64.zip",
+            "hash": "cf24cb5e3ee9969c3126384e7c897ac8728b7442f92963bc7a7fa58fff7061e3"
+        }
+    },
+    "bin": "wazero.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tetratelabs/wazero/releases/download/v$version/wazero_$version_windows_amd64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds  wazero, allows you to run wasm modules
project github: https://github.com/tetratelabs/wazero
project page: https://wazero.io/
Closes #6649 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
