### PR TITLE
Rclone UI: Add version 2.6.1

### DIFF
--- a/bucket/rclone-ui.json
+++ b/bucket/rclone-ui.json
@@ -1,0 +1,50 @@
+{
+  "version": "2.6.1",
+  "description": "GUI for rclone & S3",
+  "homepage": "https://github.com/rclone-ui/rclone-ui",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_x64.exe",
+      "hash": "5d3e7918847ca072e3309ee8d77f5f7f7d22e92c5d72dc44d390c43497631314"
+    },
+    "arm64": {
+      "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v2.6.1/Rclone.UI_arm64.exe",
+      "hash": "ad481aa5531bf78b0a379947feb662c27c52ad55a1a9c368e9cc5606e22f0bd4"
+    }
+  },
+  "installer": {
+    "args": [
+      "/S",
+      "/D=$dir"
+    ]
+  },
+  "uninstaller": {
+    "file": "Uninstall.exe",
+    "args": "/S"
+  },
+  "bin": [
+    ["Rclone UI.exe", "rclone-ui"]
+  ],
+  "shortcuts": [
+    ["Rclone UI.exe", "Rclone UI"]
+  ],
+  "suggest": {
+    "rclone": "rclone"
+  },
+  "notes": [
+    "Requires Microsoft Edge WebView2 Runtime (preinstalled on Windows 11 and most Windows 10).",
+    "If missing, install the Evergreen Runtime from Microsoft."
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_x64.exe"
+      },
+      "arm64": {
+        "url": "https://github.com/rclone-ui/rclone-ui/releases/download/v$version/Rclone.UI_arm64.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows package for Rclone UI (v2.6.1) with 64-bit and ARM64 support.
  * Provides installer/uninstaller options, command-line access, and Start Menu shortcut.
  * Includes automatic update checks and architecture-specific update sources.
  * Suggests an optional dependency for enhanced functionality.

* **Documentation**
  * Added release notes and usage notes, including a prerequisite notice for WebView2 and fallback guidance if it’s missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->