### PR TITLE
flyway@11.10.4: correct URL, update

### DIFF
--- a/bucket/flyway.json
+++ b/bucket/flyway.json
@@ -1,15 +1,15 @@
 {
-    "version": "11.8.2",
+    "version": "11.10.4",
     "description": "Database migration tool that favors simplicity and convention over configuration.",
     "homepage": "https://flywaydb.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/11.8.2/flyway-commandline-11.8.2-windows-x64.zip",
-            "hash": "sha1:05dac3c51926f8afb63ac625fff668014d4d53ff"
+            "url": "https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/11.10.4/flyway-commandline-11.10.4-windows-x64.zip",
+            "hash": "sha1:2e57855dd20d82d29bd86df45112011c0478ef2d"
         }
     },
-    "extract_dir": "flyway-11.8.2",
+    "extract_dir": "flyway-11.10.4",
     "bin": "flyway.cmd",
     "persist": [
         "conf",
@@ -17,13 +17,13 @@
         "jars"
     ],
     "checkver": {
-        "url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/maven-metadata.xml",
+        "url": "https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/maven-metadata.xml",
         "regex": "<release>(\\S+)</release>"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/$version/flyway-commandline-$version-windows-x64.zip"
+                "url": "https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/$version/flyway-commandline-$version-windows-x64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
maven.org is two minor versions behind.
Change URL to download.red-gate.com.
