### PR TITLE
superhtml@0.6.0: fix manifest

### DIFF
--- a/bucket/superhtml.json
+++ b/bucket/superhtml.json
@@ -6,13 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/kristoff-it/superhtml/releases/download/v0.6.0/x86_64-windows.zip",
-            "hash": "4fe653a82d0d091ed3b5a20838270776f3193ce6a1fbd97d5c7658a747b727bb",
-            "extract_dir": "x86_64-windows"
+            "hash": "4fe653a82d0d091ed3b5a20838270776f3193ce6a1fbd97d5c7658a747b727bb"
         },
         "arm64": {
             "url": "https://github.com/kristoff-it/superhtml/releases/download/v0.6.0/aarch64-windows.zip",
-            "hash": "620a1ed3881e436814f8bf703abe8d16f56c7896810585eed9b2c5c559fe76de",
-            "extract_dir": "aarch64-windows"
+            "hash": "620a1ed3881e436814f8bf703abe8d16f56c7896810585eed9b2c5c559fe76de"
         }
     },
     "bin": "superhtml.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

I have fixed the manifest since in the new version there is no `extract_dir` anymore.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability on 64-bit and ARM64 by removing an outdated extraction setting, preventing path-related issues and aligning with the current archive structure. Users should experience smoother installs and updates with no manual intervention. No changes to features or configuration—just stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->