### PR TITLE
juliaup: Add 'persist' and 'env_set'

### DIFF
--- a/bucket/juliaup.json
+++ b/bucket/juliaup.json
@@ -19,6 +19,11 @@
         "juliaup.exe",
         "julia.exe"
     ],
+    "env_set": {
+        "JULIA_DEPOT_PATH": "$persist_dir\\.julia;",
+        "JULIAUP_DEPOT_PATH": "$persist_dir\\.julia"
+    },
+    "persist": ".julia",
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/juliaup.json
+++ b/bucket/juliaup.json
@@ -1,17 +1,21 @@
 {
-    "version": "1.17.19",
+    "version": "1.18.0",
     "description": "Julia installer and version multiplexer",
     "homepage": "https://github.com/JuliaLang/juliaup",
     "license": "MIT",
+    "notes": [
+        "The julia depot has now been persisted.",
+        "If you have files in '$env:USERPROFILE\\.julia', move them to '$persist_dir\\.julia'"
+    ],
     "architecture": {
         "64bit": {
-            "url": "https://julialang-s3.julialang.org/juliaup/winmsi/Julia-v1.17.19-x64.msi",
-            "hash": "25d88a8bef4130fd65f5b9f37b74660f3061461a7f3d66eb0a2159abdabe9306",
+            "url": "https://julialang-s3.julialang.org/juliaup/winmsi/Julia-v1.18.0-x64.msi",
+            "hash": "f4063f2400549ee58e581122b94a3b4dcaa3e7cbf25366695b3d4614a5b48ffd",
             "extract_dir": "PFiles64\\Julia"
         },
         "32bit": {
-            "url": "https://julialang-s3.julialang.org/juliaup/winmsi/Julia-v1.17.19-x86.msi",
-            "hash": "cd15fe536213e15af03a9cdc975fe83b10cd74d6793a13dca30524debd13236d",
+            "url": "https://julialang-s3.julialang.org/juliaup/winmsi/Julia-v1.18.0-x86.msi",
+            "hash": "364a10bbf7193e2013186ec62e07381cd37143275d8a9bf8b48c56a5fb8664b5",
             "extract_dir": "PFiles\\Julia"
         }
     },


### PR DESCRIPTION
- Add `persist` where juliaup install julia and julia add packages
- Add `env_set` so that juliaup and julia can use `persist_dir`

just like what [rustup.json](https://github.com/ScoopInstaller/Main/blob/master/bucket/rustup.json) do.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bumped juliaup to v1.18.0 with updated 32-/64-bit installer downloads.
  * Automatically sets JULIA_DEPOT_PATH and JULIAUP_DEPOT_PATH to a persistent .julia directory.
  * The .julia directory is now persisted across installs and updates, preserving packages and settings.

* **Documentation**
  * Added release notes messages about depot persistence and moved files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->