### PR TITLE
mise: remove unused PATH env

### DIFF
--- a/bucket/mise.json
+++ b/bucket/mise.json
@@ -19,7 +19,6 @@
         }
     },
     "extract_dir": "mise",
-    "env_add_path": "mise\\shims",
     "bin": "bin/mise.exe",
     "checkver": {
         "github": "https://github.com/jdx/mise"


### PR DESCRIPTION
Relates to #6677 

- Since config and data dirs been reverted to default, `mise\shims` no longer exists and should be removed alongside 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
