### PR TITLE
direnv: Update to version 2.37.1 and add ARM64

### DIFF
--- a/bucket/direnv.json
+++ b/bucket/direnv.json
@@ -1,16 +1,20 @@
 {
-    "version": "2.36.0",
+    "version": "2.37.1",
     "description": "load or unload environment variables depending on the current directory",
     "homepage": "https://direnv.net",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/direnv/direnv/releases/download/v2.36.0/direnv.windows-amd64.exe#/direnv.exe",
-            "hash": "7b29c7755319116028f32a5189cdb1b873eb5e560933f2b411f3e1e9c12909d0"
+            "url": "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.windows-amd64#/direnv.exe",
+            "hash": "d96fc8b7cf020c2d4c1dbbc2ccec5fd1cab05b51c491f02c8527a7fa6c50a1cd"
+        },
+        "arm64": {
+            "url": "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.windows-arm64#/direnv.exe",
+            "hash": "6802f722f5ef12562d6e3e15c26f39e34b337e5be12ea22f17284552cd782298"
         },
         "32bit": {
-            "url": "https://github.com/direnv/direnv/releases/download/v2.36.0/direnv.windows-386.exe#/direnv.exe",
-            "hash": "7ccb071fe4a54a7708323f6fd8b90086570322a4af97e11bb7e1157a28bfbeab"
+            "url": "https://github.com/direnv/direnv/releases/download/v2.37.1/direnv.windows-386#/direnv.exe",
+            "hash": "7d9e58681a6bdc6f63460631d2e337713f4bf86feea2e617a404d474ceba77d0"
         }
     },
     "bin": "direnv.exe",
@@ -20,10 +24,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/direnv/direnv/releases/download/v$version/direnv.windows-amd64.exe#/direnv.exe"
+                "url": "https://github.com/direnv/direnv/releases/download/v$version/direnv.windows-amd64#/direnv.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/direnv/direnv/releases/download/v$version/direnv.windows-arm64#/direnv.exe"
             },
             "32bit": {
-                "url": "https://github.com/direnv/direnv/releases/download/v$version/direnv.windows-386.exe#/direnv.exe"
+                "url": "https://github.com/direnv/direnv/releases/download/v$version/direnv.windows-386#/direnv.exe"
             }
         }
     }


### PR DESCRIPTION
Excavator was erroring because upstream had added a Arm64 build, and as a result the release artifact naming scheme had changed slightly.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added native Windows ARM64 support for direnv, expanding compatibility to more devices.

- Chores
  - Updated direnv to version 2.37.1.
  - Refreshed 32-bit and 64-bit download sources to match the latest release.
  - Adjusted auto-update paths to align with upstream naming, improving update reliability.
  - Updated checksums to match new binaries, ensuring integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->