### PR TITLE
terraform-switcher: Update to version 1.9.0, fix autoupdate

### DIFF
--- a/bucket/terraform-switcher.json
+++ b/bucket/terraform-switcher.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.3.0",
+    "version": "1.9.0",
     "description": "A command line tool to switch between different versions of terraform",
     "homepage": "https://tfswitch.warrensbox.com",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v1.3.0/terraform-switcher_v1.3.0_windows_386.tar.gz",
-            "hash": "69491fdfc49bd3c3bdc6e73d7583b644f1f3579fee747b47c058ad6242d97dab"
+            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v1.9.0/terraform-switcher_v1.9.0_windows_386.zip",
+            "hash": "3611f8b2aa521c3a6245069782b74296cf479a597df5fedba57ba94f68ec9917"
         },
         "64bit": {
-            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v1.3.0/terraform-switcher_v1.3.0_windows_amd64.tar.gz",
-            "hash": "c76dfd2923792aa91dc0de0f9c32dccbd753f4c8bdfd28b5f6ca592e40a9f117"
+            "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v1.9.0/terraform-switcher_v1.9.0_windows_amd64.zip",
+            "hash": "0fcb919e3b25de5e6b3e6921f2d445567f2dd10b6a5cbf248c5636ff1a9b0513"
         }
     },
     "bin": "tfswitch.exe",
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v$version/terraform-switcher_v$version_windows_386.tar.gz"
+                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v$version/terraform-switcher_v$version_windows_386.zip"
             },
             "64bit": {
-                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v$version/terraform-switcher_v$version_windows_amd64.tar.gz"
+                "url": "https://github.com/warrensbox/terraform-switcher/releases/download/v$version/terraform-switcher_v$version_windows_amd64.zip"
             }
         }
     }


### PR DESCRIPTION
- Update to the latest version.
- Switch autoupdate to zip archives (relates to warrensbox/terraform-switcher#527).

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
