### PR TITLE
chisel: Update to version 1.11.3, add arm64

### DIFF
--- a/bucket/chisel.json
+++ b/bucket/chisel.json
@@ -1,16 +1,20 @@
 {
-    "version": "1.10.1",
+    "version": "1.11.3",
     "description": "A fast TCP tunnel over HTTP",
     "homepage": "https://github.com/jpillora/chisel",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jpillora/chisel/releases/download/v1.10.1/chisel_1.10.1_windows_amd64.gz",
-            "hash": "42fd40bb0e6e8e0072a83f3a824de5045636c1cc8e3819daa3c9b7a985a2cc58"
+            "url": "https://github.com/jpillora/chisel/releases/download/v1.11.3/chisel_1.11.3_windows_amd64.zip",
+            "hash": "e07f1cfd3ac5f77134e5289fb33a5096d037d165da56bd473744bdae2bc2fd2d"
+        },
+        "arm64": {
+            "url": "https://github.com/jpillora/chisel/releases/download/v1.11.3/chisel_1.11.3_windows_arm64.zip",
+            "hash": "861e3b6f39ddeb823b90aac7ca9b4bb29e09895159d429b6765935485e321997"
         },
         "32bit": {
-            "url": "https://github.com/jpillora/chisel/releases/download/v1.10.1/chisel_1.10.1_windows_386.gz",
-            "hash": "9af93373a3cfb8a43dd857050d3b265b70270b23184ce7ae47674c69ca44fd3c"
+            "url": "https://github.com/jpillora/chisel/releases/download/v1.11.3/chisel_1.11.3_windows_386.zip",
+            "hash": "aed093436dc7d4d56f444d7a1af9fe96dcc3b48b84af51577b802736c85cedbf"
         }
     },
     "bin": "chisel.exe",
@@ -18,10 +22,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jpillora/chisel/releases/download/v$version/chisel_$version_windows_amd64.gz"
+                "url": "https://github.com/jpillora/chisel/releases/download/v$version/chisel_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/jpillora/chisel/releases/download/v$version/chisel_$version_windows_arm64.zip"
             },
             "32bit": {
-                "url": "https://github.com/jpillora/chisel/releases/download/v$version/chisel_$version_windows_386.gz"
+                "url": "https://github.com/jpillora/chisel/releases/download/v$version/chisel_$version_windows_386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes excavator auto-update broken by upstream artifact name change (now using zip archives for Windows).

Also added the arm64 builds, since they are available.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added native support for Windows ARM64.
- Chores
  - Upgraded to version 1.11.3.
  - Switched Windows downloads from .gz to .zip across 32-bit and 64-bit builds for easier installation.
  - Updated auto-update configuration to use the new .zip artifacts and include ARM64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->