### PR TITLE
adguardhome: Add version 0.107.71

### DIFF
--- a/bucket/adguardhome.json
+++ b/bucket/adguardhome.json
@@ -1,26 +1,26 @@
 {
-    "version": "0.107.65",
+    "version": "0.107.71",
     "description": "Network-wide ads & trackers blocking DNS server",
     "homepage": "https://adguard.com/en/adguard-home/overview.html",
     "license": "GPL-3.0-or-later",
-    "extract_dir": "AdGuardHome",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.65/AdGuardHome_windows_amd64.zip",
-            "hash": "8961757c377d59d4f52d52c4e0352e1017971c6e36b0a8bfac28cc04361f2e51"
+            "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.71/AdGuardHome_windows_amd64.zip",
+            "hash": "366af0f93e496ef96f13cb3ac1e0004fbd195a9d02ffc6bb4ff69aa20067190d"
         },
         "32bit": {
-            "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.65/AdGuardHome_windows_386.zip",
-            "hash": "219eddbb3a95e67ce889097c7dc1454f1e7c6e45195c23b2395ce5e80160b3b5"
+            "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.71/AdGuardHome_windows_386.zip",
+            "hash": "821382b8cb629ecd0d7d07808cb759a3dc1fe3becca3960412a4384c6ea64f3b"
         },
         "arm64": {
-            "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.65/AdGuardHome_windows_arm64.zip",
-            "hash": "210b40a5f2c83e49ff60dc2602057dcbb1189e11971d77f15901f35115bc5910"
+            "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.71/AdGuardHome_windows_arm64.zip",
+            "hash": "50ee696c74a82032bc45e75b581331a397432d381e7482f934bfa033aa025181"
         }
     },
+    "extract_dir": "AdGuardHome",
     "bin": "AdGuardHome.exe",
     "checkver": {
-        "github": "https://github.com/AdguardTeam/AdGuardHome/"
+        "github": "https://github.com/AdguardTeam/AdGuardHome"
     },
     "autoupdate": {
         "architecture": {
@@ -33,6 +33,9 @@
             "arm64": {
                 "url": "https://github.com/AdguardTeam/AdGuardHome/releases/download/v$version/AdGuardHome_windows_arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows package manifest for AdGuard Home (v0.107.71) with installers for 64-bit, 32-bit, and ARM64 and integrity hashes.

* **Bug Fixes / Improvements**
  * Automatic update configuration aligned to GitHub releases; autoupdate reorganized to provide per-architecture update URLs.
  * Official homepage set; license maintained as GPL-3.0-or-later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->