### PR TITLE
zig: fix extract_dir

### DIFF
--- a/bucket/zig.json
+++ b/bucket/zig.json
@@ -10,17 +10,17 @@
         "64bit": {
             "url": "https://ziglang.org/download/0.14.1/zig-x86_64-windows-0.14.1.zip",
             "hash": "554f5378228923ffd558eac35e21af020c73789d87afeabf4bfd16f2e6feed2c",
-            "extract_dir": "zig-windows-x86_64-0.14.1"
+            "extract_dir": "zig-x86_64-windows-0.14.1"
         },
         "32bit": {
             "url": "https://ziglang.org/download/0.14.1/zig-x86-windows-0.14.1.zip",
             "hash": "3ee730c2a5523570dc4dc1b724f3e4f30174ebc1fa109ca472a719586a473b18",
-            "extract_dir": "zig-windows-aarch64-0.14.1"
+            "extract_dir": "zig-x86-windows-0.14.1"
         },
         "arm64": {
             "url": "https://ziglang.org/download/0.14.1/zig-aarch64-windows-0.14.1.zip",
             "hash": "b5aac0ccc40dd91e8311b1f257717d8e3903b5fefb8f659de6d65a840ad1d0e7",
-            "extract_dir": "zig-windows-aarch64-0.14.1"
+            "extract_dir": "zig-aarch64-windows-0.14.1"
         }
     },
     "bin": "zig.exe",
@@ -32,15 +32,15 @@
         "architecture": {
             "64bit": {
                 "url": "https://ziglang.org/download/$version/zig-x86_64-windows-$version.zip",
-                "extract_dir": "zig-windows-x86_64-$version"
+                "extract_dir": "zig-x86_64-windows-$version"
             },
             "32bit": {
                 "url": "https://ziglang.org/download/$version/zig-x86-windows-$version.zip",
-                "extract_dir": "zig-windows-aarch64-$version"
+                "extract_dir": "zig-x86-windows-$version"
             },
             "arm64": {
                 "url": "https://ziglang.org/download/$version/zig-aarch64-windows-$version.zip",
-                "extract_dir": "zig-windows-aarch64-$version"
+                "extract_dir": "zig-aarch64-windows-$version"
             }
         },
         "hash": {


### PR DESCRIPTION
Fix extract_dir and checkver

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
