### PR TITLE
ast-grep@0.36.2: change binary name to ast-grep

### DIFF
--- a/bucket/ast-grep.json
+++ b/bucket/ast-grep.json
@@ -9,7 +9,10 @@
             "hash": "026344c2bdab76cb92bd14bc3a0fcaa5edc27b8c77f96223a97d3a10c4bb2843"
         }
     },
-    "bin": "sg.exe",
+    "bin": [
+        "ast-grep.exe",
+        "sg.exe"
+    ],
     "checkver": {
         "github": "https://github.com/ast-grep/ast-grep"
     },


### PR DESCRIPTION
unfortunately this binary name change is due to another operating system

see https://ast-grep.github.io/guide/quick-start.html#installation
related to https://github.com/ast-grep/ast-grep/issues/56
related to https://github.com/ast-grep/ast-grep-vscode/issues/451

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
