### PR TITLE
jx: Update to version 3.16.21

### DIFF
--- a/bucket/jx.json
+++ b/bucket/jx.json
@@ -1,28 +1,23 @@
 {
-    "version": "3.10.182",
-    "description": "A command line tool for installing and using Jenkins X",
-    "homepage": "https://github.com/jenkins-x/jx",
+    "version": "3.16.21",
+    "description": "Jenkins X provides automated CI+CD for Kubernetes with Preview Environments on Pull Requests",
+    "homepage": "https://jenkins-x.io/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jenkins-x/jx/releases/download/v3.10.182/jx-windows-amd64.zip",
-            "hash": "a615777fb4e0a89887a4d0124a8d857185790f9ec761975e68810280f11e9b0c"
-        },
-        "arm64": {
-            "url": "https://github.com/jenkins-x/jx/releases/download/v3.10.182/jx-windows-arm64.zip",
-            "hash": "00e50a12dbc6f04d1a89fb00fdc64670e0e3fe9b9f98c5fb14935190b57b0c6e"
+            "url": "https://github.com/jenkins-x/jx/releases/download/v3.16.21/jx-windows-amd64.zip",
+            "hash": "66324bf873a94ccb22fcd98a50c52e8ed1b490d2fe33d039ca005d7e814f0899"
         }
     },
     "pre_install": "Stop-Process -Name 'jx' -ErrorAction 'Ignore' -Verbose",
     "bin": "jx.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/jenkins-x/jx"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/jenkins-x/jx/releases/download/v$version/jx-windows-amd64.zip"
-            },
-            "arm64": {
-                "url": "https://github.com/jenkins-x/jx/releases/download/v$version/jx-windows-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Looks like they are no longer offering ARM releases, so this manifest has been causing errors during Excavator runs. I removed the Arm64 link, and updated the description and homepage to match their current github page.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Sorta relates to #773 
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
