### PR TITLE
sass: Update to version 1.92.1, drop 32bit, add arm64

### DIFF
--- a/bucket/sass.json
+++ b/bucket/sass.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.89.0",
+    "version": "1.92.1",
     "description": "The primary implementation of Sass, written in Dart.",
     "homepage": "https://sass-lang.com/dart-sass",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sass/dart-sass/releases/download/1.89.0/dart-sass-1.89.0-windows-x64.zip",
-            "hash": "ec5ba62bf4b9bd8bd3c460d5e7009dc28ca860337527958947dcf45f83b0a161"
+            "url": "https://github.com/sass/dart-sass/releases/download/1.92.1/dart-sass-1.92.1-windows-x64.zip",
+            "hash": "eab512e794b0f8baddacbdf8da0810fb374f519c28f257d5d67bd7670dc331ea"
         },
-        "32bit": {
-            "url": "https://github.com/sass/dart-sass/releases/download/1.89.0/dart-sass-1.89.0-windows-ia32.zip",
-            "hash": "0ea890789b4d47732b2113eedfa6c18259c9ceaf9d445ac6aaa82474baf9b7c9"
+        "arm64": {
+            "url": "https://github.com/sass/dart-sass/releases/download/1.92.1/dart-sass-1.92.1-windows-arm64.zip",
+            "hash": "3d3320453a8295f75fa98b816d5c5fa2d6ffbef773bbd74017959d610c3890ec"
         }
     },
     "extract_dir": "dart-sass",
@@ -29,8 +29,8 @@
             "64bit": {
                 "url": "https://github.com/sass/dart-sass/releases/download/$version/dart-sass-$version-windows-x64.zip"
             },
-            "32bit": {
-                "url": "https://github.com/sass/dart-sass/releases/download/$version/dart-sass-$version-windows-ia32.zip"
+            "arm64": {
+                "url": "https://github.com/sass/dart-sass/releases/download/$version/dart-sass-$version-windows-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
Upstream has dropped support for 32bit releases. And has also added Arm64 builds.
In [sass/dart-sass@e7b70e2](https://redirect.github.com/sass/dart-sass/commit/e7b70e2558be0053de37313a7d3fba5a8adfa866)
Fixes excavator update errors.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows on ARM64.
* **Chores**
  * Updated Sass to version 1.92.1.
  * Refreshed Windows x64 package download and integrity details.
* **Compatibility**
  * Discontinued Windows 32-bit support; users on 32-bit systems will no longer receive updates.
* **Autoupdate**
  * Adjusted update configuration to target ARM64 instead of 32-bit on Windows, ensuring future releases are retrieved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->