### PR TITLE
dafny: Update to version 4.11.0 and fix update url

### DIFF
--- a/bucket/dafny.json
+++ b/bucket/dafny.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.10.0",
+    "version": "4.11.0",
     "description": "A programming language with a program verifier",
     "homepage": "https://dafny-lang.github.io/dafny/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dafny-lang/dafny/releases/download/v4.10.0/dafny-4.10.0-x64-windows-2019.zip",
-            "hash": "e048a91fe84b8587f62334968e145d3e78312f6b2ab4465a24eaf7e94fca5028",
+            "url": "https://github.com/dafny-lang/dafny/releases/download/v4.11.0/dafny-4.11.0-x64-windows-2022.zip",
+            "hash": "3653f05a111ca21e234709ea7b25ce96083fd6c6f10484256ba54110dbc0654d",
             "extract_dir": "dafny"
         }
     },
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/dafny-lang/dafny/releases/download/v$version/dafny-$version-x64-windows-2019.zip"
+                "url": "https://github.com/dafny-lang/dafny/releases/download/v$version/dafny-$version-x64-windows-2022.zip"
             }
         }
     }


### PR DESCRIPTION
Excavator was failing.
Windows version(?) changed in the artifact naming template. This fixes the url for  the 4.11.0 update.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Dafny package to version 4.11.0 for 64‑bit Windows.
  * Updated download source and checksum to match the new release.
  * Autoupdate now targets the Windows 2022 build.

* **User Impact**
  * Access to the latest Dafny features and fixes.
  * Improved compatibility with newer Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->