### PR TITLE
par2cmdline: Update to version 1.0.0, add arm64, drop 32bit

### DIFF
--- a/bucket/par2cmdline.json
+++ b/bucket/par2cmdline.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.8.1",
+    "version": "1.0.0",
     "description": "A program for creating and using PAR2 files to detect damage in data files and repair them if necessary.",
     "homepage": "https://github.com/Parchive/par2cmdline",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Parchive/par2cmdline/releases/download/v0.8.1/par2cmdline-0.8.1-win-x64.zip",
-            "hash": "sha512:c0e66415c6b1c34a790ff0e5a29f9cd7b413f4372440265150ef1442d577926aedb2f58edf0f934cfb2e78df6123ce15199766b89295966feedfe75d19f0ecec"
+            "url": "https://github.com/Parchive/par2cmdline/releases/download/v1.0.0/par2cmdline-1.0.0-win-x64.zip",
+            "hash": "sha512:bf8af01d7e44806fed7d1be402135e0f4c5717d0089ff8099b149bd1633632cb38592d12b2848643a97281822b24a3dbb8b2bd707386af6112e8072df8908d2d"
         },
-        "32bit": {
-            "url": "https://github.com/Parchive/par2cmdline/releases/download/v0.8.1/par2cmdline-0.8.1-win-x86.zip",
-            "hash": "sha512:2997672aadfb64701d8421b868a9c478a60faea9cf9e2d2874275812860f34d47c1313f664d5c8d608b7c62d71c8ef20718c00e9acf219434a523f255d0139cb"
+        "arm64": {
+            "url": "https://github.com/Parchive/par2cmdline/releases/download/v1.0.0/par2cmdline-1.0.0-win-arm64.zip",
+            "hash": "sha512:5ebed64f7f3d673fac1b8c1943ffb9eb6f4d0056f904574ccd76dca5b86cb223e54b439d3dee2af64d378c5b598b22aa6a2fa6864cbbf0829a03d1ad0425b35b"
         }
     },
     "bin": "par2.exe",
@@ -20,8 +20,8 @@
             "64bit": {
                 "url": "https://github.com/Parchive/par2cmdline/releases/download/v$version/par2cmdline-$version-win-x64.zip"
             },
-            "32bit": {
-                "url": "https://github.com/Parchive/par2cmdline/releases/download/v$version/par2cmdline-$version-win-x86.zip"
+            "arm64": {
+                "url": "https://github.com/Parchive/par2cmdline/releases/download/v$version/par2cmdline-$version-win-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fixes failing excavator auto-update due lack of 32bit support.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added native ARM64 build support.
- Chores
  - Upgraded to version 1.0.0.
  - Updated download sources and checksums for all supported architectures.
  - Improved autoupdate configuration to track the latest release.
  - Removed 32-bit build support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->