### PR TITLE
codex: adjust `pre-install` to work around PowerShell 5.x issue

### DIFF
--- a/bucket/codex.json
+++ b/bucket/codex.json
@@ -13,7 +13,7 @@
             "hash": "cd879b170ba827c59a44a530a09fae0d133f146c40dc179c6b52c5455b52c04f"
         }
     },
-    "pre_install": "Rename-Item \"$dir\\codex-*.exe\" \"$dir\\codex.exe\"",
+    "pre_install": "Get-Item \"$dir\\codex-*.exe\" | Rename-Item -NewName \"$dir\\codex.exe\"",
     "bin": [
         [
             "codex.exe",


### PR DESCRIPTION
This fixes a similar issue to this one (w.r.t. powershell complaining about `Rename-Item`): https://github.com/ScoopInstaller/Main/issues/6964

I followed the same structure as this commit: https://github.com/FDUZS/Main/commit/50e19d8e5d2bfc0da99ac49740e7bb8b5ed85a47

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
