### PR TITLE
cwrsync@6.4.5: add extract_dir field for 64bit architecture in cwrsync 6.4.5

### DIFF
--- a/bucket/cwrsync.json
+++ b/bucket/cwrsync.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://itefix.net/download/free/cwrsync_6.4.5_x64_free.zip",
-            "hash": "2fb0c9d1932c51d98c2ea0f09a581bd093b8a83741f3f933a263ada29007a67a"
+            "hash": "2fb0c9d1932c51d98c2ea0f09a581bd093b8a83741f3f933a263ada29007a67a",
+            "extract_dir":"cwrsync_6.4.5_x64_free"
         }
     },
     "bin": "bin\\rsync.exe",

--- a/bucket/cwrsync.json
+++ b/bucket/cwrsync.json
@@ -20,7 +20,7 @@
             "64bit": {
                 "url": "https://itefix.net/download/free/cwrsync_$version_x64_free.zip",
                 "hash": {
-                    "url": "$url.sha256.asc"
+                    "url": "https://verify.itefix.net/$basename.sha256.asc"
                 },
                 "extract_dir": "cwrsync_$version_x64_free"
             }

--- a/bucket/cwrsync.json
+++ b/bucket/cwrsync.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://itefix.net/download/free/cwrsync_6.4.5_x64_free.zip",
             "hash": "2fb0c9d1932c51d98c2ea0f09a581bd093b8a83741f3f933a263ada29007a67a",
-            "extract_dir":"cwrsync_6.4.5_x64_free"
+            "extract_dir": "cwrsync_6.4.5_x64_free"
         }
     },
     "bin": "bin\\rsync.exe",
@@ -21,7 +21,8 @@
                 "url": "https://itefix.net/download/free/cwrsync_$version_x64_free.zip",
                 "hash": {
                     "url": "$url.sha256.asc"
-                }
+                },
+                "extract_dir": "cwrsync_$version_x64_free"
             }
         }
     }


### PR DESCRIPTION
….json

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 64-bit installation and update failures by ensuring archives extract to the correct directory, preventing missing binaries and PATH issues.
  * Fixed update verification to use the proper verifier URL so signature checks work reliably during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #7131