### PR TITLE
choose: Add version 1.3.7

### DIFF
--- a/bucket/choose.json
+++ b/bucket/choose.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.3.6",
+    "description": "A human-friendly and fast alternative to cut (and sometimes awk)",
+    "homepage": "https://github.com/theryangeary/choose",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/theryangeary/choose/releases/download/v1.3.6/choose-x86_64-pc-windows-gnu#/choose.exe",
+            "hash": "62b2c196ffe77026eeff1957f77f5a1781a5b5a41ff8915ae388b4baec610321"
+        }
+    },
+    "bin": "choose.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/theryangeary/choose/releases/download/v$version/choose-x86_64-pc-windows-gnu.exe#/choose.exe"
+            }
+        }
+    }
+}

--- a/bucket/choose.json
+++ b/bucket/choose.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.3.6",
+    "version": "1.3.7",
     "description": "A human-friendly and fast alternative to cut (and sometimes awk)",
     "homepage": "https://github.com/theryangeary/choose",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/theryangeary/choose/releases/download/v1.3.6/choose-x86_64-pc-windows-gnu#/choose.exe",
-            "hash": "62b2c196ffe77026eeff1957f77f5a1781a5b5a41ff8915ae388b4baec610321"
+            "url": "https://github.com/theryangeary/choose/releases/download/v1.3.7/choose-x86_64-pc-windows-gnu.exe#/choose.exe",
+            "hash": "9233beade020c3e74854911a15aa973f7dc9f4253abe8856b8c273579a555903"
         }
     },
     "bin": "choose.exe",


### PR DESCRIPTION
~~Their release for 1.3.6 has a non-standard naming (no .exe suffix). They said they will fix it for the next release (https://github.com/theryangeary/choose/issues/72) . So the auto-update URL is different than the current 1.3.6 download url~~

Updated to v1.3.7 and the new download URL.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes: #6724 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
