### PR TITLE
biome: Fix checkver regex to avoid nightly tags

### DIFF
--- a/bucket/biome.json
+++ b/bucket/biome.json
@@ -15,8 +15,9 @@
     },
     "bin": "biome.exe",
     "checkver": {
-        "url": "https://github.com/biomejs/biome/tags",
-        "regex": "/releases/tag/cli%2F(?:v|V)?([\\d.]+)"
+        "url": "https://api.github.com/repos/biomejs/biome/releases",
+        "jsonpath": "$..tag_name",
+        "regex": "cli/[vV]([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Switches to using the github api feed for releases

Needs to match tags of the form: `cli/v1.9.4` but NOT `cli/v1.9.5-nightly.4713c52`. See: [regexr](https://regexr.com/8e71o)
There may be better regex to use, but matching on a literal `"` worked for me. 
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes Excavator checkver error [(log)](https://github.com/ScoopInstaller/Main/actions/runs/14580811575/job/40896917043#step:3:531)
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
