### PR TITLE
1password-cli: revert pin at 2.30.1

### DIFF
--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.30.3",
+    "version": "2.31.1",
     "description": "The 1Password command-line tool makes your 1Password account accessible entirely from the command line.",
     "homepage": "https://developer.1password.com/docs/cli",
     "license": {
@@ -8,20 +8,32 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.3/op_windows_amd64_v2.30.3.zip",
-            "hash": "3191456f345aab7435252284a5196fc94ecaf7f7ca3715338f01b17e50af1386"
+            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.31.1/op_windows_amd64_v2.31.1.zip",
+            "hash": "7cf3a30bde910a8087052cd453186f80b72931b94fd4e90b4c6f5485c436b451"
         },
         "32bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.3/op_windows_386_v2.30.3.zip",
-            "hash": "ff8f901f53977dd5cfd485add72375034cb2a1a953fef9c9cd97e8595287b4c1"
+            "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v2.31.1/op_windows_386_v2.31.1.zip",
+            "hash": "33739DA463138B52FD65992BDC8D6513F85E0B97C6C2BBEEFB02FD18756ED3FF"
         }
     },
     "bin": "op.exe",
     "notes": [
         "1Password CLI v2 completely changes the commands schema! Either migrate your setup, following ",
         "instructions on https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts ",
-        "or install 1Password CLI v1 from the Versions bucket.",
-        "Due to https://www.1password.community/discussions/developers/1password-cli-not-working/155988,",
-        "It has been pinned to 2.30.3 temporarily."
-    ]
+        "or install 1Password CLI v1 from the Versions bucket."
+    ],
+    "checkver": {
+        "url": "https://app-updates.agilebits.com/product_history/CLI2",
+        "regex": "/op_windows_amd64_v([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v$version/op_windows_amd64_v$version.zip"
+            },
+            "32bit": {
+                "url": "https://cache.agilebits.com/dist/1P/op2/pkg/v$version/op_windows_386_v$version.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Reverts changes made in #6841, op published a fix in version 2.31.1

see: https://www.1password.community/discussions/developers/1password-cli-not-working/155988

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
