### PR TITLE
(chore): Run formatjson.ps1 for all manifests

### DIFF
--- a/bucket/gig.json
+++ b/bucket/gig.json
@@ -3,7 +3,7 @@
     "description": "Generate .gitignore files from your terminal (mostly) offline!",
     "homepage": "https://github.com/shihanng/gig",
     "license": "MIT",
-    "depends": ["fzf"],
+    "depends": "fzf",
     "architecture": {
         "64bit": {
             "url": "https://github.com/shihanng/gig/releases/download/v0.8.3/gig_0.8.3_Windows_x86_64.tar.gz",


### PR DESCRIPTION
This PR makes the following changes:
- `(chore)`: Run formatjson.ps1 for all manifests.

Relates to:
- https://github.com/ScoopInstaller/GithubActions/pull/61

To avoid existing manifests with lint issues also modified and appear in the commit list when contributors format manifests, I am now submitting a PR to format them all.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
