### PR TITLE
clink-flex-prompt@0.18: fix clink script path

### DIFF
--- a/bucket/clink-flex-prompt.json
+++ b/bucket/clink-flex-prompt.json
@@ -15,10 +15,11 @@
     ],
     "installer": {
         "script": [
+            "$luapath = Join-Path (Split-Path -Path \"$dir\" -Parent) \"current\"",
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink installscripts \"$dir\"",
+            "   clink installscripts \"$luapath\"",
             "} elseif ($Env:CMDER_ROOT) {",
-            "   & \"$Env:CMDER_ROOT\\vendor\\clink\\clink.bat\" installscripts \"$dir\"",
+            "   & \"$Env:CMDER_ROOT\\vendor\\clink\\clink.bat\" installscripts \"$luapath\"",
             "} else {",
             "   warn 'Clink or Cmder installation not found. Please manually install these scripts.'",
             "}"
@@ -26,10 +27,11 @@
     },
     "uninstaller": {
         "script": [
+            "$luapath = Join-Path (Split-Path -Path \"$dir\" -Parent) \"current\"",
             "if (Get-Command clink -ErrorAction SilentlyContinue) {",
-            "   clink uninstallscripts \"$dir\"",
+            "   clink uninstallscripts \"$luapath\"",
             "} elseif ($Env:CMDER_ROOT) {",
-            "   & \"$Env:CMDER_ROOT\\vendor\\clink\\clink.bat\" uninstallscripts \"$dir\"",
+            "   & \"$Env:CMDER_ROOT\\vendor\\clink\\clink.bat\" uninstallscripts \"$luapath\"",
             "}"
         ]
     },


### PR DESCRIPTION
The path installed via clink installscripts was different for each
version of clink-flex-prompt, creating issues as the same script was
loaded multiple times (with different version).

This change makes the path consistent across versions, making sure only
the latest one is loaded.

Closes #7170

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
