### PR TITLE
sops@3.10.0: Updated manifest (arm64, changed filenames) and added checksums

### DIFF
--- a/bucket/sops.json
+++ b/bucket/sops.json
@@ -6,8 +6,12 @@
     "depends": "gpg",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/getsops/sops/releases/download/v3.10.0/sops-v3.10.0.exe#/sops.exe",
-            "hash": "73acb8ceea09418fcfc06e73d21040a8ac77544a7c24489a720db072adedb2d8"
+            "url": "https://github.com/getsops/sops/releases/download/v3.10.0/sops-v3.10.0.amd64.exe#/sops.exe",
+            "hash": "4532dbc8fe8fc02dbc308404da41d029cd2da0a51eadcd6c89ae4ffbac544141"
+        },
+        "arm64": {
+            "url": "https://github.com/getsops/sops/releases/download/v3.10.0/sops-v3.10.0.arm64.exe#/sops.exe",
+            "hash": "6b5e662add90c70301a2a53fe6b91410a0c575ed38883c4afc0f2161ef5998f7"
         }
     },
     "bin": "sops.exe",
@@ -15,7 +19,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.exe#/sops.exe"
+                "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.amd64.exe#/sops.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.arm64.exe#/sops.exe"
             }
         }
     }

--- a/bucket/sops.json
+++ b/bucket/sops.json
@@ -24,6 +24,9 @@
             "arm64": {
                 "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.arm64.exe#/sops.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sops-v$version_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
This PR fixes #6673. sops added arm64 architecture and changed release filenames -> sops.arch.exe.

Also, I added hash extraction from released checksums file.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
