### PR TITLE
jaq@2.2.0: fix download link in manifest

### DIFF
--- a/bucket/jaq.json
+++ b/bucket/jaq.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.6.0",
+    "version": "2.2.0",
     "description": "A jq clone focussed on correctness, speed, and simplicity",
     "homepage": "https://github.com/01mf02/jaq/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/01mf02/jaq/releases/download/v1.6.0/jaq-v1.6.0-x86_64-pc-windows-msvc.exe#/jaq.exe",
-            "hash": "def395eb31bab8af440938cddfe24113dfb68e9e5ea199903c3c354564c2296d"
+            "url": "https://github.com/01mf02/jaq/releases/download/v2.2.0/jaq-x86_64-pc-windows-msvc.exe#/jaq.exe",
+            "hash": "09a7278599afe6d9f0ac57c40bea7a8e5062bd45da6537cae4ccd0202f61d6e3"
         },
         "32bit": {
-            "url": "https://github.com/01mf02/jaq/releases/download/v1.6.0/jaq-v1.6.0-i686-pc-windows-msvc.exe#/jaq.exe",
-            "hash": "257bd74e4f01d7bc662e5f77ceaee48fcfd3f93117d5d724d11e4ac67cf21397"
+            "url": "https://github.com/01mf02/jaq/releases/download/v2.2.0/jaq-i686-pc-windows-msvc.exe#/jaq.exe",
+            "hash": "217a53415582e1ea8ee5fad6c30888bb725d30b88c055700f352592705f5ef5e"
         }
     },
     "bin": "jaq.exe",
@@ -18,10 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/01mf02/jaq/releases/download/v$version/jaq-v$version-x86_64-pc-windows-msvc.exe#/jaq.exe"
+                "url": "https://github.com/01mf02/jaq/releases/download/v$version/jaq-x86_64-pc-windows-msvc.exe#/jaq.exe"
             },
             "32bit": {
-                "url": "https://github.com/01mf02/jaq/releases/download/v$version/jaq-v$version-i686-pc-windows-msvc.exe#/jaq.exe"
+                "url": "https://github.com/01mf02/jaq/releases/download/v$version/jaq-i686-pc-windows-msvc.exe#/jaq.exe"
             }
         }
     }


### PR DESCRIPTION
Fix download links in manifest. 

Closes #6849

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
