### PR TITLE
busybox@5579-g5749feb35: Add missing applets

### DIFF
--- a/bucket/busybox.json
+++ b/bucket/busybox.json
@@ -48,6 +48,16 @@
         }
     },
     "bin": [
+        [
+            "busybox.exe",
+            "[",
+            "["
+        ],
+        [
+            "busybox.exe",
+            "[[",
+            "[["
+        ],
         "busybox.exe",
         [
             "busybox.exe",
@@ -61,6 +71,11 @@
         ],
         [
             "busybox.exe",
+            "ascii",
+            "ascii"
+        ],
+        [
+            "busybox.exe",
             "ash",
             "ash"
         ],
@@ -68,6 +83,11 @@
             "busybox.exe",
             "awk",
             "awk"
+        ],
+        [
+            "busybox.exe",
+            "base32",
+            "base32"
         ],
         [
             "busybox.exe",
@@ -83,6 +103,11 @@
             "busybox.exe",
             "bash",
             "bash"
+        ],
+        [
+            "busybox.exe",
+            "bc",
+            "bc"
         ],
         [
             "busybox.exe",
@@ -108,6 +133,16 @@
             "busybox.exe",
             "cat",
             "cat"
+        ],
+        [
+            "busybox.exe",
+            "cdrop",
+            "cdrop"
+        ],
+        [
+            "busybox.exe",
+            "chattr",
+            "chattr"
         ],
         [
             "busybox.exe",
@@ -143,6 +178,11 @@
             "busybox.exe",
             "cpio",
             "cpio"
+        ],
+        [
+            "busybox.exe",
+            "crc32",
+            "crc32"
         ],
         [
             "busybox.exe",
@@ -193,6 +233,11 @@
             "busybox.exe",
             "dpkg-deb",
             "dpkg-deb"
+        ],
+        [
+            "busybox.exe",
+            "drop",
+            "drop"
         ],
         [
             "busybox.exe",
@@ -251,8 +296,18 @@
         ],
         [
             "busybox.exe",
+            "flock",
+            "flock"
+        ],
+        [
+            "busybox.exe",
             "fold",
             "fold"
+        ],
+        [
+            "busybox.exe",
+            "free",
+            "free"
         ],
         [
             "busybox.exe",
@@ -326,8 +381,23 @@
         ],
         [
             "busybox.exe",
+            "inotifyd",
+            "inotifyd"
+        ],
+        [
+            "busybox.exe",
+            "install",
+            "install"
+        ],
+        [
+            "busybox.exe",
             "ipcalc",
             "ipcalc"
+        ],
+        [
+            "busybox.exe",
+            "jn",
+            "jn"
         ],
         [
             "busybox.exe",
@@ -338,6 +408,11 @@
             "busybox.exe",
             "killall",
             "killall"
+        ],
+        [
+            "busybox.exe",
+            "lash",
+            "lash"
         ],
         [
             "busybox.exe",
@@ -366,6 +441,11 @@
         ],
         [
             "busybox.exe",
+            "lsattr",
+            "lsattr"
+        ],
+        [
+            "busybox.exe",
             "lzcat",
             "lzcat"
         ],
@@ -383,6 +463,11 @@
             "busybox.exe",
             "lzopcat",
             "lzopcat"
+        ],
+        [
+            "busybox.exe",
+            "make",
+            "make"
         ],
         [
             "busybox.exe",
@@ -421,6 +506,11 @@
         ],
         [
             "busybox.exe",
+            "nproc",
+            "nproc"
+        ],
+        [
+            "busybox.exe",
             "od",
             "od"
         ],
@@ -433,6 +523,16 @@
             "busybox.exe",
             "patch",
             "patch"
+        ],
+        [
+            "busybox.exe",
+            "pdpmake",
+            "pdpmake"
+        ],
+        [
+            "busybox.exe",
+            "pdrop",
+            "pdrop"
         ],
         [
             "busybox.exe",
@@ -546,6 +646,11 @@
         ],
         [
             "busybox.exe",
+            "sha384sum",
+            "sha384sum"
+        ],
+        [
+            "busybox.exe",
             "sha512sum",
             "sha512sum"
         ],
@@ -591,6 +696,11 @@
         ],
         [
             "busybox.exe",
+            "stty",
+            "stty"
+        ],
+        [
+            "busybox.exe",
             "su",
             "su"
         ],
@@ -598,6 +708,11 @@
             "busybox.exe",
             "sum",
             "sum"
+        ],
+        [
+            "busybox.exe",
+            "sync",
+            "sync"
         ],
         [
             "busybox.exe",
@@ -661,6 +776,11 @@
         ],
         [
             "busybox.exe",
+            "tsort",
+            "tsort"
+        ],
+        [
+            "busybox.exe",
             "ttysize",
             "ttysize"
         ],
@@ -713,6 +833,11 @@
             "busybox.exe",
             "unzip",
             "unzip"
+        ],
+        [
+            "busybox.exe",
+            "uptime",
+            "uptime"
         ],
         [
             "busybox.exe",


### PR DESCRIPTION
Shouldn't we do this in one line? like this
```json
{
    "bin": [
        [ "busybox.exe", "ls", "ls" ]
    ]
}
```
That's much easier.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended BusyBox with additional command mappings for expanded functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->