### PR TITLE
biome@1.9.4: Update version tag format for v2+

### DIFF
--- a/bucket/biome.json
+++ b/bucket/biome.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.9.4",
+    "version": "2.0.5",
     "description": "Formatter, linter, bundler, and more for JavaScript, TypeScript, JSON, HTML, Markdown, and CSS.",
     "homepage": "https://biomejs.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.4/biome-win32-x64.exe#/biome.exe",
-            "hash": "f41b4f3ff2e6366926f932ed8c07849f81c5d08b74394bf78de1d88ba0f2c807"
+            "url": "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.0.5/biome-win32-x64.exe#/biome.exe",
+            "hash": "258e7b7ecb2daeda7e60d3b8feb92ec21991a2cdc8a5ca60ff21fa620e154763"
         },
         "arm64": {
-            "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv1.9.4/biome-win32-arm64.exe#/biome.exe",
-            "hash": "fb84cab7f614258b3f6868635ada27391380753b807e3d112a054bc78cc8a948"
+            "url": "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%402.0.5/biome-win32-arm64.exe#/biome.exe",
+            "hash": "6d96e9503d0283902f542e3a167d8c4a12899e2ff78d16e53b3b3ebde6bd9e57"
         }
     },
     "bin": "biome.exe",

--- a/bucket/biome.json
+++ b/bucket/biome.json
@@ -17,15 +17,15 @@
     "checkver": {
         "url": "https://api.github.com/repos/biomejs/biome/releases",
         "jsonpath": "$..tag_name",
-        "regex": "cli/[vV]([\\d.]+)\""
+        "regex": "@biomejs/biome@([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv$version/biome-win32-x64.exe#/biome.exe"
+                "url": "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40$version/biome-win32-x64.exe#/biome.exe"
             },
             "arm64": {
-                "url": "https://github.com/biomejs/biome/releases/download/cli%2Fv$version/biome-win32-arm64.exe#/biome.exe"
+                "url": "https://github.com/biomejs/biome/releases/download/%40biomejs%2Fbiome%40$version/biome-win32-arm64.exe#/biome.exe"
             }
         }
     }


### PR DESCRIPTION
Update checkver and autoupdate URLs to match new Biome project version tagging format.

Closes #6916

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
