### PR TITLE
rfortune: Add version 0.2.2

### DIFF
--- a/bucket/rfortune.json
+++ b/bucket/rfortune.json
@@ -6,7 +6,7 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/umpire274/rFortune/releases/download/v0.2.2/rfortune-x86_64-pc-windows-msvc.zip",
-      "hash": "e9a746c7075c7306a5621c22c8cd9eaff4bdeabf3b18f4b5748dc428e6996071"
+      "hash": "e9a746c7075c7306a5621c22c8cd9eaff4bdeabf3b18f4b5748dc428e6996071",
       "bin": "rfortune.exe"
     }
   },


### PR DESCRIPTION
Add [rfortune v0.2.2](https://github.com/umpire274/rFortune) – a Rust-based clone of the classic UNIX fortune command

This pull request adds the `rfortune` CLI tool, version 0.2.2.

`rfortune` is a cross-platform, Rust-based reimplementation of the classic UNIX `fortune` command. It selects and displays a random quote from a `.dat` file, formatted in the BSD style (delimited by `%`).

The tool is lightweight, portable, and ideal for terminal messages or scripting. It is already available on:
- crates.io
- Homebrew
- AUR

This PR adds Scoop support for Windows users via official bucket.

No related issue.

- [x] Use conventional PR title: `rfortune@0.2.2: Add new manifest`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
