### PR TITLE
elan: Add version 4.0.0

### DIFF
--- a/bucket/elan.json
+++ b/bucket/elan.json
@@ -1,0 +1,31 @@
+{
+    "version": "4.0.0",
+    "description": "Manage installations of the Lean Theorem Prover with ease.",
+    "homepage": "https://github.com/leanprover/elan",
+    "license": "MIT|Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/leanprover/elan/releases/download/v4.0.0/elan-x86_64-pc-windows-msvc.zip",
+            "hash": "eb3c8478f9f0ed1d83fbfd9bb62954edc7cbfa99c61c40ee60458497377ad6dd"
+        }
+    },
+    "installer": {
+        "script": [
+            "[Environment]::SetEnvironmentVariable('ELAN_HOME', \"$persist_dir\\.elan\", 'Process')",
+            "Invoke-ExternalCommand -Path \"$dir\\elan-init.exe\" -Args @('-y', '--no-modify-path') | Out-Null"
+        ]
+    },
+    "env_add_path": ".elan\\bin",
+    "env_set": {
+        "ELAN_HOME": "$persist_dir\\.elan"
+    },
+    "persist": ".elan",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/leanprover/elan/releases/download/v$version/elan-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Modeled off of the rustup manifest. But uses simple github releases for checkver. Only x86_64 builds available

This manifest will add an environment variable $ELAN_HOME, and modify the $PATH variable to include the persist directory
This is because elan is itself just a downloader of other tools (leanc, lake, etc) that need to be available on PATH.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6725
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
