### PR TITLE
1password-cli: revert to 2.30.1 and disable autoupdate

### DIFF
--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -20,7 +20,7 @@
     "notes": [
         "1Password CLI v2 completely changes the commands schema! Either migrate your setup, following ",
         "instructions on https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts ",
-        "or install 1Password CLI v1 from the Versions bucket."，
+        "or install 1Password CLI v1 from the Versions bucket.",
         "Due to https://www.1password.community/discussions/developers/1password-cli-not-working/155988,",
         "It has been pinned to 2.30.3 temporarily."
     ]

--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.31.0",
+    "version": "2.30.3",
     "description": "The 1Password command-line tool makes your 1Password account accessible entirely from the command line.",
     "homepage": "https://developer.1password.com/docs/cli",
     "license": {
@@ -8,32 +8,20 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.31.0/op_windows_amd64_v2.31.0.zip",
-            "hash": "45a1f2180d272ca8d5182974fa618033691260b33fb1a53cb425d532b08374a3"
+            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.3/op_windows_amd64_v2.30.3.zip",
+            "hash": "3191456f345aab7435252284a5196fc94ecaf7f7ca3715338f01b17e50af1386"
         },
         "32bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.31.0/op_windows_386_v2.31.0.zip",
-            "hash": "302aa41ec467ede05d471614a512c40f1f73e4b8d2645e7eb022f90675436175"
+            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.3/op_windows_386_v2.30.3.zip",
+            "hash": "ff8f901f53977dd5cfd485add72375034cb2a1a953fef9c9cd97e8595287b4c1"
         }
     },
     "bin": "op.exe",
     "notes": [
         "1Password CLI v2 completely changes the commands schema! Either migrate your setup, following ",
         "instructions on https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts ",
-        "or install 1Password CLI v1 from the Versions bucket."
-    ],
-    "checkver": {
-        "url": "https://app-updates.agilebits.com/product_history/CLI2",
-        "regex": "/op_windows_amd64_v([\\d.]+)\\.zip"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v$version/op_windows_amd64_v$version.zip"
-            },
-            "32bit": {
-                "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v$version/op_windows_386_v$version.zip"
-            }
-        }
-    }
+        "or install 1Password CLI v1 from the Versions bucket."，
+        "Due to https://www.1password.community/discussions/developers/1password-cli-not-working/155988,",
+        "It has been pinned to 2.30.3 temporarily."
+    ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

relates to https://www.1password.community/discussions/developers/1password-cli-not-working/155988

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
