### PR TITLE
taplo: Update to version 0.10.0 & add arm64

### DIFF
--- a/bucket/taplo.json
+++ b/bucket/taplo.json
@@ -1,16 +1,20 @@
 {
-    "version": "0.9.3",
+    "version": "0.10.0",
     "description": "A TOML toolkit written in Rust",
     "homepage": "https://taplo.tamasfe.dev/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tamasfe/taplo/releases/download/0.9.3/taplo-full-windows-x86_64.zip",
-            "hash": "8e24648e698cb5c6443de240c36a82287d00cd5b98406f6cb18b06d9ddd46ba6"
+            "url": "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-x86_64.zip",
+            "hash": "1615eed140039bd58e7089109883b1c434de5d6de8f64a993e6e8c80ca57bdf9"
+        },
+        "arm64": {
+            "url": "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-aarch64.zip",
+            "hash": "65a50c5d3b78f6014e6bc6d64eb6dc1d4992bc236589c9bb29e5609fc3454674"
         },
         "32bit": {
-            "url": "https://github.com/tamasfe/taplo/releases/download/0.9.3/taplo-full-windows-x86.zip",
-            "hash": "a2afd8a0b415edb45e4c18d4ab6cca1530b6bec8820ba51d550ce39912ad3510"
+            "url": "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-x86.zip",
+            "hash": "b825701daab10dcfc0251e6d668cd1a9c0e351e7f6762dd20844c3f3f3553aa0"
         }
     },
     "bin": "taplo.exe",
@@ -20,10 +24,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/tamasfe/taplo/releases/download/$version/taplo-full-windows-x86_64.zip"
+                "url": "https://github.com/tamasfe/taplo/releases/download/$version/taplo-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/tamasfe/taplo/releases/download/$version/taplo-windows-aarch64.zip"
             },
             "32bit": {
-                "url": "https://github.com/tamasfe/taplo/releases/download/$version/taplo-full-windows-x86.zip"
+                "url": "https://github.com/tamasfe/taplo/releases/download/$version/taplo-windows-x86.zip"
             }
         }
     }


### PR DESCRIPTION
Slight naming change upstream, caused Excavator to fail.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added native Windows ARM64 (aarch64) build.
- Chores
  - Updated release to v0.10.0.
  - Standardized Windows artifact naming for x86 and x64.
  - Refreshed checksums for all Windows builds.
  - Updated auto-update mappings for x86, x64, and ARM64 to match new artifact names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->