### PR TITLE
beef: Fix regex and update to 0.43.5

### DIFF
--- a/bucket/beef.json
+++ b/bucket/beef.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.43.4",
+    "version": "0.43.5",
     "description": "Performance-oriented compiled programming language which has been built hand-in-hand with its IDE environment.",
     "homepage": "https://www.beeflang.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/beefytech/Beef/releases/download/0.43.4/BeefSetup_0_43_4.exe#/dl.7z",
-            "hash": "3b7c75200987f05ced9428635239a35abd5c2196c56b3c00d3a049ffe446896f"
+            "url": "https://github.com/beefytech/Beef/releases/download/0.43.5/BeefSetup_0_43_5.exe#/dl.7z",
+            "hash": "fcce6aa255d5872f668afe40b21b8633ca972ccf34edf9421896d8beda612cc4"
         }
     },
     "bin": [
@@ -16,7 +16,9 @@
             "beef"
         ]
     ],
-    "checkver": ">Version ([\\d.]+)</",
+    "checkver": {
+        "github": "https://github.com/beefytech/Beef"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Noticed this failing in the Excavator action.

It appears that this is primarily a GUI app and really belongs in `Extras`. Executing `beef` opens a native GUI application, and a look through their website makes it clear this is a IDE with a dedicated built-in language for game development. I will switch this PR to deprecating the manifest and move it to `Extras` if anyone will confirm.
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
