### PR TITLE
amazon-ecr-credential-helper: Add version 0.10.1

### DIFF
--- a/bucket/amazon-ecr-credential-helper.json
+++ b/bucket/amazon-ecr-credential-helper.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.10.1",
+    "description": "Amazon ECR credential helper for Docker",
+    "homepage": "https://github.com/awslabs/amazon-ecr-credential-helper",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.10.1/windows-amd64/docker-credential-ecr-login.exe",
+            "hash": "ab027dbbd5079c66a326a48a926a50562e07bb2ba009969a651a0a08481b5a1d"
+        },
+        "arm64": {
+            "url": "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.10.1/windows-arm64/docker-credential-ecr-login.exe",
+            "hash": "fd5ff48a2b10f98cba639750cbbecf955620edaea6b246c4e2bd9280ba4ed5e4"
+        }
+    },
+    "bin": "docker-credential-ecr-login.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/$version/windows-amd64/docker-credential-ecr-login.exe"
+            },
+            "arm64": {
+                "url": "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/$version/windows-arm64/docker-credential-ecr-login.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Amazon ECR Docker Credential Helper.

Closes #6988 

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)