### PR TITLE
acli: Add version 1.3.6

### DIFF
--- a/bucket/acli.json
+++ b/bucket/acli.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.12.0",
+    "version": "1.3.6",
     "description": "Atlassian CLI - command-line interface for Jira/Confluence/Bitbucket",
     "homepage": "https://developer.atlassian.com/cloud/acli/",
     "license": "Proprietary",

--- a/bucket/acli.json
+++ b/bucket/acli.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://acli.atlassian.com/windows/latest/acli_windows_amd64/acli.exe",
-            "hash": "sha256:5D5AFB915E4376E93CBBC616943D54F8C13246362EBC6BF9A8450562D66EA583"
+            "hash": "5D5AFB915E4376E93CBBC616943D54F8C13246362EBC6BF9A8450562D66EA583"
         }
     },
     "bin": "acli.exe",

--- a/bucket/acli.json
+++ b/bucket/acli.json
@@ -1,0 +1,24 @@
+{
+    "version": "2.12.0",
+    "description": "Atlassian CLI - command-line interface for Jira/Confluence/Bitbucket",
+    "homepage": "https://developer.atlassian.com/cloud/acli/",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "url": "https://acli.atlassian.com/windows/latest/acli_windows_amd64/acli.exe",
+            "hash": "sha256:5D5AFB915E4376E93CBBC616943D54F8C13246362EBC6BF9A8450562D66EA583"
+        }
+    },
+    "bin": "acli.exe",
+    "checkver": {
+        "url": "https://acli.atlassian.com/windows/latest/",
+        "regex": "acli_windows_amd64/acli\\.exe[\\s\\S]*?(\\d+\\.\\d+\\.\\d+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://acli.atlassian.com/windows/latest/acli_windows_amd64/acli.exe"
+            }
+        }
+    }
+}

--- a/bucket/acli.json
+++ b/bucket/acli.json
@@ -11,8 +11,8 @@
     },
     "bin": "acli.exe",
     "checkver": {
-        "url": "https://acli.atlassian.com/windows/latest/",
-        "regex": "acli_windows_amd64/acli\\.exe[\\s\\S]*?(\\d+\\.\\d+\\.\\d+)"
+        "url": "https://raw.githubusercontent.com/atlassian/homebrew-acli/main/Formula/acli.rb",
+        "regex": "version \"([\\d.]+)-stable\""
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Adds manifest for the official Atlassian CLI (acli) - a command-line interface for Jira, Confluence, and Bitbucket Cloud.

**Manifest details:**
- Downloads from official Atlassian distribution URL
- Includes `checkver` to detect new versions
- Includes `autoupdate` for automated updates
- Hash will be computed automatically on download (no hash file provided by vendor)
- Tested and working on Windows 11

**Website:** https://developer.atlassian.com/cloud/acli/

**Testing:**
```powershell
scoop install acli
acli --version  # acli version 1.3.6-stable
acli --help
```

Closes #8272