### PR TITLE
chore: Fix download and autoupdate URLs in the PowerShell module manifests

### DIFF
--- a/bucket/acmesharp.json
+++ b/bucket/acmesharp.json
@@ -3,7 +3,7 @@
     "description": "An ACME (Let's Encrypt) client library and PowerShell client for the .NET platform",
     "homepage": "https://github.com/ebekker/ACMESharp",
     "license": "Unknown",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/acmesharp.0.9.1.326.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/acmesharp.0.9.1.326.nupkg",
     "hash": "e8c3c6799c03e7d3df41b6c39c7f3761ec027f94800f4bdf177b274a407012dd",
     "psmodule": {
         "name": "ACMESharp"
@@ -13,6 +13,6 @@
         "regex": "Downloads of ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/acmesharp.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/acmesharp.$version.nupkg"
     }
 }

--- a/bucket/importexcel.json
+++ b/bucket/importexcel.json
@@ -3,7 +3,7 @@
     "description": "PowerShell module to import/export Excel spreadsheets, without Excel",
     "homepage": "https://github.com/dfinke/ImportExcel",
     "license": "Apache-2.0",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/importexcel.7.8.10.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/importexcel.7.8.10.nupkg",
     "hash": "d8a1d79dc8cf10c0eea30b68b70459b3fb4cac0042fb756fcb23890671857e4c",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/importexcel.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/importexcel.$version.nupkg"
     }
 }

--- a/bucket/powershell-beautifier.json
+++ b/bucket/powershell-beautifier.json
@@ -3,7 +3,7 @@
     "description": "A whitespace reformatter and code cleaner for Windows PowerShell and PowerShell Core",
     "homepage": "https://github.com/DTW-DanWard/PowerShell-Beautifier",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-beautifier.1.2.5.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/powershell-beautifier.1.2.5.nupkg",
     "hash": "3ec3d76a2b303136bc73f91d278f03b748cf5cc6aa6287aa3ea180adf39c6ff3",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content_Types*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d\\.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-beautifier.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/powershell-beautifier.$version.nupkg"
     }
 }

--- a/bucket/powershell-yaml.json
+++ b/bucket/powershell-yaml.json
@@ -3,7 +3,7 @@
     "description": "PowerShell module for serializing and deserializing YAML",
     "homepage": "https://github.com/cloudbase/powershell-yaml",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-yaml.0.4.12.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/powershell-yaml.0.4.12.nupkg",
     "hash": "d4602bc7a4a093766520422d53ca8b09acde162286fae11e2ee6c8edfea07810",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content_Types*.xml\" -Recurse",
     "psmodule": {
@@ -14,6 +14,6 @@
         "regex": "<h2>([\\d\\.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/powershell-yaml.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/powershell-yaml.$version.nupkg"
     }
 }

--- a/bucket/psgithub.json
+++ b/bucket/psgithub.json
@@ -3,7 +3,7 @@
     "description": "PowerShell module to manage GitHub through its REST API.",
     "homepage": "https://github.com/pcgeek86/PSGitHub",
     "license": "MIT",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/psgithub.0.15.240.nupkg",
+    "url": "https://cdn.powershellgallery.com/packages/psgithub.0.15.240.nupkg",
     "hash": "8a9f1b059808f432b1f3431b2047c4702c7b562e21ef7031ee79a56c876969fa",
     "psmodule": {
         "name": "PSGitHub"
@@ -13,6 +13,6 @@
         "regex": "Downloads of ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/psgithub.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/psgithub.$version.nupkg"
     }
 }


### PR DESCRIPTION
The CDN domain for the PowerShell Gallery has been changed to `cdn.powershellgallery.com`. The certificate for the original domain has expired.

This PR fixes the download and autoupdate URLs in all PowerShell module manifests within `ScoopInstaller/Main` that were using `psg-prod-eastus.azureedge.net` as the source. At the same time, it also updates all the modules to their latest versions.

---

All modifications in this PR are identical across all files—replacing `psg-prod-eastus.azureedge.net` with `cdn.powershellgallery.com`. Therefore, only the result of `.\checkver.ps1 -App winget-ps` is listed.

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App winget-ps -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket" -f
winget-ps: 1.11.460 (scoop version is 1.11.440) autoupdate available
Forcing autoupdate!
Autoupdating winget-ps
DEBUG[1758525810] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758525810] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758525810] $substitutions.$basenameNoExt                 microsoft.winget.client.1.11.460
DEBUG[1758525810] $substitutions.$matchHead                     1.11.460
DEBUG[1758525810] $substitutions.$preReleaseVersion             1.11.460
DEBUG[1758525810] $substitutions.$buildVersion
DEBUG[1758525810] $substitutions.$dotVersion                    1.11.460
DEBUG[1758525810] $substitutions.$urlNoExt                      https://cdn.powershellgallery.com/packages/microsoft.winget.client.1.11.460
DEBUG[1758525810] $substitutions.$match1                        1.11.460
DEBUG[1758525810] $substitutions.$baseurl                       https://cdn.powershellgallery.com/packages
DEBUG[1758525810] $substitutions.$matchTail
DEBUG[1758525810] $substitutions.$majorVersion                  1
DEBUG[1758525810] $substitutions.$dashVersion                   1-11-460
DEBUG[1758525810] $substitutions.$cleanVersion                  111460
DEBUG[1758525810] $substitutions.$basename                      microsoft.winget.client.1.11.460.nupkg
DEBUG[1758525810] $substitutions.$patchVersion                  460
DEBUG[1758525810] $substitutions.$url                           https://cdn.powershellgallery.com/packages/microsoft.winget.client.1.11.460.nupkg
DEBUG[1758525810] $substitutions.$underscoreVersion             1_11_460
DEBUG[1758525810] $substitutions.$version                       1.11.460
DEBUG[1758525810] $substitutions.$minorVersion                  11
DEBUG[1758525810] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading microsoft.winget.client.1.11.460.nupkg to compute hashes!
microsoft.winget.client.1.11.460.nupkg (19.7 MB) [=========================================================================================================================] 100%
Computed hash: a3d16251fedb02a40b0394e013bf320eab43f101ac0784892961c443e8944501
Writing updated winget-ps manifest
```

- Relates to https://github.com/ScoopInstaller/Extras/pull/16153
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Resolved potential download issues by updating package source URLs to the PowerShell Gallery CDN for: acmesharp, importexcel, powershell-beautifier, powershell-yaml, and psgithub.
* Chores
  * Aligned autoupdate URLs to the PowerShell Gallery CDN for the above packages to improve reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->