### PR TITLE
tenv@4.7.6: Add x86

### DIFF
--- a/bucket/tenv.json
+++ b/bucket/tenv.json
@@ -6,7 +6,7 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/tofuutils/tenv/releases/download/v4.7.6/tenv_v4.7.6_Windows_i386.zip",
-            "hash": "622fdfdaa80b5a4a9d233c3006b6d4f8544c3b58cef502e823f608f82afe117d"
+            "hash": "6812e0dfe1fe2ae94717310b5a26ccf2bdbbf949fbab5b365e104a3bf1ea69fd"
         },
         "64bit": {
             "url": "https://github.com/tofuutils/tenv/releases/download/v4.7.6/tenv_v4.7.6_Windows_x86_64.zip",

--- a/bucket/tenv.json
+++ b/bucket/tenv.json
@@ -4,6 +4,10 @@
     "homepage": "https://tofuutils.github.io/tenv/",
     "license": "Apache-2.0",
     "architecture": {
+        "32bit": {
+            "url": "https://github.com/tofuutils/tenv/releases/download/v4.7.6/tenv_v4.7.6_Windows_i386.zip",
+            "hash": "622fdfdaa80b5a4a9d233c3006b6d4f8544c3b58cef502e823f608f82afe117d"
+        },
         "64bit": {
             "url": "https://github.com/tofuutils/tenv/releases/download/v4.7.6/tenv_v4.7.6_Windows_x86_64.zip",
             "hash": "c6637fbac9b9760fcba620a7d42a70aa1b99e79fc69fb743b4b9e0ea10c2aae0"
@@ -26,6 +30,9 @@
     },
     "autoupdate": {
         "architecture": {
+            "32bit": {
+                "url": "https://github.com/tofuutils/tenv/releases/download/v$version/tenv_v$version_Windows_i386.zip"
+            },
             "64bit": {
                 "url": "https://github.com/tofuutils/tenv/releases/download/v$version/tenv_v$version_Windows_x86_64.zip"
             },


### PR DESCRIPTION
Closes #7033

I thought ARM64 was missing, but it wasn't. So added x86 instead.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
