### PR TITLE
reyohoho: Add ReYohoho Desktop 1.1.21

### DIFF
--- a/bucket/reyohoho.json
+++ b/bucket/reyohoho.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.1.21",
+  "description": "ReYohoho Desktop — Electron/Vue3 desktop client",
+  "homepage": "https://github.com/reyohoho/reyohoho-desktop",
+  "license": "MIT",
+  "url": "https://github.com/reyohoho/reyohoho-desktop/releases/download/1.1.21/ReYohoho.Setup.1.1.21_x64.exe",
+  "hash": "sha512:C62mCLZkGwIHHidYjI1aGUh33V05362tcvZdVXg4bgKYgNeWeNIjCHnitGBkXHmNyAZf5mVai8YTuyoue1ydJg==",
+  "installer": {
+    "args": ["/S"]
+  },
+  "shortcuts": [
+    [
+      "ReYohoho.exe",
+      "ReYohoho"
+    ]
+  ]
+}


### PR DESCRIPTION
ReYohoho Desktop is a modern Electron/Vue3 desktop client for streaming movies and TV shows online.

- **Version:** 1.1.21
- **License:** MIT
- **Installer:** NSIS with silent installation support (`/S`)
- **URL:** https://github.com/reyohoho/reyohoho-desktop/releases/download/1.1.21/ReYohoho.Setup.1.1.21_x64.exe

This PR adds the `reyohoho.json` manifest to the Main bucket.


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows installer manifest for ReYohoho Desktop 1.1.21, enabling installation via package manager.
  * Supports silent installation ("/S") and creates a desktop shortcut named "ReYohoho".
  * Includes app metadata such as version, description, homepage, license, download URL, and integrity hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->