### PR TITLE
curl: Update to version 8.15.0_7, drop 32bit

### DIFF
--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -1,23 +1,18 @@
 {
-    "version": "8.15.0_5",
+    "version": "8.15.0_7",
     "description": "Command line tool and library for transferring data with URLs",
     "homepage": "https://curl.se/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://curl.se/windows/dl-8.15.0_5/curl-8.15.0_5-win64-mingw.tar.xz",
-            "hash": "a812569b3fbe64e6efa90d9f7cfdffdb3c45ae6dafbad25e238c1e854dfcf2df",
-            "extract_dir": "curl-8.15.0_5-win64-mingw"
-        },
-        "32bit": {
-            "url": "https://curl.se/windows/dl-8.15.0_5/curl-8.15.0_5-win32-mingw.tar.xz",
-            "hash": "30799b6ec93c416d068581533e523d86968f75b73a8c2f82d5cd55f62e028e0d",
-            "extract_dir": "curl-8.15.0_5-win32-mingw"
+            "url": "https://curl.se/windows/dl-8.15.0_7/curl-8.15.0_7-win64-mingw.tar.xz",
+            "hash": "f77490a4c59b253f0951b2202b871ec77e0bddebe655ad241bb6881577ad2f90",
+            "extract_dir": "curl-8.15.0_7-win64-mingw"
         },
         "arm64": {
-            "url": "https://curl.se/windows/dl-8.15.0_5/curl-8.15.0_5-win64a-mingw.tar.xz",
-            "hash": "075011c9f6d48e3a83eb74e0aafc7a8ee7dd9d775177b49cfbb760998bdb304b",
-            "extract_dir": "curl-8.15.0_5-win64a-mingw"
+            "url": "https://curl.se/windows/dl-8.15.0_7/curl-8.15.0_7-win64a-mingw.tar.xz",
+            "hash": "96e2a1f685188f1860c7402d0e1c3357e36cdd1e316d431959f06f8e55cb411f",
+            "extract_dir": "curl-8.15.0_7-win64a-mingw"
         }
     },
     "bin": "bin\\curl.exe",
@@ -30,10 +25,6 @@
             "64bit": {
                 "url": "https://curl.se/windows/dl-$version/curl-$version-win64-mingw.tar.xz",
                 "extract_dir": "curl-$version-win64-mingw"
-            },
-            "32bit": {
-                "url": "https://curl.se/windows/dl-$version/curl-$version-win32-mingw.tar.xz",
-                "extract_dir": "curl-$version-win32-mingw"
             },
             "arm64": {
                 "url": "https://curl.se/windows/dl-$version/curl-$version-win64a-mingw.tar.xz",


### PR DESCRIPTION
This PR makes the following changes:
- `curl`: Update to version 8.15.0_7, drop 32bit.

<!-- notes -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated curl to version 8.15.0_7.
  - Refreshed 64-bit and ARM64 downloads and checksums to ensure reliable installs.
  - Adjusted package metadata for the new release.
  - Removed 32-bit support from the package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->