### PR TITLE
fix(lua): Update manifest for 32-bit package

### DIFF
--- a/bucket/lua.json
+++ b/bucket/lua.json
@@ -1,22 +1,22 @@
 {
-    "version": "5.4.7-2",
-    "description": "A powerful, efficient, lightweight, embeddable scripting language",
+    "version": "5.4.8-1",
+    "description": "A powerful, efficient, lightweight, embeddable scripting language.",
     "homepage": "https://www.lua.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-5.4.7-2-any.pkg.tar.zst",
-            "hash": "28c382c7f33162deaa19d4722d611301ccc6825b097cb0504e3ff60ee27c392a",
+            "url": "https://mirror.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-lua-5.4.8-1-any.pkg.tar.zst",
+            "hash": "18d6fb9747d174a8707ad875c8c7fa1d7872a42af95beedd6837911a9df9cb82",
             "extract_dir": "clang64"
         },
         "32bit": {
-            "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-5.4.7-2-any.pkg.tar.zst",
-            "hash": "6d3a4555be01eac5056d574c15f6b8459b428915f09b80f037a80c4281d66439",
-            "extract_dir": "clang32"
+            "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-5.4.8-1-any.pkg.tar.zst",
+            "hash": "ec32a5f32ffa724c5523dc7000057fb45cf89e8a67852157d5e924a3ff440d79",
+            "extract_dir": "mingw32"
         },
         "arm64": {
-            "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-5.4.7-2-any.pkg.tar.zst",
-            "hash": "b00c1a7818ac6f7ef20c3b1ea75c01b205d049dc302da8fa85d609b875ee7dd2",
+            "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-5.4.8-1-any.pkg.tar.zst",
+            "hash": "c644d96a7203443c9500cbdb43fc06a607ad9337562e93f74c439489f5db5870",
             "extract_dir": "clangarm64"
         }
     },
@@ -39,8 +39,8 @@
                 "extract_dir": "clang64"
             },
             "32bit": {
-                "url": "https://mirror.msys2.org/mingw/clang32/mingw-w64-clang-i686-lua-$version-any.pkg.tar.zst",
-                "extract_dir": "clang32"
+                "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-lua-$version-any.pkg.tar.zst",
+                "extract_dir": "mingw32"
             },
             "arm64": {
                 "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-lua-$version-any.pkg.tar.zst",


### PR DESCRIPTION
Closes #6976

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

I've updated i686 package to mingw32 build which is the cause of prevention of manifest update.
And then applied updated packages' information to the manifest.