### PR TITLE
oh-my-posh: Update to version 26.23.8, drop 32bit support

### DIFF
--- a/bucket/oh-my-posh.json
+++ b/bucket/oh-my-posh.json
@@ -48,10 +48,6 @@
                     "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$version/posh-windows-arm64.exe#/oh-my-posh.exe"
                 ]
             }
-        },
-        "hash": {
-            "url": "$baseurl/checksums.txt",
-            "regex": "$sha256.*?$basename"
         }
     }
 }

--- a/bucket/oh-my-posh.json
+++ b/bucket/oh-my-posh.json
@@ -1,5 +1,5 @@
 {
-    "version": "26.23.2",
+    "version": "26.23.8",
     "description": "A prompt theme engine for any shell",
     "homepage": "https://ohmyposh.dev",
     "license": "MIT",
@@ -7,22 +7,22 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/posh-windows-amd64.exe#/oh-my-posh.exe"
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.8/themes.zip",
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.8/posh-windows-amd64.exe#/oh-my-posh.exe"
             ],
             "hash": [
-                "bc8512fd8685fea3d33694127667b57c8e717c58d34c96d52e72a026852550c9",
-                "8eff2942b7a352a5e308d1a83b24f9756eed864ab33dd43d4a9a10d7edb24c42"
+                "4ebab1e0126b64c7bdfcde3ed946dd20d1f53f8c5fa756a98d3f1139ae99e7f7",
+                "4b73bd2b899ca76e0624bcaeebc89cbc85c13e7baa2d08c565bc99744c817887"
             ]
         },
         "arm64": {
             "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/posh-windows-arm64.exe#/oh-my-posh.exe"
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.8/themes.zip",
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.8/posh-windows-arm64.exe#/oh-my-posh.exe"
             ],
             "hash": [
-                "bc8512fd8685fea3d33694127667b57c8e717c58d34c96d52e72a026852550c9",
-                "2489c035e31337ca98a17c80e67128b53f39df5518a0c4d6619a979aa03140ef"
+                "4ebab1e0126b64c7bdfcde3ed946dd20d1f53f8c5fa756a98d3f1139ae99e7f7",
+                "1f81d7659a08d4ec6e0ef4c59310b81ae258edbd557f579f777d72dac464ea04"
             ]
         }
     },

--- a/bucket/oh-my-posh.json
+++ b/bucket/oh-my-posh.json
@@ -1,5 +1,5 @@
 {
-    "version": "26.20.1",
+    "version": "26.23.2",
     "description": "A prompt theme engine for any shell",
     "homepage": "https://ohmyposh.dev",
     "license": "MIT",
@@ -7,32 +7,22 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.20.1/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.20.1/posh-windows-amd64.exe#/oh-my-posh.exe"
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/themes.zip",
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/posh-windows-amd64.exe#/oh-my-posh.exe"
             ],
             "hash": [
-                "b44aff0a6f6509fe46de354d1b2e8a5f0b2f5061274b5449e440502f6af74940",
-                "df94a60b1eda6ea01504476e95927aa621d573bfb6f92e57034067fcb1b8cba7"
-            ]
-        },
-        "32bit": {
-            "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.20.1/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.20.1/posh-windows-386.exe#/oh-my-posh.exe"
-            ],
-            "hash": [
-                "b44aff0a6f6509fe46de354d1b2e8a5f0b2f5061274b5449e440502f6af74940",
-                "9a3a10842a0b1733c22c2c79cf14182c9410230ddd29f4bb9f30c5030da9f997"
+                "bc8512fd8685fea3d33694127667b57c8e717c58d34c96d52e72a026852550c9",
+                "8eff2942b7a352a5e308d1a83b24f9756eed864ab33dd43d4a9a10d7edb24c42"
             ]
         },
         "arm64": {
             "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.20.1/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.20.1/posh-windows-arm64.exe#/oh-my-posh.exe"
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/themes.zip",
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v26.23.2/posh-windows-arm64.exe#/oh-my-posh.exe"
             ],
             "hash": [
-                "b44aff0a6f6509fe46de354d1b2e8a5f0b2f5061274b5449e440502f6af74940",
-                "3b2ee48a78c397efa6acfbe94e56fb89402f2534763c533c1bb61acf024ad276"
+                "bc8512fd8685fea3d33694127667b57c8e717c58d34c96d52e72a026852550c9",
+                "2489c035e31337ca98a17c80e67128b53f39df5518a0c4d6619a979aa03140ef"
             ]
         }
     },
@@ -50,12 +40,6 @@
                 "url": [
                     "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$version/themes.zip",
                     "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$version/posh-windows-amd64.exe#/oh-my-posh.exe"
-                ]
-            },
-            "32bit": {
-                "url": [
-                    "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$version/themes.zip",
-                    "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$version/posh-windows-386.exe#/oh-my-posh.exe"
                 ]
             },
             "arm64": {


### PR DESCRIPTION
Upstream has stopped publishing windows 32bit builds with their releases as of 2025-09-09. [JanDeDobbeleer/oh-my-posh@a975e211](https://redirect.github.com/JanDeDobbeleer/oh-my-posh/commit/a975e211655aee6e285af26883a3b3af80d975c2)

The resulting 404 errors have prevented excavator from updating successfully.
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated oh-my-posh to version 26.23.2 with refreshed download sources and new checksums for 64-bit and ARM64 builds.
  - Updated autoupdate configuration to reference the new release and corresponding artifacts for supported architectures.
  - Removed all 32-bit artifacts and autoupdate entries, reflecting the end of 32-bit support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->