### PR TITLE
sonarqube: Update to version 25.8.0.112029

### DIFF
--- a/bucket/sonarqube.json
+++ b/bucket/sonarqube.json
@@ -4,9 +4,9 @@
     "homepage": "https://www.sonarsource.com/products/sonarqube/",
     "license": "LGPL-3.0-only",
     "notes": [
-        "Start SonarQube server by running: \"StartSonar\" or \"$dir\\bin\\windows-x86-64\\StartSonar.bat\".",
-        "Note that it requires Java version 17 or 21 to function. Using Java 24 or higher will cause a startup failure.",
-        "For more infomations, please refer to:",
+        "Start the SonarQube server via: \"StartSonar\" or \"$dir\\bin\\windows-x86-64\\StartSonar.bat\".",
+        "Requires Java 17 or 21. Using Java 24 or newer currently causes startup failure.",
+        "For more information, see:",
         "https://docs.sonarsource.com/sonarqube-server/latest/server-installation/server-host-requirements/#software-requirements",
         "https://docs.oracle.com/en/java/javase/24/security/security-manager-is-permanently-disabled.html"
     ],


### PR DESCRIPTION
This PR makes the following changes:
- `sonarqube`:
    - Update to version 25.8.0.112029, Fix checkver,
    - Fix suggest & bin, add notes.
    Note: SonarQube requires Java version 17 or 21 to function. Using Java 24 or higher will cause a startup failure.
    ```console
    PS> startsonar
    Starting SonarQube...
    ...
    Exception in thread "main" java.lang.UnsupportedOperationException: Setting a Security Manager is not supported
    ···
    2025.08.19 07:36:46 INFO  app[][o.s.a.SchedulerImpl] SonarQube is stopped
    ```
See also:
- https://docs.sonarsource.com/sonarqube-server/latest/server-installation/server-host-requirements/#software-requirements
- https://docs.oracle.com/en/java/javase/24/security/security-manager-is-permanently-disabled.html

Closes #7115
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Easier startup with direct StartSonar script exposure.
  - Explicit support for Java 17 and Java 21 runtimes.

- Documentation
  - Added startup notes with Java requirements and links to official docs.
  - Homepage updated to SonarSource product page.

- Chores
  - Upgraded SonarQube to 25.9.0.
  - Improved version detection, changed download source, and switched integrity checks to SHA-256.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->