### PR TITLE
use dvc.org url for download urls

### DIFF
--- a/bucket/dvc.json
+++ b/bucket/dvc.json
@@ -3,7 +3,7 @@
     "description": "Data & models versioning for ML projects, make them shareable and reproducible",
     "homepage": "https://dvc.org/",
     "license": "Apache-2.0",
-    "url": "https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-3.59.2.exe",
+    "url": "https://dvc.org/download/win/dvc-3.59.2",
     "hash": "d0c5420de635e3b56daed16d6705ae0f8eecec5bf3a2b487b0181bd7892f064b",
     "innosetup": true,
     "bin": "dvc.exe",
@@ -11,6 +11,6 @@
         "github": "https://github.com/iterative/dvc"
     },
     "autoupdate": {
-        "url": "https://s3-us-east-2.amazonaws.com/dvc-public/dvc-pkgs/exe/dvc-$version.exe"
+        "url": "https://dvc.org/download/win/dvc-$version"
     }
 }


### PR DESCRIPTION
We currently only support download URLs from dvc.org. The S3 URL is a result of us using s3 bucket for hosting packages, and we're in the process of transitioning to Cloudflare R2.

Related:
- #4942
- #4931