### PR TITLE
winmemorycleaner: Add version 3.0.5

### DIFF
--- a/bucket/winmemorycleaner.json
+++ b/bucket/winmemorycleaner.json
@@ -1,0 +1,41 @@
+{
+  "version": "3.0.5",
+  "description": "Portable RAM cleaner using native Windows APIs to release memory.",
+  "homepage": "https://github.com/IgorMundstein/WinMemoryCleaner",
+  "license": {
+    "url": "https://github.com/IgorMundstein/WinMemoryCleaner/blob/main/LICENSE",
+    "identifier": "GPL-3.0-or-later"
+  },
+  "notes": [
+    "Requires administrator privileges (UAC prompt).",
+    "Requires .NET Framework 4.x runtime."
+  ],
+  "architecture": {
+    "64bit": {
+      "hash": "75939c777b5c55685607039dfeda45ba7517674a1e3e77b71b5e524aea5ef96b",
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.5/WinMemoryCleaner.exe"
+    },
+    "32bit": {
+      "hash": "75939c777b5c55685607039dfeda45ba7517674a1e3e77b71b5e524aea5ef96b",
+      "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/3.0.5/WinMemoryCleaner.exe"
+    }
+  },
+  "bin": "WinMemoryCleaner.exe",
+  "shortcuts": [
+    [
+      "WinMemoryCleaner.exe",
+      "WinMemoryCleaner"
+    ]
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      },
+      "32bit": {
+        "url": "https://github.com/IgorMundstein/WinMemoryCleaner/releases/download/$version/WinMemoryCleaner.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the initial Scoop manifest for WinMemoryCleaner 3.0.5.

Portable RAM cleaner using native Windows APIs to release memory.

Closes #7368

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
