### PR TITLE
winget-ps: Update to version 1.11.460, fix autoupdate

### DIFF
--- a/bucket/winget-ps.json
+++ b/bucket/winget-ps.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.11.440",
+    "version": "1.11.460",
     "description": "A PowerShell Module for the Windows Package Manager Client.",
     "homepage": "https://github.com/microsoft/winget-cli/tree/master/src/PowerShell/Microsoft.WinGet.Client",
     "license": "MIT",
     "suggest": {
         "WinGet": "winget"
     },
-    "url": "https://psg-prod-eastus.azureedge.net/packages/microsoft.winget.client.1.11.440.nupkg",
-    "hash": "b48dacc2f787f1e0c8966dc8a20456e78d996bae4b5520bd4baa9000b1b8654c",
+    "url": "https://cdn.powershellgallery.com/packages/microsoft.winget.client.1.11.460.nupkg",
+    "hash": "a3d16251fedb02a40b0394e013bf320eab43f101ac0784892961c443e8944501",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
         "name": "Microsoft.WinGet.Client"
@@ -17,6 +17,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/microsoft.winget.client.$version.nupkg"
+        "url": "https://cdn.powershellgallery.com/packages/microsoft.winget.client.$version.nupkg"
     }
 }


### PR DESCRIPTION
https://github.com/ScoopInstaller/Main/actions/runs/17921841527/job/50958534032

> winget-ps: 1.11.460 (scoop version is 1.11.440) autoupdate available
Autoupdating winget-ps
Downloading microsoft.winget.client.1.11.460.nupkg to compute hashes!
ERROR The SSL connection could not be established, see inner exception.

Relates to #7195


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Winget PowerShell package to version 1.11.460.
  * Switched download and autoupdate sources to the PowerShell Gallery CDN for improved availability and consistency.
  * Refreshed the package checksum to match the new release.
  * Users should experience more reliable and potentially faster downloads during installation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->