### PR TITLE
bat@0.26.0: Add arm64 support

### DIFF
--- a/bucket/bat.json
+++ b/bucket/bat.json
@@ -17,6 +17,11 @@
             "url": "https://github.com/sharkdp/bat/releases/download/v0.26.0/bat-v0.26.0-i686-pc-windows-msvc.zip",
             "hash": "d6f4f38815ae2f7f400d8091869ec487f930c36e3f6c189d104e4ddd9e81131d",
             "extract_dir": "bat-v0.26.0-i686-pc-windows-msvc"
+        },
+        "arm64": {
+            "url": "https://github.com/sharkdp/bat/releases/download/v0.26.0/bat-v0.26.0-aarch64-pc-windows-msvc.zip",
+            "hash": "8feb1582b5a141b2c6d63d1f1abfc496c97ff2255eb9b797d5444393d233232c",
+            "extract_dir": "bat-v0.26.0-aarch64-pc-windows-msvc"
         }
     },
     "pre_install": [
@@ -49,6 +54,10 @@
             "32bit": {
                 "url": "https://github.com/sharkdp/bat/releases/download/v$version/bat-v$version-i686-pc-windows-msvc.zip",
                 "extract_dir": "bat-v$version-i686-pc-windows-msvc"
+            },
+            "arm64": {
+                "url": "https://github.com/sharkdp/bat/releases/download/v$version/bat-v$version-aarch64-pc-windows-msvc.zip",
+                "extract_dir": "bat-v$version-aarch64-pc-windows-msvc"
             }
         }
     }


### PR DESCRIPTION
This change adds support for the arm64 architecture, which Bat now supports as of 0.26.0.

Closes #7285

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
