### PR TITLE
bom: Update to version 0.7.0

### DIFF
--- a/bucket/bom.json
+++ b/bucket/bom.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.6.0",
+    "version": "0.7.0",
     "description": "A utility that lets you create, view and transform Software Bills of Materials (SBOMs).",
     "homepage": "https://kubernetes-sigs.github.io/bom/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kubernetes-sigs/bom/releases/download/v0.6.0/bom-amd64-windows.exe#/bom.exe",
-            "hash": "34697174293afe491bedc5ce5ef24f3a36fe4a293aebe81bd519593c550aa0fd"
+            "url": "https://github.com/kubernetes-sigs/bom/releases/download/v0.7.0/bom-amd64-windows_0.7.0_windows_amd64.exe#/bom.exe",
+            "hash": "bb0fd81ea97bc05ab5b4bba5f29f1afa2cccb097968c37082b0ac34c380f2d13"
         }
     },
     "bin": "bom.exe",
@@ -16,7 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kubernetes-sigs/bom/releases/download/v$version/bom-amd64-windows.exe#/bom.exe"
+                "url": "https://github.com/kubernetes-sigs/bom/releases/download/v$version/bom-amd64-windows_$version_windows_amd64.exe#/bom.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes failing Excavator auto-update due to artifact name change on upstream release
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 0.7.0.
  * Updated 64-bit Windows download link to match the new filename convention.
  * Refreshed checksum for the 64-bit Windows build to ensure integrity.
  * Adjusted the autoupdate URL pattern to include the version in the filename for future releases.

Impact: Users on 64-bit Windows will see smoother installs and updates with the correct download path and verified binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->