### PR TITLE
presentmon: fix erroneous full removal of 32 bit version

### DIFF
--- a/bucket/presentmon.json
+++ b/bucket/presentmon.json
@@ -7,14 +7,14 @@
         "64bit": {
             "url": "https://github.com/GameTechDev/PresentMon/releases/download/v2.3.0/PresentMon-2.3.0-x64.exe#/PresentMon.exe",
             "hash": "690533cf5c2591ef571a3037aa4c205c8e75860ef3f56927bf3a98acf7198485"
+        },
+        "32bit": {
+            "url": "https://github.com/GameTechDev/PresentMon/releases/download/v2.1.1/PresentMon-2.1.1-x86.exe#/PresentMon.exe",
+            "hash": "3c38b5907b3a2051894f86e2b5736888bbda401e9945efa5011723eaa68aa94d"
         }
     },
     "bin": "PresentMon.exe",
-    "checkver": {
-        "url": "https://api.github.com/repos/GameTechDev/PresentMon/releases/latest",
-        "jsonpath": "$.tag_name",
-        "regex": "v([\\d.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
fix erroneous full removal of 32 bit version in https://github.com/ScoopInstaller/Main/commit/f5ef12b0c11026b93b40be0502cd20dd15f49749
only remove the 32 bit `autoupdate` entry