### PR TITLE
teleport: Update version 18.3.2, fix checkver & license

### DIFF
--- a/bucket/teleport.json
+++ b/bucket/teleport.json
@@ -1,12 +1,12 @@
 {
-    "version": "18.3.1",
+    "version": "18.3.2",
     "description": "Privileged access management for cloud-native infrastructure",
     "homepage": "https://goteleport.com",
     "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.teleport.dev/teleport-v18.3.1-windows-amd64-bin.zip",
-            "hash": "e5361630690ef747cfd6c65a7bbf308d2d079c840870f6d78ff98be903320d56"
+            "url": "https://cdn.teleport.dev/teleport-v18.3.2-windows-amd64-bin.zip",
+            "hash": "a789f6ac56ea5a47f44cb5945fa1f87964ddedbea4f59deb17af614defe39d9b"
         }
     },
     "bin": "tsh.exe",


### PR DESCRIPTION
- Update to the latest version.
- Fix `checkver` (switch to GH releases).
- Update license.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
