### PR TITLE
fake: Update to version 6.1.3 and fix urls

### DIFF
--- a/bucket/fake.json
+++ b/bucket/fake.json
@@ -5,25 +5,25 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fsharp/FAKE/releases/download/6.1.3/fake-dotnetcore-win-x64.zip",
+            "url": "https://github.com/fsprojects/fake/releases/download/6.1.3/fake-dotnetcore-win-x64.zip",
             "hash": "ff8ed31be028f5ee04d9bc46faaec67c323bfb001e688ddff08f42be5cc518cb"
         },
         "32bit": {
-            "url": "https://github.com/fsharp/FAKE/releases/download/6.1.3/fake-dotnetcore-win-x86.zip",
+            "url": "https://github.com/fsprojects/fake/releases/download/6.1.3/fake-dotnetcore-win-x86.zip",
             "hash": "a83918d43178192096cc5afd3d4c98ce36c9ad646cee947e63913cc412844aad"
         }
     },
     "bin": "fake.exe",
     "checkver": {
-        "github": "https://github.com/fsharp/FAKE"
+        "github": "https://github.com/fsprojects/fake"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/fsharp/FAKE/releases/download/$version/fake-dotnetcore-win-x64.zip"
+                "url": "https://github.com/fsprojects/fake/releases/download/$version/fake-dotnetcore-win-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/fsharp/FAKE/releases/download/$version/fake-dotnetcore-win-x86.zip"
+                "url": "https://github.com/fsprojects/fake/releases/download/$version/fake-dotnetcore-win-x86.zip"
             }
         }
     }


### PR DESCRIPTION
Excavator was failing due to very slight naming change in their release artifacts.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded FAKE to version 6.1.3 for Windows.
  - Switched to the fsprojects release artifacts and updated the source used for version checks.
  - Adopted generic artifact names (win-x64 / win-x86), removing the previous win7 qualifiers.
  - Updated installer checksums and autoupdate links to match the new version and filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->