### PR TITLE
balena-cli: Fix and update to version 22.1.4

### DIFF
--- a/bucket/balena-cli.json
+++ b/bucket/balena-cli.json
@@ -1,16 +1,16 @@
 {
-    "version": "22.1.2",
+    "version": "22.1.4",
     "description": "Official balena CLI for interacting with balenaCloud and balena API.",
     "homepage": "https://github.com/balena-io/balena-cli",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/balena-io/balena-cli/releases/download/v22.1.2/balena-cli-v22.1.2-windows-x64-standalone.tar.gz",
-            "hash": "c2c82f85dd9046b2277e6def30b30b52c96e9701d72667a0338a82ce3a476998"
+            "url": "https://github.com/balena-io/balena-cli/releases/download/v22.1.4/balena-cli-v22.1.4-windows-x64-standalone.tar.gz",
+            "hash": "8ec9bdbfaf34f179015297fcbd397d89eac220e1cdada117f273dabc18e9e440"
         }
     },
-    "extract_dir":"balena",
-    "env_add_path": "bin",
+    "extract_dir": "balena",
+    "bin": "bin/balena.cmd",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/balena-cli.json
+++ b/bucket/balena-cli.json
@@ -1,21 +1,21 @@
 {
-    "version": "21.1.14",
+    "version": "22.1.2",
     "description": "Official balena CLI for interacting with balenaCloud and balena API.",
     "homepage": "https://github.com/balena-io/balena-cli",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/balena-io/balena-cli/releases/download/v21.1.14/balena-cli-v21.1.14-windows-x64-standalone.zip",
-            "hash": "fecd5a9374611d0c5e3477b46e480b1b4b3ab0781583acc42ed8368b96608d0b"
+            "url": "https://github.com/balena-io/balena-cli/releases/download/v22.1.2/balena-cli-v22.1.2-windows-x64-standalone.tar.gz",
+            "hash": "c2c82f85dd9046b2277e6def30b30b52c96e9701d72667a0338a82ce3a476998"
         }
     },
-    "extract_dir": "balena-cli",
-    "bin": "balena.exe",
+    "extract_dir":"balena",
+    "env_add_path": "bin",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/balena-io/balena-cli/releases/download/v$version/balena-cli-v$version-windows-x64-standalone.zip"
+                "url": "https://github.com/balena-io/balena-cli/releases/download/v$version/balena-cli-v$version-windows-x64-standalone.tar.gz"
             }
         }
     }


### PR DESCRIPTION
Fixes 404 errors in CI Excavator.

Apparently they have completely changed the distribution format and contents. A standalone executable is no longer provided, instead a cmd/bash script uses a redistributable node executable to execute the JS/TS app. Upstream recommends the installer for Windows.

Seems like no one has noticed this for 2 months, maybe should be removed from scoop?

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Relates to #773

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
