### PR TITLE
jruby: Fix URL and update to version 10.0.2.0

### DIFF
--- a/bucket/jruby.json
+++ b/bucket/jruby.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.0.0.0",
+    "version": "10.0.2.0",
     "description": "The Ruby Programming Language on the JVM.",
     "homepage": "https://www.jruby.org/",
     "license": {
@@ -13,9 +13,9 @@
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://s3.amazonaws.com/jruby.org/downloads/10.0.0.0/jruby-bin-10.0.0.0.zip",
-    "hash": "2d65d414c22393309e45e8a6afec2c5c5714e75b218860ba849a41fb680b4291",
-    "extract_dir": "jruby-10.0.0.0",
+    "url": "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.2.0/jruby-dist-10.0.2.0-bin.zip",
+    "hash": "cc85bc72152d29629585e53ebf85723725bbd506d985695c3ad3822aadbf8202",
+    "extract_dir": "jruby-10.0.2.0",
     "env_add_path": [
         "bin",
         "gems\\bin"
@@ -31,7 +31,7 @@
         "regex": "Current Release:\\s+JRuby\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://s3.amazonaws.com/jruby.org/downloads/$version/jruby-bin-$version.zip",
+        "url": "https://repo1.maven.org/maven2/org/jruby/jruby-dist/$version/jruby-dist-$version-bin.zip",
         "hash": {
             "url": "$url.sha256"
         },


### PR DESCRIPTION
Fixing another Excavator error.

Looks like they switched file hosting from AWS to Maven. The same files are available from the github releases, so it may make since to switch to github style autoupdate for this one...

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Relates to #773 
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated JRuby to version 10.0.2.0.
  - Switched download source to Maven Central for the new distribution.
  - Refreshed checksum to match the new release.
  - Adjusted extraction directory to align with 10.0.2.0.
  - Updated autoupdate configuration to use the new source path.

Impact: Users receive the latest JRuby with more reliable downloads and streamlined updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->