### PR TITLE
vivid: Add version 0.10.1

### DIFF
--- a/bucket/vivid.json
+++ b/bucket/vivid.json
@@ -3,16 +3,31 @@
     "description": "A themeable LS_COLORS generator with a rich filetype database.",
     "homepage": "https://github.com/sharkdp/vivid",
     "license": "Apache-2.0|MIT",
+    "notes": [
+        "vivid generates LS_COLORS for colorizing file listings in terminals.",
+        "Tools that use LS_COLORS on Windows include ls (GNU coreutils), eza and lsd:",
+        "  scoop install main/coreutils",
+        "  scoop install main/eza",
+        "  scoop install main/lsd",
+        "",
+        "POSIX shells:   export LS_COLORS=\"$(vivid generate molokai)\"",
+        "PowerShell:     $env:LS_COLORS = (vivid.exe generate molokai)",
+        "View available themes: vivid themes"
+    ],
+    "suggest": {
+        "GNU coreutils": "coreutils",
+        "Modern ls alternatives": ["eza", "lsd"]
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/sharkdp/vivid/releases/download/v0.10.1/vivid-v0.10.1-x86_64-pc-windows-msvc.zip",
-            "extract_dir": "vivid-v0.10.1-x86_64-pc-windows-msvc",
-            "hash": "c26978625c5e3c26f33ce056272db545573c56008f3b3b5dd0860cb6b6e521db"
+            "hash": "c26978625c5e3c26f33ce056272db545573c56008f3b3b5dd0860cb6b6e521db",
+            "extract_dir": "vivid-v0.10.1-x86_64-pc-windows-msvc"
         },
         "32bit": {
             "url": "https://github.com/sharkdp/vivid/releases/download/v0.10.1/vivid-v0.10.1-i686-pc-windows-msvc.zip",
-            "extract_dir": "vivid-v0.10.1-i686-pc-windows-msvc",
-            "hash": "eea061ac8d3d8c07fcd20267f0d5c6361357ca9b490cf36dec500ef561290869"
+            "hash": "eea061ac8d3d8c07fcd20267f0d5c6361357ca9b490cf36dec500ef561290869",
+            "extract_dir": "vivid-v0.10.1-i686-pc-windows-msvc"
         }
     },
     "bin": "vivid.exe",

--- a/bucket/vivid.json
+++ b/bucket/vivid.json
@@ -16,7 +16,10 @@
     ],
     "suggest": {
         "GNU coreutils": "coreutils",
-        "Modern ls alternatives": ["eza", "lsd"]
+        "Modern ls alternatives": [
+            "eza",
+            "lsd"
+        ]
     },
     "architecture": {
         "64bit": {

--- a/bucket/vivid.json
+++ b/bucket/vivid.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.10.1",
+    "description": "A themeable LS_COLORS generator with a rich filetype database.",
+    "homepage": "https://github.com/sharkdp/vivid",
+    "license": "Apache-2.0|MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sharkdp/vivid/releases/download/v0.10.1/vivid-v0.10.1-x86_64-pc-windows-msvc.zip",
+            "extract_dir": "vivid-v0.10.1-x86_64-pc-windows-msvc",
+            "hash": "c26978625c5e3c26f33ce056272db545573c56008f3b3b5dd0860cb6b6e521db"
+        },
+        "32bit": {
+            "url": "https://github.com/sharkdp/vivid/releases/download/v0.10.1/vivid-v0.10.1-i686-pc-windows-msvc.zip",
+            "extract_dir": "vivid-v0.10.1-i686-pc-windows-msvc",
+            "hash": "eea061ac8d3d8c07fcd20267f0d5c6361357ca9b490cf36dec500ef561290869"
+        }
+    },
+    "bin": "vivid.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sharkdp/vivid/releases/download/v$version/vivid-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "vivid-v$version-x86_64-pc-windows-msvc"
+            },
+            "32bit": {
+                "url": "https://github.com/sharkdp/vivid/releases/download/v$version/vivid-v$version-i686-pc-windows-msvc.zip",
+                "extract_dir": "vivid-v$version-i686-pc-windows-msvc"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Vivid is [dual licensed](https://github.com/sharkdp/vivid?tab=readme-ov-file#license), so I used the format as specified in the [manifest documentation](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests#required-properties)

- Closes #6717
- Closes #7223


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new package for the vivid LS_COLORS generator.
  * Includes both 64-bit and 32-bit Windows builds with verified downloads.
  * Provides usage notes and shell/Windows guidance for applying themes.
  * Installs the vivid executable for immediate use.
  * Supports automatic update checks and seamless version upgrades.
  * Suggests integrations with common tooling for easy setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->