### PR TITLE
espanso: Add `espanso.cmd` to bin for CLI

### DIFF
--- a/bucket/espanso.json
+++ b/bucket/espanso.json
@@ -13,7 +13,10 @@
         }
     },
     "innosetup": true,
-    "bin": "espansod.exe",
+    "bin": [
+        "espanso.cmd",
+        "espansod.exe"
+    ],
     "shortcuts": [
         [
             "espansod.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Add `espanso.cmd` to bin for the CLI. For example, the [Espanso docs ask you to run `espanso path` to find your config files](https://espanso.org/docs/get-started/#configuration).
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
