### PR TITLE
scoop-search: Update hook guidance in Notes to avoid Windows Defender

### DIFF
--- a/bucket/scoop-search.json
+++ b/bucket/scoop-search.json
@@ -3,7 +3,7 @@
     "description": "Fast scoop search drop-in replacement",
     "homepage": "https://github.com/shilangyu/scoop-search",
     "license": "MIT",
-    "notes": "To replace built-in scoop search, add this to $PROFILE: Invoke-Expression (&scoop-search --hook)",
+    "notes": "To replace built-in scoop search, add this to $PROFILE: . ([ScriptBlock]::Create((& scoop-search --hook | Out-String)))",
     "url": "https://github.com/shilangyu/scoop-search/releases/download/v2.1.0/scoop-search.exe",
     "hash": "387ef78ad8c212a36bb38077e67b51adaec1cee8bbcdc50f35d1107d1fe70705",
     "bin": "scoop-search.exe",


### PR DESCRIPTION
The manifest notes currently recommends:

    Invoke-Expression (&scoop-search --hook)

On PowerShell 7+, this gets blocked by Windows Defender as suspicious:

    This script contains malicious content and has been blocked by your antivirus software.

A safer equivalent that avoids AV false positives is:

    . ([ScriptBlock]::Create((& scoop-search --hook | Out-String)))

This change keeps the same functionality (loads argument completers), works in both
Windows PowerShell and PowerShell 7+, and avoids requiring users to disable or exclude
files in their AV settings.

Note: This change was also proposed in https://github.com/shilangyu/scoop-search/pull/84

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the scoop-search hook execution for better reliability and compatibility across PowerShell environments.
* **Chores**
  * Updated manifest notes formatting with no changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->