### PR TITLE
rust-analyzer@2025-03-24: Fix manifest

### DIFF
--- a/bucket/rust-analyzer.json
+++ b/bucket/rust-analyzer.json
@@ -5,11 +5,10 @@
     "license": "Apache-2.0|MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2024-10-28/rust-analyzer-x86_64-pc-windows-msvc.gz",
-            "hash": "6049d31b34f9c27f96b67bf25edbcd9ad68a85c498ab724ddc0583b30507865e"
+            "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2025-03-24/rust-analyzer-x86_64-pc-windows-msvc.zip",
+            "hash": "f62c9ba4e80c020adf26783805223982a49f5e52986aa7c794e8c1cf75d5edc9"
         }
     },
-    "pre_install": "Rename-Item \"$dir\\$($fname -replace '\\.gz$')\" 'rust-analyzer.exe'",
     "bin": "rust-analyzer.exe",
     "checkver": {
         "github": "https://github.com/rust-lang/rust-analyzer",
@@ -18,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/rust-lang/rust-analyzer/releases/download/$version/rust-analyzer-x86_64-pc-windows-msvc.gz"
+                "url": "https://github.com/rust-lang/rust-analyzer/releases/download/$version/rust-analyzer-x86_64-pc-windows-msvc.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix the `rust-analyzer` manifest to account for the change from `gz` to `zip` in the download url.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
