### PR TITLE
winmemorycleaner: Add version 3.0.2

### DIFF
--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,41 +1,23 @@
 {
-  "version": "3.0.2",
-  "description": "Portable RAM cleaner using native Windows APIs to release memory.",
-  "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
-  "license": {
-    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE",
-    "identifier": "GPL-3.0-or-later"
-  },
-  "notes": [
-    "Requires administrator privileges (UAC prompt).",
-    "Requires .NET Framework 4.x runtime."
-  ],
-  "architecture": {
-    "64bit": {
-      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
+    "version": "3.0.2",
+    "description": "Portable RAM cleaner using native Windows APIs to release memory.",
+    "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE"
     },
-    "32bit": {
-      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
-    }
-  },
-  "bin": "WinMemoryCleaner.exe",
-  "shortcuts": [
-    [
-      "WinMemoryCleaner.exe",
-      "WinMemoryCleaner"
-    ]
-  ],
-  "checkver": "github",
-  "autoupdate": {
-    "architecture": {
-      "64bit": {
+    "notes": "Requires .NET Framework 4.x runtime.",
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
+    "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+    "bin": "WinMemoryCleaner.exe",
+    "shortcuts": [
+        [
+            "WinMemoryCleaner.exe",
+            "WinMemoryCleaner"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
         "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
-      },
-      "32bit": {
-        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
-      }
     }
-  }
 }

--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -10,17 +10,14 @@
     "Requires administrator privileges (UAC prompt).",
     "Requires .NET Framework 4.x runtime."
   ],
-  "suggest": {
-    ".NET Framework 4.x runtime": "extras/dotnetfx"
-  },
   "architecture": {
     "64bit": {
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
-      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d"
+      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
     },
     "32bit": {
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
-      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d"
+      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
     }
   },
   "bin": "WinMemoryCleaner.exe",

--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,26 +1,5 @@
 {
-  "architecture": {
-    "32bit": {
-      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
-    },
-    "64bit": {
-      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
-    }
-  },
-  "autoupdate": {
-    "architecture": {
-      "32bit": {
-        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
-      },
-      "64bit": {
-        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
-      }
-    }
-  },
-  "bin": "WinMemoryCleaner.exe",
-  "checkver": "github",
+  "version": "3.0.2",
   "description": "Portable RAM cleaner using native Windows APIs to release memory.",
   "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
   "license": {
@@ -31,11 +10,35 @@
     "Requires administrator privileges (UAC prompt).",
     "Requires .NET Framework 4.x runtime."
   ],
+  "suggest": {
+    ".NET Framework 4.x runtime": "extras/dotnetfx"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
+      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d"
+    },
+    "32bit": {
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
+      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d"
+    }
+  },
+  "bin": "WinMemoryCleaner.exe",
   "shortcuts": [
     [
       "WinMemoryCleaner.exe",
       "WinMemoryCleaner"
     ]
   ],
-  "version": "3.0.2"
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      },
+      "32bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      }
+    }
+  }
 }

--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,0 +1,30 @@
+{
+  "version": "3.0.2",
+  "description": "Portable RAM cleaner using native Windows APIs to release memory.",
+  "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
+  "license": {
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE",
+    "identifier": "GPL-3.0-or-later"
+  },
+  "notes": [
+    "Requires administrator privileges (UAC prompt).",
+    "Requires .NET Framework 4.x runtime.",
+    "If missing: scoop bucket add extras then scoop install dotnetfx."
+  ],
+  "suggest": {
+    ".NET Framework 4.x runtime": "extras/dotnetfx"
+  },
+  "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
+  "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+  "bin": "WinMemoryCleaner.exe",
+  "shortcuts": [
+    [
+      "WinMemoryCleaner.exe",
+      "WinMemoryCleaner"
+    ]
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+  }
+}

--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,5 +1,26 @@
 {
-  "version": "3.0.2",
+  "architecture": {
+    "32bit": {
+      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
+    },
+    "64bit": {
+      "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe"
+    }
+  },
+  "autoupdate": {
+    "architecture": {
+      "32bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      },
+      "64bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      }
+    }
+  },
+  "bin": "WinMemoryCleaner.exe",
+  "checkver": "github",
   "description": "Portable RAM cleaner using native Windows APIs to release memory.",
   "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
   "license": {
@@ -8,23 +29,13 @@
   },
   "notes": [
     "Requires administrator privileges (UAC prompt).",
-    "Requires .NET Framework 4.x runtime.",
-    "If missing: scoop bucket add extras then scoop install dotnetfx."
+    "Requires .NET Framework 4.x runtime."
   ],
-  "suggest": {
-    ".NET Framework 4.x runtime": "extras/dotnetfx"
-  },
-  "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.2/WinMemoryCleaner.exe",
-  "hash": "5dcaa33af0034ac8f40c8109d5c46858de4f8ed53b9989e7a8cb59ed7cb4dc6d",
-  "bin": "WinMemoryCleaner.exe",
   "shortcuts": [
     [
       "WinMemoryCleaner.exe",
       "WinMemoryCleaner"
     ]
   ],
-  "checkver": "github",
-  "autoupdate": {
-    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
-  }
+  "version": "3.0.2"
 }


### PR DESCRIPTION
Adds the initial Scoop manifest for WinMemoryCleaner 3.0.2.

Portable RAM cleaner using native Windows APIs to release memory.

Closes #7163

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WinMemoryCleaner v3.0.2 to the bucket — a portable RAM cleaner using native Windows APIs.
  * Provides a Start Menu shortcut and command alias for quick access.
  * Includes automatic version checks and autoupdate support for seamless updates.

* **Documentation**
  * Notes that administrator (UAC) privileges and .NET Framework 4.x are required.
  * Clarifies secure downloads with checksum verification and GPL-3.0-or-later licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->