### PR TITLE
octave@10.3.0: Use mirror download URL as mandated by GNU

### DIFF
--- a/bucket/octave.json
+++ b/bucket/octave.json
@@ -1,7 +1,7 @@
 {
     "version": "10.3.0",
     "description": "A high-level language primarily intended for numerical computations.",
-    "homepage": "https://www.gnu.org/software/octave/",
+    "homepage": "https://octave.org",
     "license": "GPL-3.0-only",
     "notes": [
         "* Known issue:",
@@ -11,8 +11,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://ftp.gnu.org/gnu/octave/windows/octave-10.3.0-w64.zip",
-            "hash": "d201e9b5a082427b22e5691a039b861b2a27167f7771b3e3cf0a74556f986777",
+            "url": "https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64.7z",
+            "hash": "4595B055C73DE090839F5B86F289B0AC22B69549676B3452252306FFFDC37AC6",
             "extract_dir": "octave-10.3.0-w64",
             "bin": [
                 [
@@ -39,7 +39,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://ftp.gnu.org/gnu/octave/windows/octave-$version-w64.zip",
+                "url": "https://ftpmirror.gnu.org/octave/windows/octave-$version-w64.7z",
                 "extract_dir": "octave-$version-w64"
             }
         }

--- a/bucket/octave.json
+++ b/bucket/octave.json
@@ -12,7 +12,7 @@
     "architecture": {
         "64bit": {
             "url": "https://ftpmirror.gnu.org/octave/windows/octave-10.3.0-w64.7z",
-            "hash": "4595B055C73DE090839F5B86F289B0AC22B69549676B3452252306FFFDC37AC6",
+            "hash": "4595b055c73de090839f5b86f289b0ac22b69549676b3452252306fffdc37ac6",
             "extract_dir": "octave-10.3.0-w64",
             "bin": [
                 [


### PR DESCRIPTION
Closes #7232

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
