### PR TITLE
gallery-dl: fix license

### DIFF
--- a/bucket/gallery-dl.json
+++ b/bucket/gallery-dl.json
@@ -2,7 +2,7 @@
     "version": "1.29.3",
     "description": "Command-line program to download image-galleries and -collections from several image hosting sites.",
     "homepage": "https://github.com/mikf/gallery-dl",
-    "license": "GPL-2.0-or-later",
+    "license": "GPL-2.0-only",
     "url": "https://github.com/mikf/gallery-dl/releases/download/v1.29.3/gallery-dl.exe",
     "hash": "72fd84c3296d6f6fff8e6649c45cba061d6a1938b6445bcd2b2658f10575a7db",
     "bin": "gallery-dl.exe",


### PR DESCRIPTION
Use the correct SPDX license identifier in the gallery-dl manifest

Closes #6711

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
