### PR TITLE
vim: Update to version 9.1.1825, add arm64 support, update checkver

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.1.1882",
+    "version": "9.1.1825",
     "description": "A highly configurable text editor",
     "homepage": "https://www.vim.org",
     "license": "Vim",
@@ -9,16 +9,16 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vim/vim-win32-installer/releases/download/v9.1.1882/gvim_9.1.1882_x64.zip",
-            "hash": "d9c1533ec80b373405b8f07193b460e4f19f836594b8d70e9f3bc9471d5e8a95"
+            "url": "https://github.com/vim/vim-win32-installer/releases/download/v9.1.1825/gvim_9.1.1825_x64.zip",
+            "hash": "0d343c5acffe985f4ebfd4790a9ec2ceb3a9cf6440eeed2b6390f2171d131a41"
         },
         "32bit": {
-            "url": "https://github.com/vim/vim-win32-installer/releases/download/v9.1.1882/gvim_9.1.1882_x86.zip",
-            "hash": "c175258802638888657f392bad807f6b1b961d5419563185d1cf17d7f14fa09f"
+            "url": "https://github.com/vim/vim-win32-installer/releases/download/v9.1.1825/gvim_9.1.1825_x86.zip",
+            "hash": "ff1a46dfdda8d4729bf91e701cf7eff8ae97478e86cb3f4c6c03bd28e426acc6"
         },
         "arm64": {
-            "url": "https://github.com/vim/vim-win32-installer/releases/download/v9.1.1882/gvim_9.1.1882_arm64.zip",
-            "hash": "23907fca7493f2b05a6c0bb88e8df7b1002dc63e5774c6c3f72c45b6a7e3c281"
+            "url": "https://github.com/vim/vim-win32-installer/releases/download/v9.1.1825/gvim_9.1.1825_arm64.zip",
+            "hash": "d0a8bf5e41dfa57464131d6c52963b0db95857171adc890469528fc8d5ae2e60"
         }
     },
     "extract_dir": "vim/vim91",
@@ -101,19 +101,19 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/microsoft/winget-pkgs/commits/master/manifests/v/vim/vim",
-        "regex": "vim.vim version ([\\d.]+)"
+        "url": "https://www.vim.org/download.php",
+        "regex": "gvim_([\\d.]+)_x64(?<suffix>[^.]+)?\\.zip"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x64.zip"
+                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x64$matchSuffix.zip"
             },
             "32bit": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x86.zip"
+                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x86$matchSuffix.zip"
             },
             "arm64": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_arm64.zip"
+                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_arm64$matchSuffix.zip"
             }
         },
         "extract_dir": "vim/vim$majorVersion$minorVersion"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

The vim manifest has not been updated for a long time (1.5 years) as they do not post signed build updates on the vim download page. Also, there are no guarantees from the site that signed builds are more stable than unsigned builds.

This PR changes checkver URL to track winget vim.vim (stable) release, which according to [vim/vim-win32-installer](https://github.com/vim/vim-win32-installer?tab=readme-ov-file#winget) is updated approximately every month. ARM64 builds are now available from the repository so they are added to the manifest as well.

Winget repository only provides unsigned builds so the autoupdate URLs are changed to use unsigned zips instead. I have tested updating from signed build to unsigned build and no errors were found.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
