### PR TITLE
multi-gitter: Add version 0.58.0

### DIFF
--- a/bucket/multi-gitter.json
+++ b/bucket/multi-gitter.json
@@ -1,6 +1,6 @@
 {
     "version": "0.58.0",
-    "description": "Update multiple repositories in with one command",
+    "description": "A command-line tool for updating multiple repositories with a single command.",
     "homepage": "https://github.com/lindell/multi-gitter",
     "license": "Apache-2.0",
     "architecture": {
@@ -18,9 +18,7 @@
         }
     },
     "bin": "multi-gitter.exe",
-    "checkver": {
-        "github": "https://github.com/lindell/multi-gitter"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/multi-gitter.json
+++ b/bucket/multi-gitter.json
@@ -1,0 +1,40 @@
+{
+  "version": "0.58.0",
+  "description": "Update multiple repositories in with one command",
+  "homepage": "https://github.com/lindell/multi-gitter",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_x86_64.tar.gz",
+      "hash": "4af737d541cda9c7736b01284def7a084f619baa6c528148712cad50877791cb"
+    },
+    "32bit": {
+      "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_i386.tar.gz",
+      "hash": "1ebfaf8f6e88e8e5e9f433a054ab3e9729ca9831e8622af7ec1bb7f7d6ea06f3"
+    },
+    "arm64": {
+      "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_ARM64.tar.gz",
+      "hash": "84164ce82da1c9f4e749d2d649ed632a4471668d6e261aff050c2c7658c1f168"
+    }
+  },
+  "bin": "multi-gitter.exe",
+  "checkver": {
+    "github": "https://github.com/lindell/multi-gitter"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_x86_64.tar.gz"
+      },
+      "32bit": {
+        "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_i386.tar.gz"
+      },
+      "arm64": {
+        "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_ARM64.tar.gz"
+      }
+    },
+    "hash": {
+      "url": "$baseurl/checksums.txt"
+    }
+  }
+}

--- a/bucket/multi-gitter.json
+++ b/bucket/multi-gitter.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.58.0",
-  "description": "Update multiple repositories in with one command",
-  "homepage": "https://github.com/lindell/multi-gitter",
-  "license": "Apache-2.0",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_x86_64.tar.gz",
-      "hash": "4af737d541cda9c7736b01284def7a084f619baa6c528148712cad50877791cb"
-    },
-    "32bit": {
-      "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_i386.tar.gz",
-      "hash": "1ebfaf8f6e88e8e5e9f433a054ab3e9729ca9831e8622af7ec1bb7f7d6ea06f3"
-    },
-    "arm64": {
-      "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_ARM64.tar.gz",
-      "hash": "84164ce82da1c9f4e749d2d649ed632a4471668d6e261aff050c2c7658c1f168"
-    }
-  },
-  "bin": "multi-gitter.exe",
-  "checkver": {
-    "github": "https://github.com/lindell/multi-gitter"
-  },
-  "autoupdate": {
+    "version": "0.58.0",
+    "description": "Update multiple repositories in with one command",
+    "homepage": "https://github.com/lindell/multi-gitter",
+    "license": "Apache-2.0",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_x86_64.tar.gz"
-      },
-      "32bit": {
-        "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_i386.tar.gz"
-      },
-      "arm64": {
-        "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_ARM64.tar.gz"
-      }
+        "64bit": {
+            "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_x86_64.tar.gz",
+            "hash": "4af737d541cda9c7736b01284def7a084f619baa6c528148712cad50877791cb"
+        },
+        "32bit": {
+            "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_i386.tar.gz",
+            "hash": "1ebfaf8f6e88e8e5e9f433a054ab3e9729ca9831e8622af7ec1bb7f7d6ea06f3"
+        },
+        "arm64": {
+            "url": "https://github.com/lindell/multi-gitter/releases/download/v0.58.0/multi-gitter_0.58.0_Windows_ARM64.tar.gz",
+            "hash": "84164ce82da1c9f4e749d2d649ed632a4471668d6e261aff050c2c7658c1f168"
+        }
     },
-    "hash": {
-      "url": "$baseurl/checksums.txt"
+    "bin": "multi-gitter.exe",
+    "checkver": {
+        "github": "https://github.com/lindell/multi-gitter"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_x86_64.tar.gz"
+            },
+            "32bit": {
+                "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_i386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/lindell/multi-gitter/releases/download/v$version/multi-gitter_$version_Windows_ARM64.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
     }
-  }
 }


### PR DESCRIPTION
multi-gitter: a command-line tool to apply changes on multiple repos at once.

Closes #7216

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows package for multi-gitter v0.58.0 to enable easy installation via Scoop.
  * Supports 32‑bit, 64‑bit, and ARM64 Windows architectures for broader device compatibility.
  * Includes automatic update checks and architecture-aware autoupdate configuration for streamlined future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->