### PR TITLE
llvm-full: Add version 20.1.1

### DIFF
--- a/bucket/llvm-full.json
+++ b/bucket/llvm-full.json
@@ -1,0 +1,31 @@
+{
+    "version": "20.1.1",
+    "description": "Collection of modular and reusable compiler and toolchain technologies (full build).",
+    "homepage": "https://www.llvm.org",
+    "license": "NCSA",
+    "notes": "Since upstream does not provide a pre-compiled binary of arm64 for every release, LLVM arm64 is a separate manifest: 'llvm-full-arm64'.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.1/clang+llvm-20.1.1-x86_64-pc-windows-msvc.tar.xz",
+            "hash": "f8114cb674317e8a303731b1f9d22bf37b8c571b64f600abe528e92275ed4ace",
+            "extract_dir": "clang+llvm-20.1.1-x86_64-pc-windows-msvc"
+        }
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "LIBCLANG_PATH": "$dir\\bin",
+        "LLVM_LIB_DIR": "$dir\\lib"
+    },
+    "checkver": {
+        "github": "https://github.com/llvm/llvm-project",
+        "regex": "tag/llvmorg-([\\d._]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/clang+llvm-$version-x86_64-pc-windows-msvc.tar.xz",
+                "extract_dir": "clang+llvm-$version-x86_64-pc-windows-msvc"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This adds `llvm-full`. The main difference to `llvm` is that this contains headers for Clang and LLVM, static libraries for them, and additional tools like `llvm-config` (often required when building a tool that interacts with LLVM).

I have never contributed to a bucket, so I don't know the exact conventions. Since `llvm` comes in two manifests, I want to replicate that here, because LLVM 19, for example, doesn't include full builds for arm64. Similarly, the beta versions of LLVM 20.1 didn't include a build for arm64 either. Can I include the arm64 version in here, or should I open another PR? I currently just mentioned that `llvm-full-arm64` will exist at some point.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6402

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
