### PR TITLE
k2tf: Fix excavator error, update to 0.8.0, add Arm

### DIFF
--- a/bucket/k2tf.json
+++ b/bucket/k2tf.json
@@ -1,12 +1,16 @@
 {
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "Converts Kubernetes API Objects (in YAML format) into HashiCorp's Terraform configuration language.",
     "homepage": "https://github.com/sl1pm4t/k2tf",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sl1pm4t/k2tf/releases/download/v0.7.0/k2tf_0.7.0_Windows_x86_64.tar.gz",
-            "hash": "a759f8dc28941db3673f38e4ac320cad831870c3775c1757f4e768fea66d5b96"
+            "url": "https://github.com/sl1pm4t/k2tf/releases/download/v0.8.0/k2tf_0.8.0_Windows_amd64.tar.gz",
+            "hash": "850debab0a080c2317e1c0554db50cfdedd49bb28c45dac14d6de99a94b2b6c4"
+        },
+        "arm64": {
+            "url": "https://github.com/sl1pm4t/k2tf/releases/download/v0.8.0/k2tf_0.8.0_Windows_arm64.tar.gz",
+            "hash": "ed9f243a9eca66e75c9ff140fbd8a203705c1115ee788cabc5cdc80d13a09705"
         }
     },
     "bin": "k2tf.exe",
@@ -14,7 +18,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sl1pm4t/k2tf/releases/download/v$version/k2tf_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/sl1pm4t/k2tf/releases/download/v$version/k2tf_$version_Windows_amd64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/sl1pm4t/k2tf/releases/download/v$version/k2tf_$version_Windows_arm64.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
Update URLs to new format, and add ARM64 architecture.

This manifest has been erroring during excavator runs, presumable since v0.8.0 was released (March 18, 2024)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
