### PR TITLE
Trippy: Update homepage

### DIFF
--- a/bucket/trippy.json
+++ b/bucket/trippy.json
@@ -1,7 +1,7 @@
 {
     "version": "0.13.0",
     "description": "Trippy combines the functionality of traceroute and ping and is designed to assist with the analysis of networking issues.",
-    "homepage": "https://trippy.cli.rs/",
+    "homepage": "https://trippy.rs/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Update to match homepage presented in GitHub repo

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Trippy homepage URL to https://trippy.rs/, ensuring users are directed to the correct official site wherever the app surfaces this link.
* **Documentation**
  * Refreshed the project homepage link to reflect the new domain, improving accuracy for users seeking more information or support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->