### PR TITLE
winmemorycleaner: Add version 3.0.4

### DIFF
--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -12,12 +12,12 @@
   ],
   "architecture": {
     "64bit": {
-      "hash": "b276eaa5685a6b35fa927a86345637e0cf9b336330869afebf6435a809806bf6",
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.4/WinMemoryCleaner.exe"
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.4/WinMemoryCleaner.exe",
+      "hash": "174798887f35005a096535ba720633272e146fdcd765e652f86a44c3df6bc606"
     },
     "32bit": {
-      "hash": "b276eaa5685a6b35fa927a86345637e0cf9b336330869afebf6435a809806bf6",
-      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.4/WinMemoryCleaner.exe"
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.4/WinMemoryCleaner.exe",
+      "hash": "174798887f35005a096535ba720633272e146fdcd765e652f86a44c3df6bc606"
     }
   },
   "bin": "WinMemoryCleaner.exe",


### PR DESCRIPTION
Adds the initial Scoop manifest for WinMemoryCleaner 3.0.4.

Portable RAM cleaner using native Windows APIs to release memory.

Closes #7368

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
