### PR TITLE
swc@1.13.19: Add pre_install, update checkver and autoupdate

### DIFF
--- a/bucket/swc.json
+++ b/bucket/swc.json
@@ -5,33 +5,33 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-x64-msvc.exe#/swc.exe",
+            "url": "https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-x64-msvc.exe",
             "hash": "7f5a4059391f059b64e7eef65bf97b04842e9943cfd688c7d671d8388185f784"
         },
         "32bit": {
-            "url": "https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-ia32-msvc.exe#/swc.exe",
+            "url": "https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-ia32-msvc.exe",
             "hash": "1f23986b58161c91291a02aaa81f44a24f1af7674b0d0c5bb507e1f0b7958842"
         },
         "arm64": {
-            "url": "https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-arm64-msvc.exe#/swc.exe",
+            "url": "https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-arm64-msvc.exe",
             "hash": "501f5a712519a7c2b93b95604b59408cc78024cc8295999012d61a970195f31e"
         }
     },
+    "pre_install": "Get-ChildItem -Path \"$dir\" -Filter '*swc*' | Rename-Item -NewName 'swc.exe' -Force",
     "bin": "swc.exe",
     "checkver": {
-        "github": "https://github.com/swc-project/swc",
-        "regex": "tag/v([\\w\\.-]+)"
+        "github": "https://github.com/swc-project/swc"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/swc-project/swc/releases/download/v$version/swc-win32-x64-msvc.exe#/swc.exe"
+                "url": "https://github.com/swc-project/swc/releases/download/v$version/swc-win32-x64-msvc.exe"
             },
             "32bit": {
-                "url": "https://github.com/swc-project/swc/releases/download/v$version/swc-win32-ia32-msvc.exe#/swc.exe"
+                "url": "https://github.com/swc-project/swc/releases/download/v$version/swc-win32-ia32-msvc.exe"
             },
             "arm64": {
-                "url": "https://github.com/swc-project/swc/releases/download/v$version/swc-win32-arm64-msvc.exe#/swc.exe"
+                "url": "https://github.com/swc-project/swc/releases/download/v$version/swc-win32-arm64-msvc.exe"
             }
         }
     }


### PR DESCRIPTION
This PR fixes the issue where the `swc` manifest would be updated to a Nightly version and resolves related problems.  

Here are some tests:  

- Remove `#/swc.exe` from the download and autoupdate URLs to use Scoop's built-in hash retrieval method.  

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App swc -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket" -f
swc: 1.13.19 (scoop version is 1.13.19)
Forcing autoupdate!
Autoupdating swc
DEBUG[1758805250] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758805250] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758805250] $substitutions.$dashVersion                   1-13-19
DEBUG[1758805250] $substitutions.$cleanVersion                  11319
DEBUG[1758805250] $substitutions.$dotVersion                    1.13.19
DEBUG[1758805250] $substitutions.$basenameNoExt                 swc-win32-ia32-msvc
DEBUG[1758805250] $substitutions.$underscoreVersion             1_13_19
DEBUG[1758805250] $substitutions.$urlNoExt                      https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-ia32-msvc
DEBUG[1758805250] $substitutions.$preReleaseVersion             1.13.19
DEBUG[1758805250] $substitutions.$baseurl                       https://github.com/swc-project/swc/releases/download/v1.13.19
DEBUG[1758805250] $substitutions.$url                           https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-ia32-msvc.exe
DEBUG[1758805250] $substitutions.$basename                      swc-win32-ia32-msvc.exe
DEBUG[1758805250] $substitutions.$matchTail
DEBUG[1758805250] $substitutions.$minorVersion                  13
DEBUG[1758805250] $substitutions.$matchHead                     1.13.19
DEBUG[1758805250] $substitutions.$majorVersion                  1
DEBUG[1758805250] $substitutions.$patchVersion                  19
DEBUG[1758805250] $substitutions.$version                       1.13.19
DEBUG[1758805250] $substitutions.$buildVersion
DEBUG[1758805250] $substitutions.$match1                        1.13.19
DEBUG[1758805250] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1758805252] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-ia32-msvc.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 1f23986b58161c91291a02aaa81f44a24f1af7674b0d0c5bb507e1f0b7958842 using Github Mode
DEBUG[1758805252] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758805252] $substitutions.$dashVersion                   1-13-19
DEBUG[1758805252] $substitutions.$cleanVersion                  11319
DEBUG[1758805252] $substitutions.$dotVersion                    1.13.19
DEBUG[1758805252] $substitutions.$basenameNoExt                 swc-win32-x64-msvc
DEBUG[1758805252] $substitutions.$underscoreVersion             1_13_19
DEBUG[1758805252] $substitutions.$urlNoExt                      https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-x64-msvc
DEBUG[1758805252] $substitutions.$preReleaseVersion             1.13.19
DEBUG[1758805252] $substitutions.$baseurl                       https://github.com/swc-project/swc/releases/download/v1.13.19
DEBUG[1758805252] $substitutions.$url                           https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-x64-msvc.exe
DEBUG[1758805252] $substitutions.$basename                      swc-win32-x64-msvc.exe
DEBUG[1758805252] $substitutions.$matchTail
DEBUG[1758805252] $substitutions.$minorVersion                  13
DEBUG[1758805252] $substitutions.$matchHead                     1.13.19
DEBUG[1758805252] $substitutions.$majorVersion                  1
DEBUG[1758805252] $substitutions.$patchVersion                  19
DEBUG[1758805252] $substitutions.$version                       1.13.19
DEBUG[1758805252] $substitutions.$buildVersion
DEBUG[1758805252] $substitutions.$match1                        1.13.19
DEBUG[1758805252] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1758805253] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-x64-msvc.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 7f5a4059391f059b64e7eef65bf97b04842e9943cfd688c7d671d8388185f784 using Github Mode
DEBUG[1758805253] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758805253] $substitutions.$dashVersion                   1-13-19
DEBUG[1758805253] $substitutions.$cleanVersion                  11319
DEBUG[1758805253] $substitutions.$dotVersion                    1.13.19
DEBUG[1758805253] $substitutions.$basenameNoExt                 swc-win32-arm64-msvc
DEBUG[1758805253] $substitutions.$underscoreVersion             1_13_19
DEBUG[1758805253] $substitutions.$urlNoExt                      https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-arm64-msvc
DEBUG[1758805253] $substitutions.$preReleaseVersion             1.13.19
DEBUG[1758805253] $substitutions.$baseurl                       https://github.com/swc-project/swc/releases/download/v1.13.19
DEBUG[1758805253] $substitutions.$url                           https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-arm64-msvc.exe
DEBUG[1758805253] $substitutions.$basename                      swc-win32-arm64-msvc.exe
DEBUG[1758805253] $substitutions.$matchTail
DEBUG[1758805253] $substitutions.$minorVersion                  13
DEBUG[1758805253] $substitutions.$matchHead                     1.13.19
DEBUG[1758805253] $substitutions.$majorVersion                  1
DEBUG[1758805253] $substitutions.$patchVersion                  19
DEBUG[1758805253] $substitutions.$version                       1.13.19
DEBUG[1758805253] $substitutions.$buildVersion
DEBUG[1758805253] $substitutions.$match1                        1.13.19
DEBUG[1758805253] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1758805254] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/swc-project/swc/releases/download/v1.13.19/swc-win32-arm64-msvc.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 501f5a712519a7c2b93b95604b59408cc78024cc8295999012d61a970195f31e using Github Mode
Writing updated swc manifest
```

- Add a `pre_install` script to handle the renaming process.  

```
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket][ swc ≢]
└─> scoop install .\swc.json
Installing 'swc' (1.13.19) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket\swc.json'
Loading swc-win32-x64-msvc.exe from cache.
Checking hash of swc-win32-x64-msvc.exe ... ok.
Running pre_install script...done.
Linking D:\Software\Scoop\Local\apps\swc\current => D:\Software\Scoop\Local\apps\swc\1.13.19
Creating shim for 'swc'.
'swc' (1.13.19) was installed successfully!

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket][ swc ≢]
└─> swc --help
SWC 42.0.0

USAGE:
    swc.exe <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    bundle
    compile    Run SWC's transformer
    help       Print this message or the help of the given subcommand(s)
    lint
    minify
    plugin     Commandline utilities for creating, building plugins
```

- Closes #7203 
<br>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
