### PR TITLE
android-payload-dumper@1.2.2: update to 1.3.0, fix autoupdate, change to 64bit only

### DIFF
--- a/bucket/android-payload-dumper.json
+++ b/bucket/android-payload-dumper.json
@@ -1,31 +1,24 @@
 {
-  "version": "1.2.2",
-  "description": "Android OTA payload dumper written in Go",
-  "homepage": "https://github.com/ssut/payload-dumper-go",
-  "license": "Apache-2.0",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/ssut/payload-dumper-go/releases/download/1.2.2/payload-dumper-go_1.2.2_windows_amd64.tar.gz",
-      "hash": "89d2090b2c669ecdbe1b1d57c452ad4a5dd3047a4c0247a9f3a31a9485fbda61"
-    },
-    "32bit": {
-      "url": "https://github.com/ssut/payload-dumper-go/releases/download/1.2.2/payload-dumper-go_1.2.2_windows_386.tar.gz",
-      "hash": "8ac5b93e9e109730fccf4a6f988743c4a835cccd03c62a8dd57708f734f2c9a9"
-    }
-  },
-  "bin": "payload-dumper-go.exe",
-  "checkver": "github",
-  "autoupdate": {
+    "version": "1.3.0",
+    "description": "Android OTA payload dumper written in Go",
+    "homepage": "https://github.com/ssut/payload-dumper-go",
+    "license": "Apache-2.0",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/ssut/payload-dumper-go/releases/download/1.2.2/payload-dumper-go_1.2.2_windows_amd64.tar.gz"
-      },
-      "32bit": {
-        "url": "https://github.com/ssut/payload-dumper-go/releases/download/1.2.2/payload-dumper-go_$version_windows_386.tar.gz"
-      }
+        "64bit": {
+            "url": "https://github.com/ssut/payload-dumper-go/releases/download/1.3.0/payload-dumper-go_1.3.0_windows_amd64.tar.gz",
+            "hash": "0f96e07477963327f7f50a03bf2aa9dac5c76dba110ab332dc759321ae345d52"
+        }
     },
-    "hash": {
-      "url": "https://github.com/ssut/payload-dumper-go/releases/download/1.2.2/payload-dumper-go_sha256checksums.txt"
+    "bin": "payload-dumper-go.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ssut/payload-dumper-go/releases/download/$version/payload-dumper-go_$version_windows_amd64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/ssut/payload-dumper-go/releases/download/$version/payload-dumper-go_sha256checksums.txt"
+        }
     }
-  }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Original manifest autoupdate not correctly configured.
This PR fix autoupdate, update to 1.3.0 and change to 64 bit only. (and format fix)
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #6810 
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
