### PR TITLE
winmemorycleaner: Add version 3.0.2

### DIFF
--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,0 +1,33 @@
+{
+  "version": "3.0.2",
+  "description": "Portable RAM cleaner using native Windows APIs to release memory.",
+  "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
+  "license": {
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE",
+    "identifier": "GPL-3.0-or-later"
+  },
+  "notes": [
+    "Requires administrator privileges (UAC prompt).",
+    "Requires .NET Framework 4.x runtime.",
+    "If missing: scoop bucket add extras then scoop install dotnetfx."
+  ],
+  "suggest": {
+    ".NET Framework 4.x runtime": "extras/dotnetfx"
+  },
+  "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
+  "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+  "bin": "WinMemoryCleaner.exe",
+  "shortcuts": [
+    [
+      "WinMemoryCleaner.exe",
+      "WinMemoryCleaner"
+    ]
+  ],
+  "checkver": {
+    "regex": "([\\\\d.]+)",
+    "github": "IgorMundstein/WinMemoryCleaner"
+  },
+  "autoupdate": {
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+  }
+}


### PR DESCRIPTION
Adds the initial Scoop manifest for WinMemoryCleaner 3.0.2.

Portable RAM cleaner using native Windows APIs to release memory.

Closes #7161

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added WinMemoryCleaner package (v3.0.2), a portable RAM cleaner for Windows.
  - Creates a Start Menu shortcut for easy access.
  - Supports automatic updates via GitHub releases.

- Notes
  - May prompt for administrator privileges (UAC).
  - Requires .NET Framework 4.x; a suggested install is provided if missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->