### PR TITLE
typstyle: Add version 0.13.17

### DIFF
--- a/bucket/typstyle.json
+++ b/bucket/typstyle.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.13.3",
+    "version": "0.13.17",
     "description": "Beautiful and reliable typst code formatter.",
-    "homepage": "https://github.com/Enter-tainer/typstyle",
+    "homepage": "https://github.com/typstyle-rs/typstyle",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe",
-            "hash": "b3d8de0a529bb38c7166182f78c6dbc4dcb389ff39f41797deade146695e4d66"
+            "url": "https://github.com/typstyle-rs/typstyle/releases/download/v0.13.17/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe",
+            "hash": "e5fae8dbd03d3871555985c466af075bbd9ab50edb8b2c1b53bb95efffb3d42e"
         },
         "arm64": {
-            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe",
-            "hash": "d65c1dc2dc51c7bad14938e5ae52eb22a31f1fa5de799be7f79afd92aab99330"
+            "url": "https://github.com/typstyle-rs/typstyle/releases/download/v0.13.17/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe",
+            "hash": "57436af4e2416b52dba3fcf044fa3df0a54b960d8e78802b56cc76fddfc5670d"
         }
     },
     "bin": "typstyle.exe",
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe"
+                "url": "https://github.com/typstyle-rs/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe"
             },
             "arm64": {
-                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe"
+                "url": "https://github.com/typstyle-rs/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe"
             }
         }
     }

--- a/bucket/typstyle.json
+++ b/bucket/typstyle.json
@@ -3,6 +3,9 @@
     "description": "Beautiful and reliable typst code formatter.",
     "homepage": "https://github.com/typstyle-rs/typstyle",
     "license": "Apache-2.0",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/typstyle-rs/typstyle/releases/download/v0.13.17/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe",

--- a/bucket/typstyle.json
+++ b/bucket/typstyle.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.13.3",
+    "description": "Beautiful and reliable typst code formatter.",
+    "homepage": "https://github.com/Enter-tainer/typstyle",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-x86_64-pc-windows-msvc.exe#typstyle.exe",
+            "hash": "b3d8de0a529bb38c7166182f78c6dbc4dcb389ff39f41797deade146695e4d66"
+        },
+        "arm64": {
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-aarch64-pc-windows-msvc.exe#typstyle.exe",
+            "hash": "d65c1dc2dc51c7bad14938e5ae52eb22a31f1fa5de799be7f79afd92aab99330"
+        }
+    },
+    "bin": "typstyle.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe#typstyle.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe#typstyle.exe"
+            }
+        }
+    }
+}

--- a/bucket/typstyle.json
+++ b/bucket/typstyle.json
@@ -5,11 +5,11 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-x86_64-pc-windows-msvc.exe#typstyle.exe",
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe",
             "hash": "b3d8de0a529bb38c7166182f78c6dbc4dcb389ff39f41797deade146695e4d66"
         },
         "arm64": {
-            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-aarch64-pc-windows-msvc.exe#typstyle.exe",
+            "url": "https://github.com/Enter-tainer/typstyle/releases/download/v0.13.3/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe",
             "hash": "d65c1dc2dc51c7bad14938e5ae52eb22a31f1fa5de799be7f79afd92aab99330"
         }
     },
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe#typstyle.exe"
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-x86_64-pc-windows-msvc.exe#/typstyle.exe"
             },
             "arm64": {
-                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe#typstyle.exe"
+                "url": "https://github.com/Enter-tainer/typstyle/releases/download/v$version/typstyle-aarch64-pc-windows-msvc.exe#/typstyle.exe"
             }
         }
     }


### PR DESCRIPTION
This pr add support for [typstyle](https://github.com/typstyle-rs/typstyle), a beautiful and reliable [typst](https://typst.app) code formatter.

Relates to #6123, and it may also relate to #6746.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
