### PR TITLE
argo-rollouts-kubectl-plugin: Add version 1.8.3

### DIFF
--- a/bucket/argo-rollouts-kubectl-plugin.json
+++ b/bucket/argo-rollouts-kubectl-plugin.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.8.3",
+    "description": "Argo Rollouts kubectl plugin",
+    "homepage": "https://github.com/argoproj/argo-rollouts",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/argoproj/argo-rollouts/releases/download/v1.8.3/kubectl-argo-rollouts-windows-amd64",
+            "hash": "b02566c538b0d8ec564544e5899795e4e4136adfecbc8d467c5dce74b102c697"
+        }
+    },
+    "pre_install": "if ($architecture -eq '64bit') { Rename-Item \"$dir\\kubectl-argo-rollouts-windows-amd64\" \"$dir\\kubectl-argo-rollouts.exe\" }",
+    "bin": "kubectl-argo-rollouts.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/argoproj/argo-rollouts/releases/download/v$version/kubectl-argo-rollouts-windows-amd64"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Argo Rollouts Kubectl Plugin

Closes #6990 

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
