### PR TITLE
red: upgrade hash URL to HTTPS

### DIFF
--- a/bucket/red.json
+++ b/bucket/red.json
@@ -16,7 +16,7 @@
     "autoupdate": {
         "url": "https://static.red-lang.org/dl/auto/win/red-$version-$matchCommit.exe#/red.exe",
         "hash": {
-            "url": "http://static.red-lang.org/download.html",
+            "url": "https://static.red-lang.org/download.html",
             "regex": "$basename[\\s\\S]+?$sha256"
         }
     }


### PR DESCRIPTION
red: upgrade hash URL to HTTPS

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
