### PR TITLE
aqua: fix arm64 version

### DIFF
--- a/bucket/aqua.json
+++ b/bucket/aqua.json
@@ -9,8 +9,8 @@
             "hash": "91ea25575782c1573c9245b0b4532938e02f4a3874da1ac1fe1f8b3a3901de67"
         },
         "arm64": {
-            "url": "https://github.com/aquaproj/aqua/releases/download/v2.53.9/aqua_windows_amd64.zip",
-            "hash": "91ea25575782c1573c9245b0b4532938e02f4a3874da1ac1fe1f8b3a3901de67"
+            "url": "https://github.com/aquaproj/aqua/releases/download/v2.53.9/aqua_windows_arm64.zip",
+            "hash": "5628572c6e5ac5c215094f82f1414da83ef8bc744fe2fa172dcb32eaaca666fb"
         }
     },
     "bin": "aqua.exe",
@@ -23,7 +23,7 @@
                 "url": "https://github.com/aquaproj/aqua/releases/download/v$version/aqua_windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/aquaproj/aqua/releases/download/v$version/aqua_windows_amd64.zip"
+                "url": "https://github.com/aquaproj/aqua/releases/download/v$version/aqua_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Manifest for aqua had mistakenly used `amd64` in the `arm64` links.