### PR TITLE
mill: Fix urls and update to 1.0.4

### DIFF
--- a/bucket/mill.json
+++ b/bucket/mill.json
@@ -1,18 +1,18 @@
 {
-    "version": "0.12.5",
+    "version": "1.0.4",
     "description": "Build tool aiming for Java and Scala.",
-    "homepage": "https://mill-build.com/",
+    "homepage": "https://mill-build.org",
     "license": "MIT",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://github.com/com-lihaoyi/mill/releases/download/0.12.5/0.12.5-assembly#/mill.bat",
-    "hash": "0c7b25412feecf06d955d013418de9a9080ce755bedbac7601c9109c33d5a057",
+    "url": "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.bat#/mill.bat",
+    "hash": "b12f533eea3f951a2e90898a84266af3677a8fddcf116d0acfd03e1f4b8c8224",
     "bin": "mill.bat",
     "checkver": {
         "github": "https://github.com/com-lihaoyi/mill"
     },
     "autoupdate": {
-        "url": "https://github.com/com-lihaoyi/mill/releases/download/$matchHead/$version-assembly#/mill.bat"
+        "url": "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/$version/mill-dist-$version-mill.bat#/mill.bat"
     }
 }


### PR DESCRIPTION
The github releases are not longer including the wrapper/install .bat script. I used the maven repository link referenced in some of their [manual installation method documentation.](https://mill-build.org/mill/cli/installation-ide.html#_bootstrap_scripts)
Also updated the homepage url to a working one.

Fairly important that this works, as their documentation references scoop as an installation method.

Relates to #773

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded Mill to version 1.0.4.
  - Switched downloads to Maven Central for more reliable installs and updates.
  - Updated integrity checksum for the new release.

- Documentation
  - Updated homepage link to the new official site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->