### PR TITLE
rakudo-star@2025.06.1-01: correct zef extension

### DIFF
--- a/bucket/rakudo-star.json
+++ b/bucket/rakudo-star.json
@@ -28,7 +28,7 @@
         },
         "hash": {
             "url": "$url.checksums.txt",
-            "regex": "SHA256\\s+$sha256"
+            "regex": "SHA256\\s\\(\\S+\\)\\s=\\s$sha256"
         }
     }
 }


### PR DESCRIPTION
`zef.bat` is now `zef.exe`.