### PR TITLE
dirx: Add version 0.30

### DIFF
--- a/bucket/dirx.json
+++ b/bucket/dirx.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.30",
+    "description": "DIR eXtended for Windows",
+    "homepage": "https://github.com/chrisant996/dirx",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/chrisant996/dirx/releases/download/v0.30/dirx-v0.30.zip",
+            "hash": "84dfe52c57f56050b955248d1a2f36c459843f75bee27b44bca93d8933b8fa27"
+        }
+    },
+    "bin": "dirx.exe",
+    "checkver": {
+        "github": "https://github.com/chrisant996/dirx"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/chrisant996/dirx/releases/download/v$version/dirx-v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds `dirx` to the main scoop bucket, by user request.

DirX is designed so that most command line options from the CMD `dir` command work the same, to make DirX mostly a drop-in replacement for `dir`.

DirX adds features like nerd font icons for file types, color coding by file attributes or names, apply color scales to file sizes or dates, and much more.

DirX is designed to be high performance.

Dirx repo at: https://github.com/chrisant996/dirx
User request: https://github.com/chrisant996/dirx/issues/10

Closes #5822 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>` -- _NOTE: the title uses the convention `<app name>: Add version <version>` per the Contributing Guide._
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
