### PR TITLE
isx: Update to version 0.3.10

### DIFF
--- a/bucket/isx.json
+++ b/bucket/isx.json
@@ -8,7 +8,7 @@
     "pre_install": [
         "if ($architecture -eq '32bit') {",
         "  Move-Item \"$dir\\ISx-x86.exe\" \"$dir\\ISx.exe\" -Force",
-        "}"
+        "} else { Remove-Item \"$dir\\ISx-x86.exe\" }"
     ],
     "bin": "ISx.exe",
     "checkver": "github",

--- a/bucket/isx.json
+++ b/bucket/isx.json
@@ -5,6 +5,11 @@
     "license": "MIT",
     "url": "https://github.com/lifenjoiner/ISx/releases/download/v0.3.10/ISx-v0.3.10.7z",
     "hash": "4ad0a19b986799c7454efaf7edd12b777800acf066b6ca49c73f961f11faf797",
+    "pre_install": [
+        "if ($architecture -eq '32bit') {",
+        "  Move-Item \"$dir\\ISx-x86.exe\" \"$dir\\ISx.exe\" -Force",
+        "}"
+    ],
     "bin": "ISx.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/isx.json
+++ b/bucket/isx.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/lifenjoiner/ISx",
     "license": "MIT",
     "url": "https://github.com/lifenjoiner/ISx/releases/download/v0.3.10/ISx-v0.3.10.7z",
-    "hash": "31f2bf585118a597d7129bd44235a602c285772984d9cc146f6f5023457b14f9",
+    "hash": "4ad0a19b986799c7454efaf7edd12b777800acf066b6ca49c73f961f11faf797",
     "bin": "ISx.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/isx.json
+++ b/bucket/isx.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.3.9",
+    "version": "0.3.10",
     "description": "InstallShield installer extractor. Continuation of 'ISXUnpack'.",
     "homepage": "https://github.com/lifenjoiner/ISx",
     "license": "MIT",
-    "url": "https://github.com/lifenjoiner/ISx/releases/download/v0.3.9/ISx-v0.3.9-win32.7z",
+    "url": "https://github.com/lifenjoiner/ISx/releases/download/v0.3.10/ISx-v0.3.10.7z",
     "hash": "31f2bf585118a597d7129bd44235a602c285772984d9cc146f6f5023457b14f9",
     "bin": "ISx.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/lifenjoiner/ISx/releases/download/v$version/ISx-v$version-win32.7z"
+        "url": "https://github.com/lifenjoiner/ISx/releases/download/v$version/ISx-v$version.7z"
     }
 }


### PR DESCRIPTION
Fix isx autoupdate wrong file name

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
