### PR TITLE
clipboard: Remove unsupported ARM build

### DIFF
--- a/bucket/clipboard.json
+++ b/bucket/clipboard.json
@@ -1,28 +1,23 @@
 {
-    "version": "0.9.0.1",
+    "version": "0.10.0",
     "description": "Cut, copy, and paste anything, anywhere in the terminal",
-    "homepage": "https://github.com/Slackadays/Clipboard",
+    "homepage": "https://getclipboard.app",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Slackadays/Clipboard/releases/download/0.9.0.1/clipboard-windows-amd64.zip",
-            "hash": "fd7715f3a79b69d249027e3f7403438b7ff762c5f26aac8aa8226ff245101e5f"
-        },
-        "arm64": {
-            "url": "https://github.com/Slackadays/Clipboard/releases/download/0.9.0.1/clipboard-windows-arm64.zip",
-            "hash": "e058e19091f4d04a849e8385b87effd9ae55f7659cf15b3d0394b0e6144ffb1b"
+            "url": "https://github.com/Slackadays/Clipboard/releases/download/0.10.0/clipboard-windows-amd64.zip",
+            "hash": "498ad9c2fb3f4432df28ff1fb26ea2223a8c5a822e39a1239bbdc31af5494244"
         }
     },
     "extract_dir": "bin",
     "bin": "cb.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/Slackadays/Clipboard"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/Slackadays/Clipboard/releases/download/$version/clipboard-windows-amd64.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/Slackadays/Clipboard/releases/download/$version/clipboard-windows-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
Fixes failure to update to 0.10.0

Upstream has (~temporaily?~) dropped support for Windows Arm64 as of 0.9.1
<!-- Provide a general summary of your changes in the title above -->

Also updates the homepage url to project website.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes: #6514 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
