### PR TITLE
libjpeg-turbo: Update to version 3.1.2 and fix urls

### DIFF
--- a/bucket/libjpeg-turbo.json
+++ b/bucket/libjpeg-turbo.json
@@ -1,16 +1,20 @@
 {
-    "version": "3.1.0",
+    "version": "3.1.2",
     "description": "A JPEG image codec that uses SIMD instructions",
     "homepage": "https://libjpeg-turbo.org/",
     "license": "IJG,BSD-3-Clause,Zlib",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.0/libjpeg-turbo-3.1.0-vc64.exe#/dl.7z",
-            "hash": "49fd0295245cda636bae079f0258c751c1adec4794dbba29274c620c1c10a9b0"
+            "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.2/libjpeg-turbo-3.1.2-vc-x64.exe#/dl.7z",
+            "hash": "36ebf787adf093b12efe43d4a25f988863fb64d49f69008cba3dbcb4a3d78e6d"
+        },
+        "arm64": {
+            "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.2/libjpeg-turbo-3.1.2-vc-arm64.exe#dl.7z",
+            "hash": "7e890640b1cc7bdaf9d91402465bc618044182e004043f1d159726a315632313"
         },
         "32bit": {
-            "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.0/libjpeg-turbo-3.1.0-vc.exe#/dl.7z",
-            "hash": "1eec2a49e31316f0fa8ff004393b0b33057d1611cd0b4d7fa94e8624d06378ab"
+            "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.2/libjpeg-turbo-3.1.2-vc-x86.exe#/dl.7z",
+            "hash": "600b3eeeeb458ab2705bdc1924e688320006ebafaae5bdafe6e017ae9aec042b"
         }
     },
     "pre_install": "'PLUGINS', 'SYS' | ForEach-Object { Remove-Item -Recurse \"$dir/`$$_`DIR\" }",
@@ -31,10 +35,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$version/libjpeg-turbo-$version-vc64.exe#/dl.7z"
+                "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$version/libjpeg-turbo-$version-vc-x64.exe#/dl.7z"
+            },
+            "arm64": {
+                "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$version/libjpeg-turbo-$version-vc-arm64.exe#dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$version/libjpeg-turbo-$version-vc.exe#/dl.7z"
+                "url": "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$version/libjpeg-turbo-$version-vc-x86.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Also adds 32bit release artifact (are we still supporting Windows 32bit?)

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
