### PR TITLE
pacparser@1.4.6: fix install and autoupdate

### DIFF
--- a/bucket/pacparser.json
+++ b/bucket/pacparser.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/manugarg/pacparser/releases/download/v1.4.6/pacparser-v1.4.6-windows-x86_64.zip",
-            "hash": "f1b5ef0cb633754578a86f1a8acab6f67e88b1b0e8c635677b9889c55661f787"
+            "hash": "f1b5ef0cb633754578a86f1a8acab6f67e88b1b0e8c635677b9889c55661f787",
+            "extract_dir": "pacparser-v1.4.6-windows-x86_64"
         }
     },
     "bin": "pactester.exe",
@@ -14,7 +15,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/manugarg/pacparser/releases/download/v$version/pacparser-v$version-windows-x86_64.zip"
+                "url": "https://github.com/manugarg/pacparser/releases/download/v$version/pacparser-v$version-windows-x86_64.zip",
+                "extract_dir": "pacparser-v$version-windows-x86_64"
             }
         }
     }


### PR DESCRIPTION
The zip archive contains a folder once again like v1.4.3 and under.

This PR adds `extract_dir` to the manifest to fix installing.

Closes #7323

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
