### PR TITLE
dart@3.8.0: Remove 32bit installer sections

### DIFF
--- a/bucket/dart.json
+++ b/bucket/dart.json
@@ -9,10 +9,6 @@
         "64bit": {
             "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.8.0/sdk/dartsdk-windows-x64-release.zip",
             "hash": "08e6b2450cea4ea8afb8f278acc55bc2da01f84a3a4d53a946b6bf4f75a7b270"
-        },
-        "32bit": {
-            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.8.0/sdk/dartsdk-windows-ia32-release.zip",
-            "hash": "787ea851ffbcb8147c6bfb4c544a9771a2f6abea73bc09feba3f9ff03f7feca9"
         }
     },
     "checkver": {
@@ -23,9 +19,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/$version/sdk/dartsdk-windows-x64-release.zip"
-            },
-            "32bit": {
-                "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/$version/sdk/dartsdk-windows-ia32-release.zip"
             }
         },
         "hash": {

--- a/bucket/dart.json
+++ b/bucket/dart.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.8.0",
+    "version": "3.9.0",
     "description": "SDK for the Dart programming language",
     "homepage": "https://dart.dev/",
     "license": "BSD-3-Clause",
@@ -7,8 +7,8 @@
     "env_add_path": "bin",
     "architecture": {
         "64bit": {
-            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.8.0/sdk/dartsdk-windows-x64-release.zip",
-            "hash": "08e6b2450cea4ea8afb8f278acc55bc2da01f84a3a4d53a946b6bf4f75a7b270"
+            "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/3.9.0/sdk/dartsdk-windows-x64-release.zip",
+            "hash": "2ff493a784daa8d9d80380c47856e09830cf0e9b9a9ce0d86780769f40290604"
         }
     },
     "checkver": {


### PR DESCRIPTION
The manifest was failing to update because Dart removed ia32 (32-bit) packages from 3.8.0 onwards.

Relates to #7067.