### PR TITLE
gk: Update to version 3.1.10 and fix urls

### DIFF
--- a/bucket/gk.json
+++ b/bucket/gk.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.2",
+    "version": "3.1.10",
     "description": "GitKraken CLI",
     "homepage": "https://www.gitkraken.com/cli",
     "license": {
@@ -8,16 +8,16 @@
     },
     "architecture": {
         "32bit": {
-            "url": "https://github.com/gitkraken/gk-cli/releases/download/v2.1.2/gk_2.1.2_Windows_i386.zip",
-            "hash": "17cfb0f67174a8cb83eee61424dba75efbd0513a9deeab7f2b101aa130a13e1e"
+            "url": "https://github.com/gitkraken/gk-cli/releases/download/v3.1.10/gk_3.1.10_windows_386.zip",
+            "hash": "3911771d72e6b5f403e946a01e6f0ed059e384900065447d474aa2a6536b6391"
         },
         "64bit": {
-            "url": "https://github.com/gitkraken/gk-cli/releases/download/v2.1.2/gk_2.1.2_Windows_x86_64.zip",
-            "hash": "e39c63abe11567da4be2e846e6ce84c11aa2d7f8ad778c0d37811e853baeafb7"
+            "url": "https://github.com/gitkraken/gk-cli/releases/download/v3.1.10/gk_3.1.10_windows_amd64.zip",
+            "hash": "25e0aa1e76f55d459d7b21beaeaee37b7012e90af53eaf7a26568222d6446f72"
         },
         "arm64": {
-            "url": "https://github.com/gitkraken/gk-cli/releases/download/v2.1.2/gk_2.1.2_Windows_arm64.zip",
-            "hash": "595883251e0c62933691526437bfb0f2057e4b12f94bec868d4f1b85ff29420d"
+            "url": "https://github.com/gitkraken/gk-cli/releases/download/v3.1.10/gk_3.1.10_windows_arm64.zip",
+            "hash": "25d1e623e518853a51824d0f5ac3fb231c817b520df38e22f35c5973e14b654c"
         }
     },
     "bin": "gk.exe",
@@ -27,17 +27,17 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/gitkraken/gk-cli/releases/download/v$version/gk_$version_Windows_i386.zip"
+                "url": "https://github.com/gitkraken/gk-cli/releases/download/v$version/gk_$version_windows_386.zip"
             },
             "64bit": {
-                "url": "https://github.com/gitkraken/gk-cli/releases/download/v$version/gk_$version_Windows_x86_64.zip"
+                "url": "https://github.com/gitkraken/gk-cli/releases/download/v$version/gk_$version_windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/gitkraken/gk-cli/releases/download/v$version/gk_$version_Windows_arm64.zip"
+                "url": "https://github.com/gitkraken/gk-cli/releases/download/v$version/gk_$version_windows_arm64.zip"
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.txt"
+            "url": "$baseurl/gk_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
Excavator was failing due to slight naming change in release artifacts. I fixed the urls.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
