### PR TITLE
nomino: Update to version 1.6.4 and fix urls

### DIFF
--- a/bucket/nomino.json
+++ b/bucket/nomino.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.3.5",
+    "version": "1.6.4",
     "description": "Batch rename utility for developers",
     "homepage": "https://github.com/yaa110/nomino",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/yaa110/nomino/releases/download/1.3.5/nomino-windows-64bit.exe#/nomino.exe",
-            "hash": "ce9012944c9417be18ba313d7812a314709f2767ada06f09008247b5c6efa92b"
+            "url": "https://github.com/yaa110/nomino/releases/download/v1.6.4/nomino-windows-64bit.exe#/nomino.exe",
+            "hash": "ea77b987adb4d802983ed73ada32e026cf92f8dfde23a35e2cc547e622b283b8"
         }
     },
     "bin": "nomino.exe",
@@ -14,7 +14,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/yaa110/nomino/releases/download/$version/nomino-windows-64bit.exe#/nomino.exe"
+                "url": "https://github.com/yaa110/nomino/releases/download/v$version/nomino-windows-64bit.exe#/nomino.exe"
             }
         }
     }


### PR DESCRIPTION
Excavator was failing because upstream changed the tag format to include a `v` prefix.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
