### PR TITLE
kube-linter@0.7.6: Add arm64 version

### DIFF
--- a/bucket/kube-linter.json
+++ b/bucket/kube-linter.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/stackrox/kube-linter/releases/download/v0.7.6/kube-linter.exe",
             "hash": "e714f09f22a36c9c0c62fcb9472a933688c7820957d9956dcf6a01e3fd7b2340"
+        },
+        "arm64": {
+            "url": "https://github.com/stackrox/kube-linter/releases/download/v0.7.6/kube-linter_arm64.exe#/kube-linter.exe",
+            "hash": "203ce4a73f1f7c22d245677df92731cc4e94ab7cb593e99937c14d53cc72f72a"
         }
     },
     "bin": "kube-linter.exe",
@@ -15,6 +19,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/stackrox/kube-linter/releases/download/v$version/kube-linter.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/stackrox/kube-linter/releases/download/v$version/kube-linter_arm64.exe#/kube-linter.exe"
             }
         }
     }


### PR DESCRIPTION
Add arm64 version.
Relates to stackrox/kube-linter#725.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
