### PR TITLE
postgresql@18.0: Simplify extraction, update notes & checkver

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -17,7 +17,7 @@
     "extract_dir": "pgsql",
     "post_install": [
         "if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) {",
-        "   Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList @('--username=postgres', '--encoding=UTF8', '--locale=en', '--lc-collate=C') | Out-Null",
+        "   Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList @('--username=postgres', '--encoding=UTF8', '--locale=C') | Out-Null",
         "}"
     ],
     "shortcuts": [
@@ -34,8 +34,8 @@
     },
     "persist": "data",
     "checkver": {
-        "url": "https://www.postgresql.org/ftp/source/",
-        "regex": "v(?<version>[\\d.]+)/"
+        "url": "https://www.enterprisedb.com/downloads/postgres-postgresql-downloads",
+        "regex": ">(?<version>\\d+\\.[\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {
@@ -45,4 +45,3 @@
         }
     }
 }
-


### PR DESCRIPTION
- Make `notes` neater and clearer
- Remove `depends` , files can now be extracted correctly without `7zip19.00-helper` (refer to #3816) 
- Update `checkver`, switch to https://www.enterprisedb.com/downloads/postgres-postgresql-downloads
- Update post_install script to resolve the following errors:
>performing post-bootstrap initialization ...
FATAL:  collations with different collate and ctype values are not supported on this platform
child process exited with exit code 1

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package to 18.0 and aligned auto-update/download sources to the new ZIP scheme.
  * Removed an unneeded helper dependency and internal pre-install steps.

* **Bug Fixes**
  * Fixed 64-bit download/autoupdate retrieval and streamlined extraction into a dedicated "pgsql" directory.

* **Documentation**
  * Clarified post-install notes with simpler wording and improved capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->