### PR TITLE
harfbuzz@11.2.1: Remove obsolete binary name

### DIFF
--- a/bucket/harfbuzz.json
+++ b/bucket/harfbuzz.json
@@ -18,8 +18,7 @@
     "bin": [
         "hb-shape.exe",
         "hb-subset.exe",
-        "hb-view.exe",
-        "hb-ot-shape-closure.exe"
+        "hb-view.exe"
     ],
     "checkver": {
         "github": "https://github.com/harfbuzz/harfbuzz"


### PR DESCRIPTION
hb-ot-shape-closure has been gone since 11.0.1:
https://github.com/harfbuzz/harfbuzz/commit/2b5f244639079d91233662a00a3c3e149aa1be9a

Closes https://github.com/ScoopInstaller/Main/issues/6883

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
