### PR TITLE
gallery-dl@1.30.10: Add 32bit architecture

### DIFF
--- a/bucket/gallery-dl.json
+++ b/bucket/gallery-dl.json
@@ -3,13 +3,28 @@
     "description": "Command-line program to download image-galleries and -collections from several image hosting sites.",
     "homepage": "https://github.com/mikf/gallery-dl",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/mikf/gallery-dl/releases/download/v1.30.10/gallery-dl.exe",
-    "hash": "d22723e46d10e26ce18d6ffd1796de2b8e0f7e0b6ae41e3c6196283ea8e421cb",
-    "bin": "gallery-dl.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mikf/gallery-dl/releases/download/v1.30.10/gallery-dl.exe",
+            "hash": "d22723e46d10e26ce18d6ffd1796de2b8e0f7e0b6ae41e3c6196283ea8e421cb"
+        },
+        "32bit": {
+            "url": "https://github.com/mikf/gallery-dl/releases/download/v1.30.10/gallery-dl_x86.exe#/gallery-dl.exe",
+            "hash": "b37e4f740dffe0a013c4507648cd1fd9c62867de385db0c33ccda16653a74f6a"
+        }
+    },
     "pre_install": "if (-not (Test-Path \"$persist_dir\\gallery-dl.conf\")) { Set-Content \"$dir\\gallery-dl.conf\" '{}' -Encoding Ascii | Out-Null }",
+    "bin": "gallery-dl.exe",
     "persist": "gallery-dl.conf",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mikf/gallery-dl/releases/download/v$version/gallery-dl.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mikf/gallery-dl/releases/download/v$version/gallery-dl.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/mikf/gallery-dl/releases/download/v$version/gallery-dl_x86.exe#/gallery-dl.exe"
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Use the `architecture` field to specify the download URLs for the 32bit and 64bit versions of gallery-dl.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Closes #7294

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
