### PR TITLE
sops@3.10.2: fix release url & add arm64

### DIFF
--- a/bucket/sops.json
+++ b/bucket/sops.json
@@ -1,13 +1,17 @@
 {
-    "version": "3.10.0",
+    "version": "3.10.2",
     "description": "Editor of encrypted files that supports YAML, JSON, ENV, INI and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP",
     "homepage": "https://github.com/getsops/sops",
     "license": "MPL-2.0",
     "depends": "gpg",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/getsops/sops/releases/download/v3.10.0/sops-v3.10.0.exe#/sops.exe",
-            "hash": "73acb8ceea09418fcfc06e73d21040a8ac77544a7c24489a720db072adedb2d8"
+            "url": "https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.amd64.exe#/sops.exe",
+            "hash": "056d18d9f12966aebd33a8181b54c358bcb312661fadc5a3141bb6f84b9c3502"
+        },
+        "arm64": {
+            "url": "https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.arm64.exe#/sops.exe",
+            "hash": "9e08c708147634f485f8574a22add98b6a092511e84ff69c6d2849834aec865d"
         }
     },
     "bin": "sops.exe",
@@ -15,7 +19,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.exe#/sops.exe"
+                "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.amd64.exe#/sops.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/getsops/sops/releases/download/v$version/sops-v$version.arm64.exe#/sops.exe"
             }
         }
     }


### PR DESCRIPTION
Release naming format changed, now supporting amd64 and arm64 architecture. 

Fixes: #6701 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
