### PR TITLE
nodejs-lts: deprecate 32-bit and update to v24.11.0

### DIFF
--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -1,23 +1,18 @@
 {
-    "version": "22.21.0",
+    "version": "24.11.0",
     "description": "As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications. (Long Term Support)",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v22.21.0/node-v22.21.0-win-x64.7z",
-            "hash": "31a82a950fd2524651f0409307afe3276ae68a13a131e8b72945a3931109c8c3",
-            "extract_dir": "node-v22.21.0-win-x64"
-        },
-        "32bit": {
-            "url": "https://nodejs.org/dist/v22.21.0/node-v22.21.0-win-x86.7z",
-            "hash": "d2767e24741f915477002d6325dda40f7554ce9e5176c8d2e824dc127d273725",
-            "extract_dir": "node-v22.21.0-win-x86"
+            "url": "https://nodejs.org/dist/v24.11.0/node-v24.11.0-win-x64.7z",
+            "hash": "261277b58400f23595804c0ad246f924c621b942da052bebf897f49e126733f3",
+            "extract_dir": "node-v24.11.0-win-x64"
         },
         "arm64": {
-            "url": "https://nodejs.org/dist/v22.21.0/node-v22.21.0-win-arm64.7z",
-            "hash": "3fce2daac6b36f6343d79ef72590b46ada5b22df3538e45e46c521c531f3f205",
-            "extract_dir": "node-v22.21.0-win-arm64"
+            "url": "https://nodejs.org/dist/v24.11.0/node-v24.11.0-win-arm64.7z",
+            "hash": "cebc870a3597f53fc979a6ff8a8e866de1ce7d98a4b671ffa4de56b907118a5b",
+            "extract_dir": "node-v24.11.0-win-arm64"
         }
     },
     "post_install": [
@@ -42,10 +37,6 @@
             "64bit": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-x64.7z",
                 "extract_dir": "node-v$version-win-x64"
-            },
-            "32bit": {
-                "url": "https://nodejs.org/dist/v$version/node-v$version-win-x86.7z",
-                "extract_dir": "node-v$version-win-x86"
             },
             "arm64": {
                 "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

Removes 32-bit and updates to the latest LTS.

Closes #7306

Reference: #6264

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
