### PR TITLE
cwrsync@6.4.6: Remove extract_dir

### DIFF
--- a/bucket/cwrsync.json
+++ b/bucket/cwrsync.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/itefixnet/download/releases/download/cwrsync-client-v6.4.6/cwrsync_6.4.6_x64_free.zip",
-            "hash": "7f9d6ec80b174a04fe42768a4df369bccc98674e6d139f853229871869e5c707",
+            "hash": "7f9d6ec80b174a04fe42768a4df369bccc98674e6d139f853229871869e5c707"
         }
     },
     "bin": "bin\\rsync.exe",
@@ -18,7 +18,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/itefixnet/download/releases/download/cwrsync-client-v$version/cwrsync_$version_x64_free.zip",
+                "url": "https://github.com/itefixnet/download/releases/download/cwrsync-client-v$version/cwrsync_$version_x64_free.zip"
             }
         }
     }


### PR DESCRIPTION
The manifest@6.4.6 doesn't work with "extract_dir". Removed "extract_dir" fields from architecture and autoupdate sections.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--

or
Relates to #XXXX
-->
Closes #7322

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
