### PR TITLE
uv: Add the "uvw" binary for shim

### DIFF
--- a/bucket/uv.json
+++ b/bucket/uv.json
@@ -15,7 +15,8 @@
     },
     "bin": [
         "uv.exe",
-        "uvx.exe"
+        "uvx.exe",
+        "uvw.exe"
     ],
     "checkver": {
         "github": "https://github.com/astral-sh/uv"


### PR DESCRIPTION
I recently [added](https://github.com/astral-sh/uv/pull/11786) a new "uvw.exe" binary to the uv repo. It is similar to what pythonw.exe does, which hides console window for uv. I believe it could be useful to add it for shim.

The binary is released since [uv 0.7.9](https://github.com/astral-sh/uv/releases/tag/0.7.9).

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
