### PR TITLE
vulkan@1.4.313.0: update package manifest to correctly handle new installers

### DIFF
--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.313.1",
+    "version": "1.4.313.2",
     "description": "SDK for new generation graphics and compute API",
     "homepage": "https://www.vulkan.org",
     "license": {
@@ -40,12 +40,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.1/windows/vulkansdk-windows-X64-1.4.313.1.exe",
-            "hash": "2ce4c7b226d025c3be836ff667bd70c6764f407c69738c31e360dcb6352a34db"
+            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.2/windows/vulkansdk-windows-X64-1.4.313.2.exe",
+            "hash": "34a921d951858274ca8e470e9d0a3b7624db41216b3908ccea9f73c8a1b7500e"
         },
         "arm64": {
-            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.1/warm/vulkansdk-windows-ARM64-1.4.313.1.exe",
-            "hash": "f2a9324eaa9e1b957422cba48115a8cbce2188d14a3a898eee1b52eb711c5b91"
+            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.2/warm/vulkansdk-windows-ARM64-1.4.313.2.exe",
+            "hash": "29c3e7b9ff9c9d38455708bed7e744f879c770c15f3fedae55c409817c375515"
         }
     },
     "env_add_path": [

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.313.0",
+    "version": "1.4.313.1",
     "description": "SDK for new generation graphics and compute API",
     "homepage": "https://www.vulkan.org",
     "license": {
@@ -40,12 +40,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe",
-            "hash": "b643ca8ab4aea5c47b9c4e021a0b33b3a13871bf1d8131e162a9e48c257c4694"
+            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.1/windows/vulkansdk-windows-X64-1.4.313.1.exe",
+            "hash": "2ce4c7b226d025c3be836ff667bd70c6764f407c69738c31e360dcb6352a34db"
         },
         "arm64": {
-            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/warm/vulkansdk-windows-ARM64-1.4.313.0.exe",
-            "hash": "b19a8683df982d302fec07c110962153f02a2e5cf1e5118ff72d8532aa5fc567"
+            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.1/warm/vulkansdk-windows-ARM64-1.4.313.1.exe",
+            "hash": "f2a9324eaa9e1b957422cba48115a8cbce2188d14a3a898eee1b52eb711c5b91"
         }
     },
     "env_add_path": [

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -13,7 +13,7 @@
         "Allow vulkan applications to find VK layers provided by Khronos, run \"$dir\\install-vk-layers.ps1\"",
         "(\"powershell \"$dir\\install-vk-layers.ps1\"\" under cmd)"
     ],
-    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe#/dl.7z",
+    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe",
     "hash": "b643ca8ab4aea5c47b9c4e021a0b33b3a13871bf1d8131e162a9e48c257c4694",
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstal*\" -Recurse",
     "post_install": [
@@ -25,7 +25,20 @@
         "   $content = $content.Replace('$global', $(if ($global) { '$true' } else { '$false' }))",
         "   $content = $content.Replace('$is_admin', $(if (is_admin) { '$true' } else { '$false' }))",
         "}",
-        "Set-Content -Path \"$dir\\install-vk-layers.ps1\" -Value $content -Encoding UTF8"
+        "Set-Content -Path \"$dir\\install-vk-layers.ps1\" -Value $content -Encoding UTF8",
+        "$UninstallRegistryPath = \"HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\"",
+        "$keys = @()",
+        "Get-ChildItem -Path $UninstallRegistryPath -Recurse | ForEach-Object {",
+        "   $key = $_.Name",
+        "   Get-ItemProperty -Path $_.PSPath | ForEach-Object {",
+        "      if ($_.PSObject.Properties[\"DisplayName\"].Value.Contains(\"Vulkan SDK\")) {",
+        "         $keys += $key",
+        "      }",
+        "   }",
+        "}",
+        "foreach ($key in $keys) {",
+        "   reg delete $key /va /f",
+        "}"
     ],
     "architecture": {
         "64bit": {
@@ -62,10 +75,21 @@
         "jsonpath": "$.windows"
     },
     "autoupdate": {
-        "url": "https://sdk.lunarg.com/sdk/download/$version/windows/vulkansdk-windows-X64-$version.exe#/dl.7z",
+        "url": "https://sdk.lunarg.com/sdk/download/$version/windows/vulkansdk-windows-X64-$version.exe",
         "hash": {
             "url": "https://vulkan.lunarg.com/sdk/files.json",
             "jsonpath": "$.windows['$version'].files[?(@.file_name == '$basename')].sha"
         }
+    },
+    "installer": {
+        "args": [
+            "--root",
+            "$dir",
+            "--accept-licenses",
+            "--accept-messages",
+            "--confirm-command",
+            "install",
+            "copy_only=1"
+        ]
     }
 }

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -13,13 +13,11 @@
         "Allow vulkan applications to find VK layers provided by Khronos, run \"$dir\\install-vk-layers.ps1\"",
         "(\"powershell \"$dir\\install-vk-layers.ps1\"\" under cmd)"
     ],
-    "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe",
-    "hash": "b643ca8ab4aea5c47b9c4e021a0b33b3a13871bf1d8131e162a9e48c257c4694",
     "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstal*\" -Recurse",
     "post_install": [
         "$script_path = \"$bucketsdir\\main\\scripts\\$app\\install-vk-layers.ps1\"",
         "if (Test-Path $script_path) {",
-        "   $vulkan_bin = if ($architecture -eq '64bit') { \"$dir\\Bin\" } else { \"$dir\\Bin32\" }",
+        "   $vulkan_bin = \"$dir\\Bin\"",
         "   $content = Get-Content $script_path",
         "   $content = $content.Replace('$vulkan_bin', \"\"\"$vulkan_bin\"\"\")",
         "   $content = $content.Replace('$global', $(if ($global) { '$true' } else { '$false' }))",
@@ -42,18 +40,18 @@
     ],
     "architecture": {
         "64bit": {
-            "env_add_path": [
-                "Bin",
-                "Tools"
-            ]
+            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/vulkansdk-windows-X64-1.4.313.0.exe",
+            "hash": "b643ca8ab4aea5c47b9c4e021a0b33b3a13871bf1d8131e162a9e48c257c4694"
         },
-        "32bit": {
-            "env_add_path": [
-                "Bin32",
-                "Tools32"
-            ]
+        "arm64": {
+            "url": "https://sdk.lunarg.com/sdk/download/1.4.313.0/warm/vulkansdk-windows-ARM64-1.4.313.0.exe",
+            "hash": "b19a8683df982d302fec07c110962153f02a2e5cf1e5118ff72d8532aa5fc567"
         }
     },
+    "env_add_path": [
+        "Bin",
+        "Tools"
+    ],
     "env_set": {
         "VULKAN_SDK": "$dir",
         "VK_SDK_PATH": "$dir"
@@ -61,7 +59,7 @@
     "pre_uninstall": [
         "$reg_root = if ($global) { [Microsoft.Win32.Registry]::LocalMachine } else { [Microsoft.Win32.Registry]::CurrentUser }",
         "$vk_explicit_reg_path = 'SOFTWARE\\Khronos\\Vulkan\\ExplicitLayers'",
-        "$bin_dir = if ($architecture -eq '64bit') { 'Bin' } else { 'Bin32' }",
+        "$bin_dir = 'Bin'",
         "$vulkan_bin = if ($global) { \"$globaldir\\apps\\$app\\current\\$bin_dir\" } else { \"$scoopdir\\apps\\$app\\current\\$bin_dir\" }",
         "$vk_layers = Get-ChildItem -Path $vulkan_bin -Filter '*.json' | ForEach-Object { $_.FullName }",
         "$vk_explicit_reg = $reg_root.CreateSubKey($vk_explicit_reg_path)",
@@ -75,10 +73,21 @@
         "jsonpath": "$.windows"
     },
     "autoupdate": {
-        "url": "https://sdk.lunarg.com/sdk/download/$version/windows/vulkansdk-windows-X64-$version.exe",
-        "hash": {
-            "url": "https://vulkan.lunarg.com/sdk/files.json",
-            "jsonpath": "$.windows['$version'].files[?(@.file_name == '$basename')].sha"
+        "architecture": {
+            "64bit": {
+                "url": "https://sdk.lunarg.com/sdk/download/$version/windows/vulkansdk-windows-X64-$version.exe",
+                "hash": {
+                    "url": "https://vulkan.lunarg.com/sdk/files.json",
+                    "jsonpath": "$.windows['$version'].files[?(@.file_name == '$basename')].sha"
+                }
+            },
+            "arm64": {
+                "url": "https://sdk.lunarg.com/sdk/download/$version/warm/vulkansdk-windows-ARM64-$version.exe",
+                "hash": {
+                    "url": "https://vulkan.lunarg.com/sdk/files.json",
+                    "jsonpath": "$.warm['$version'].files[?(@.file_name == '$basename')].sha"
+                }
+            }
         }
     },
     "installer": {

--- a/bucket/vulkan.json
+++ b/bucket/vulkan.json
@@ -56,6 +56,16 @@
         "VULKAN_SDK": "$dir",
         "VK_SDK_PATH": "$dir"
     },
+    "shortcuts": [
+        [
+            "Bin\\vkconfig-gui.exe",
+            "vkconfig-gui"
+        ],
+        [
+            "Bin\\vulkanCapsViewer.exe",
+            "vulkanCapsViewer"
+        ]
+    ],
     "pre_uninstall": [
         "$reg_root = if ($global) { [Microsoft.Win32.Registry]::LocalMachine } else { [Microsoft.Win32.Registry]::CurrentUser }",
         "$vk_explicit_reg_path = 'SOFTWARE\\Khronos\\Vulkan\\ExplicitLayers'",


### PR DESCRIPTION
This PR addresses the following:
1. Fixes #6805 . The new Vulkan installer does not allow complete extraction of the install tree through 7zip. This changes the logic to instead calling the installer directly. See the note below.
2. Adds support for arm64 installers and removes 32-bit support. Vulkan deprecated 32-bit years ago, so the code is no longer relevant.
3. Adds a QoL improvement by linking `vkconfig-gui.exe` and `vulkanCapsViewer.exe` to the start menu so users can easily configure validation layers as well as check supported features on their GPUs.

## Note
There is a bug in the installer where attempting to run it with the `copy_only` flag still causes an uninstall entry to be added in the registry. The bug has been logged and can be found [here](https://vulkan.lunarg.com/issue/view/6813a6a34b6dfefb74a56fcb).
In order to ensure that the scoop install remains isolated from the registry, I added some code to the `post_install` node that will automatically scan the registry for the added Vulkan key and remove it. This should be a stop-gap measure until LunarG fixes the installer so that this doesn't happen. Once that occurs, I'll remove the extra code. Hopefully I will also be able to remove the call to run the installer itself as well.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
