### PR TITLE
harfbuzz@11.4.2: fix extraction (ref #7084,#7052)

### DIFF
--- a/bucket/harfbuzz.json
+++ b/bucket/harfbuzz.json
@@ -6,17 +6,16 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/harfbuzz/harfbuzz/releases/download/11.4.2/harfbuzz-win64-11.4.2.zip",
-            "hash": "6cf16144f4baf7cdcfdd67f4a74bfc56d357a50b174aa47da976c92424f27e71"
+            "hash": "6cf16144f4baf7cdcfdd67f4a74bfc56d357a50b174aa47da976c92424f27e71",
+            "extract_dir": "harfbuzz-win64"
         },
         "32bit": {
             "url": "https://github.com/harfbuzz/harfbuzz/releases/download/11.4.2/harfbuzz-win32-11.4.2.zip",
-            "hash": "0a44a65355fb1f8272a15daed8550ddba8e1ca3b23c914456ffa2a6e81215f5c"
+            "hash": "0a44a65355fb1f8272a15daed8550ddba8e1ca3b23c914456ffa2a6e81215f5c",
+            "extract_dir": "harfbuzz-win32"
         }
     },
-    "pre_install": [
-        "$innerdir = if ($architecture -eq '32bit') { 'harfbuzz-win32' } else { 'harfbuzz-win64' }",
-        "Expand-ZipArchive -Path \"$dir\\$innerdir.zip\" -DestinationPath \"$dir\" -ExtractDir $innerdir -Removal"
-    ],
+    
     "bin": [
         "hb-shape.exe",
         "hb-subset.exe",

--- a/bucket/harfbuzz.json
+++ b/bucket/harfbuzz.json
@@ -15,7 +15,6 @@
             "extract_dir": "harfbuzz-win32"
         }
     },
-    
     "bin": [
         "hb-shape.exe",
         "hb-subset.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #7084

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured correct installation for 32-bit and 64-bit Windows by using architecture-specific extraction folders, preventing files from being placed in the wrong location.
* **Refactor**
  * Simplified the installation flow by removing the pre-install extraction logic.
* **Chores**
  * Aligned manifest structure with per-architecture conventions; no changes to version, download URLs, or hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->