### PR TITLE
rfortune: add new v0.3.0

### DIFF
--- a/bucket/rfortune.json
+++ b/bucket/rfortune.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/umpire274/rFortune/releases/download/v0.3.0/rfortune-x86_64-pc-windows-msvc.zip",
-      "hash": "d611cac83b1f782a6ba800dc523232f399c062a7ecdc58dd41932341086a68ee",
+      "url": "https://github.com/umpire274/rFortune/releases/download/v0.3.0/rfortune-0.3.0-x86_64-pc-windows-msvc.zip",
+      "hash": "0c93aabe2b388b648e37d8c932b03a13dbfd12df7440dd213b52599b6b620ae4",
       "bin": "rfortune.exe"
     }
   },


### PR DESCRIPTION
Add rfortune v0.3.0 – a Rust-based clone of the classic UNIX fortune command

This pull request adds the `rfortune` CLI tool, version 0.3.0.

`rfortune` is a cross-platform, Rust-based reimplementation of the classic UNIX `fortune` command. It selects and displays a random quote from a `.dat` file, formatted in the BSD style (delimited by `%`).

The tool is lightweight, portable, and ideal for terminal messages or scripting. It is already available on:
- crates.io
- Homebrew
- AUR

This PR adds Scoop support for Windows users via official bucket.

No related issue.

- [x] Use conventional PR title: `rfortune@0.3.0: Add new manifest`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
