### PR TITLE
yt-dlp@2025.06.09: switch to SHA256 for virustotal compatibility

### DIFF
--- a/bucket/yt-dlp.json
+++ b/bucket/yt-dlp.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/yt-dlp/yt-dlp/releases/download/2025.06.09/yt-dlp.exe",
-            "hash": "sha512:82c23ad07873005ffb1653fece8eba8b7b8c2b73f3fcff6c399c8075925f3afa914bfdf9ef8e720e4a2ddb2dd9945e6b8aa65ab400b6453d51cf3b13604d1799"
+            "hash": "c35921a051770047211b522af957e65a3eb4f788572533b4ce6b67b619b2a443"
         },
         "32bit": {
             "url": "https://github.com/yt-dlp/yt-dlp/releases/download/2025.06.09/yt-dlp_x86.exe#/yt-dlp.exe",
-            "hash": "sha512:62a7a3fc492b0944cb5b5bbc5dbf186b527fd3fc4e53984216b392d3967d1670074430052aefbc99bc85ecda567645e2f97b95d42ebb429178aab5eb6de4b157"
+            "hash": "48db5a676cc01b77e60794002b180ed00f12858dd85ae31190fb41fdb82e744f"
         }
     },
     "bin": "yt-dlp.exe",
@@ -34,7 +34,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/SHA2-512SUMS"
+            "url": "$baseurl/SHA2-256SUMS"
         }
     }
 }


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
