### PR TITLE
ghdl: add version v5.0.1

### DIFF
--- a/bucket/ghdl.json
+++ b/bucket/ghdl.json
@@ -1,12 +1,12 @@
 {
-    "version": "5.0.1",
+    "version": "5.1.1",
     "description": "Free and open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL",
     "homepage": "https://github.com/ghdl/ghdl/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ghdl/ghdl/releases/download/v5.0.1/ghdl-mcode-5.0.1-mingw64.zip",
-            "hash": "034e8e98481bf86ce06c682630c9fbab26542fb96601cac7472f4aa877c44334"
+            "url": "https://github.com/ghdl/ghdl/releases/download/v5.1.1/ghdl-mcode-5.1.1-ucrt64.zip",
+            "hash": "ac82b10bed0754db466640f49079e736da1de0b43b1196564aff5d8ebf435aaf"
         }
     },
     "bin": [
@@ -17,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ghdl/ghdl/releases/download/v$version/ghdl-mcode-$version-mingw64.zip"
+                "url": "https://github.com/ghdl/ghdl/releases/download/v$version/ghdl-mcode-$version-ucrt64.zip"
             }
         }
     }

--- a/bucket/ghdl.json
+++ b/bucket/ghdl.json
@@ -1,0 +1,24 @@
+{
+    "version": "5.0.1",
+    "description": "Free and open-source analyzer, compiler, simulator and (experimental) synthesizer for VHDL",
+    "homepage": "https://github.com/ghdl/ghdl/",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ghdl/ghdl/releases/download/v5.0.1/ghdl-mcode-5.0.1-mingw64.zip",
+            "hash": "034e8e98481bf86ce06c682630c9fbab26542fb96601cac7472f4aa877c44334"
+        }
+    },
+    "bin": [
+        "bin\\ghdl.exe",
+        "bin\\ghwdump.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ghdl/ghdl/releases/download/v$version/ghdl-mcode-$version-mingw64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds [GHDL](https://github.com/ghdl/ghdl):
> VHDL analyzer, compiler, simulator and (experimental) synthesizer

GHDL is an open source command line tool to analyze and simulate [VHDL](https://en.wikipedia.org/wiki/VHDL).

It has 2.3k stars on GitHub and is likely the most widely known/used open source VHDL simulator.

As suggested by @jack-mil I have created this PR relating to the following issues/PRs:

Closes #5991 
and
Relates to https://github.com/ScoopInstaller/Extras/pull/13541

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
