### PR TITLE
Adds Edgescape Navigator to the Bucket

### DIFF
--- a/bucket/edgescape_navigator.json
+++ b/bucket/edgescape_navigator.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "url": "https://github.com/thedoggybrad/edgescape_navigator/releases/download/2%2C0/setup.exe",
+  "hash": "db523bf64cb33ff8fdf6698767ef762155ca68f3cf522d3cc89111271bd91383",
+  "installer": {
+    "script": [
+      "$exe = \"$dir\\setup.exe\"",
+      "Start-Process $exe -ArgumentList \"/s\" -Wait"
+    ]
+  }
+}


### PR DESCRIPTION
I am submitting this pull request so that Edgescape Navigator of TheDoggyBrad Software Labs (that was me) to be added to the main bucket of Scoop.

TheDoggyBrad Software Labs