### PR TITLE
gping: Update to version 1.20.1 and fix urls

### DIFF
--- a/bucket/gping.json
+++ b/bucket/gping.json
@@ -1,23 +1,23 @@
 {
-    "version": "1.18.0",
+    "version": "1.20.1",
     "description": "Ping, but with a graph",
     "homepage": "https://github.com/orf/gping",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/orf/gping/releases/download/gping-v1.18.0/gping-Windows-x86_64.zip",
-            "hash": "b044f99bcc77bf6206688c9c2c00f4eda2fcce7fc045fea41ad8dfc61724076b"
+            "url": "https://github.com/orf/gping/releases/download/gping-v1.20.1/gping-Windows-msvc-x86_64.zip",
+            "hash": "f08559444bcd7af8d629cbad6a972dea4033a116ff9aaf0b1b2bef2a3cabb0af"
         }
     },
     "bin": "gping.exe",
     "checkver": {
         "github": "https://github.com/orf/gping",
-        "regex": "/releases/tag/gping-v([\\d.]+)"
+        "regex": "tag/gping-v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/orf/gping/releases/download/gping-v$version/gping-Windows-x86_64.zip"
+                "url": "https://github.com/orf/gping/releases/download/gping-v$version/gping-Windows-msvc-x86_64.zip"
             }
         }
     }


### PR DESCRIPTION
Fixes excavator errors due to upstream artifact naming change.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
