### PR TITLE
uv@0.7.18: Add ARM64

### DIFF
--- a/bucket/uv.json
+++ b/bucket/uv.json
@@ -4,13 +4,17 @@
     "homepage": "https://docs.astral.sh/uv/",
     "license": "Apache-2.0|MIT",
     "architecture": {
+        "32bit": {
+            "url": "https://github.com/astral-sh/uv/releases/download/0.7.18/uv-i686-pc-windows-msvc.zip",
+            "hash": "4293c65f1fce52bd5396ec4419ce1c76412e276e0f292ec2464c319b7f8d59be"
+        },
         "64bit": {
             "url": "https://github.com/astral-sh/uv/releases/download/0.7.18/uv-x86_64-pc-windows-msvc.zip",
             "hash": "5a5b3ef7c6aee0bb1101ef047f35a0fc7cc82e34eef3286e54c5badd261cb599"
         },
-        "32bit": {
-            "url": "https://github.com/astral-sh/uv/releases/download/0.7.18/uv-i686-pc-windows-msvc.zip",
-            "hash": "4293c65f1fce52bd5396ec4419ce1c76412e276e0f292ec2464c319b7f8d59be"
+        "arm64": {
+            "url": "https://github.com/astral-sh/uv/releases/download/0.7.18/uv-aarch64-pc-windows-msvc.zip",
+            "hash": "c9c78de380e459f8424f648d107d4ab5286273ab19622a5d17796dc6689de453"
         }
     },
     "bin": [
@@ -23,11 +27,14 @@
     },
     "autoupdate": {
         "architecture": {
+            "32bit": {
+                "url": "https://github.com/astral-sh/uv/releases/download/$version/uv-i686-pc-windows-msvc.zip"
+            },
             "64bit": {
                 "url": "https://github.com/astral-sh/uv/releases/download/$version/uv-x86_64-pc-windows-msvc.zip"
             },
-            "32bit": {
-                "url": "https://github.com/astral-sh/uv/releases/download/$version/uv-i686-pc-windows-msvc.zip"
+            "arm64": {
+                "url": "https://github.com/astral-sh/uv/releases/download/$version/uv-aarch64-pc-windows-msvc.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
uv has had ARM64 for a while.

* <https://github.com/astral-sh/uv/releases/tag/0.7.18>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
