### PR TITLE
uutils-coreutils: Remove wrong `relpath`

### DIFF
--- a/bucket/uutils-coreutils.json
+++ b/bucket/uutils-coreutils.json
@@ -288,11 +288,6 @@
         ],
         [
             "coreutils.exe",
-            "relpath",
-            "relpath"
-        ],
-        [
-            "coreutils.exe",
             "rm",
             "rm"
         ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<img width="326" height="51" alt="image" src="https://github.com/user-attachments/assets/4ce5d4ce-f610-4ed4-92d0-a22471b6900c" />


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
