### PR TITLE
go-jsonnet: Update to version 0.21.0 and fix urls

### DIFF
--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -1,23 +1,39 @@
 {
-    "version": "0.20.0",
+    "version": "0.21.0",
     "description": "A data templating language for app and tool developers",
-    "homepage": "https://github.com/google/go-jsonnet",
+    "homepage": "https://jsonnet.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Windows_x86_64.tar.gz",
-            "hash": "82440a646a8d29487a243afc880db245f612a205d3eccbb900bc76d7a4049ad1"
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_x86_64.tar.gz",
+            "hash": "81d71a287ee5dfd0860831eeac281a7327ce8876d5fe9a8b7e19726dbbc0ce4f"
+        },
+        "arm64": {
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_arm64.tar.gz",
+            "hash": "5244713590b976d8cb675aba57434b2fa667663c299fe777a478c01c86e46341"
+        },
+        "32bit": {
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_i386.tar.gz",
+            "hash": "93921aa0bd999ed45348e862ffbb1649c8939020468f52f80176a86b71e9978e"
         }
     },
     "bin": [
         "jsonnet.exe",
         "jsonnetfmt.exe"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/google/go-jsonnet"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz"
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_Windows_x86_64.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_Windows_arm64.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_Windows_i386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
Fixes excavator errors due to upstream artifact naming change. 
Also adds ARM 64 and 32bit architecture. 
Also add homepage url

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
