### PR TITLE
go-feature-flag: Fix and update to v1.45.5

### DIFF
--- a/bucket/go-feature-flag.json
+++ b/bucket/go-feature-flag.json
@@ -1,50 +1,43 @@
 {
-    "version": "1.34.3",
+    "version": "1.45.5",
     "description": "Simple, complete, and lightweight feature flag solution",
     "homepage": "https://gofeatureflag.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag_1.34.3_Windows_x86_64.tar.gz",
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag-migration-cli_1.34.3_Windows_x86_64.tar.gz",
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag-lint_1.34.3_Windows_x86_64.tar.gz"
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.45.5/go-feature-flag_1.45.5_Windows_x86_64.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.45.5/go-feature-flag-cli_1.45.5_Windows_x86_64.tar.gz"
             ],
             "hash": [
-                "7d9a3afdd6792115f9acb1c4ba82e6c912cd3bddecdfcd5db3eadddc5b6680cf",
-                "66e74fcf24f04b6e563657cc81879bf82695acf735ecd62dd9bd378fc5676165",
-                "326ce6f3c867b270ce4bcadd89b0f31238f83eff16a1baaa2cc46a67c34dbac2"
+                "420c41365a82431a163eb11cf209eed391206ac20662b31166029e6ada76821f",
+                "2f08be5eb7f21c0a942cb229ee6964ed7016554bb7274bc1e5d62d22494e01d2"
             ]
         },
         "32bit": {
             "url": [
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag_1.34.3_Windows_i386.tar.gz",
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag-migration-cli_1.34.3_Windows_i386.tar.gz",
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag-lint_1.34.3_Windows_i386.tar.gz"
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.45.5/go-feature-flag_1.45.5_Windows_i386.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.45.5/go-feature-flag-cli_1.45.5_Windows_i386.tar.gz"
             ],
             "hash": [
-                "71cf6e6e472c1fb5fe49800ddbeb3b0ac87a21e764d61d29b93ca3b9e72d1cd4",
-                "27687be16ca3d450c3f6bb4713f83878538604188f55139935b3cf39af8bd199",
-                "474ded57de32849d8355a95119f93c5122b3063cc498e26b0193b2b3277758b0"
+                "ea2c01290a4de53d09899ec989279f786a318a7bf855a96f898b43c6973f4ac0",
+                "e75f08756e31ad952dde016719030d2750aa12a90456a8e4f0973a76a3eccb72"
             ]
         },
         "arm64": {
             "url": [
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag_1.34.3_Windows_arm64.tar.gz",
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag-migration-cli_1.34.3_Linux_arm64.tar.gz",
-                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.34.3/go-feature-flag-lint_1.34.3_Windows_arm64.tar.gz"
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.45.5/go-feature-flag_1.45.5_Windows_arm64.tar.gz",
+                "https://github.com/thomaspoignant/go-feature-flag/releases/download/v1.45.5/go-feature-flag-cli_1.45.5_Windows_arm64.tar.gz"
             ],
             "hash": [
-                "1f1ce2e7b1646ec7b79d37dfcc8af420c4465d2b293db3fa479eca3316bc6212",
-                "0b2f5ab0c33edd5e1a6ff6c357f0b7b0b8f7bacb7a323d6643eb15ab3d943d1c",
-                "1adf08e8952d2006bc7b6d2a37804ce9609aef62e0b1963cf9e76dc24d4da173"
+                "644949bdea4b8dc26c3bd5bd941e247d6f234e5e455c5cafc431cf252c218367",
+                "ef5db654bdfb03f32bca06fbab75e8bbdc2e707627d2290fd4374ec529e77340"
             ]
         }
     },
     "bin": [
         "go-feature-flag.exe",
-        "go-feature-flag-migration-cli.exe",
-        "go-feature-flag-lint.exe"
+        "go-feature-flag-cli.exe"
     ],
     "checkver": {
         "github": "https://github.com/thomaspoignant/go-feature-flag"
@@ -54,22 +47,19 @@
             "64bit": {
                 "url": [
                     "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_x86_64.tar.gz",
-                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-migration-cli_$version_Windows_x86_64.tar.gz",
-                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-lint_$version_Windows_x86_64.tar.gz"
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-cli_$version_Windows_x86_64.tar.gz"
                 ]
             },
             "32bit": {
                 "url": [
                     "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_i386.tar.gz",
-                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-migration-cli_$version_Windows_i386.tar.gz",
-                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-lint_$version_Windows_i386.tar.gz"
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-cli_$version_Windows_i386.tar.gz"
                 ]
             },
             "arm64": {
                 "url": [
                     "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag_$version_Windows_arm64.tar.gz",
-                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-migration-cli_$version_Linux_arm64.tar.gz",
-                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-lint_$version_Windows_arm64.tar.gz"
+                    "https://github.com/thomaspoignant/go-feature-flag/releases/download/v$version/go-feature-flag-cli_$version_Windows_arm64.tar.gz"
                 ]
             }
         },


### PR DESCRIPTION
Actual version of the GO Feature Flag scoop is not valid anymore because we have changed the release process for the binaries.

This new manifest is updated to be compatible with the actual process.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
