### PR TITLE
biber: Update to version 2.21 and drop win32

### DIFF
--- a/bucket/biber.json
+++ b/bucket/biber.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.20",
+    "version": "2.21",
     "description": "Biber is a BibTeX replacement for users of biblatex, with full Unicode support.",
     "license": "Artistic-2.0",
     "homepage": "https://biblatex-biber.sourceforge.net/",
@@ -9,11 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip",
-            "hash": "sha1:c05d45fdfbe8a8e15244a6b24dadef3d6c7f1f36"
-        },
-        "32bit": {
-            "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip",
-            "hash": "sha1:bead34ed7f31b4203c58407feb2ea8e5a0966556"
+            "hash": "sha1:ee3ffda40abd7d420427620d6db3203923cda4c7"
         }
     },
     "bin": "biber.exe",
@@ -22,9 +18,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN64.zip"
-            },
-            "32bit": {
-                "url": "https://downloads.sourceforge.net/project/biblatex-biber/biblatex-biber/current/binaries/Windows/biber-MSWIN32.zip"
             }
         }
     }


### PR DESCRIPTION
Excavator was failing because upstream has dropped support for Windows 32bit in the 2.21 update cycle.
See [commit: 6c9dec4](https://redirect.github.com/plk/biber/commit/6c9dec4c16a55d001179b64b2d4e47231a2bd40c)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Biber to version 2.21 for Windows.
  * Discontinued 32-bit Windows support; only 64-bit builds are now available.
  * Updated the integrity hash for the 64-bit Windows download to ensure verification.
  * Users on 32-bit Windows will no longer receive updates or new installs for Biber via this package; 64-bit users continue to install and update as usual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->