### PR TITLE
1password-cli@2.32.0: Add to path instead of shim

### DIFF
--- a/bucket/1password-cli.json
+++ b/bucket/1password-cli.json
@@ -16,7 +16,7 @@
             "hash": "ac65421654c401cbc73cd75bce909ab74299197b467ed6a27c474678fa6c2299"
         }
     },
-    "bin": "op.exe",
+    "env_add_path": ".",
     "notes": [
         "1Password CLI v2 completely changes the commands schema! Either migrate your setup, following ",
         "instructions on https://developer.1password.com/docs/cli/upgrade/#step-2-update-your-scripts ",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The Scoop shim layer doesn't play nice with the 1password CLI authentication caching mechanism.
This pull request replaces the shim with directly adding the current directory to the path.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #6684


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved how the 1Password CLI is exposed in your shell: the install directory is now added to your PATH, allowing the CLI to be discovered without relying on a fixed binary shim.
- Bug Fixes
  - Reduces potential issues where the CLI might not be found due to hardcoded paths.
- Chores
  - Streamlined manifest configuration while keeping all versioning, download, and update details unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->