### PR TITLE
q-dns: fix auto-update information

### DIFF
--- a/bucket/q-dns.json
+++ b/bucket/q-dns.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.19.10",
+    "version": "0.19.11",
     "description": "A tiny command line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH.",
     "homepage": "https://github.com/natesales/q",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/natesales/q/releases/download/v0.19.10/q_0.19.10_windows_amd64.tar.gz",
-            "hash": "c9df738d44d31fc792f66bb26df6da1a25484b9d0432924bf7b0585d42d40145"
+            "url": "https://github.com/natesales/q/releases/download/v0.19.11/q_0.19.11_windows_amd64.zip",
+            "hash": "2e9547e982438ab552ecbb0aa80165dd0ac7f1d7a1deecec2479d2eb0715f9ae"
         },
         "arm64": {
-            "url": "https://github.com/natesales/q/releases/download/v0.19.10/q_0.19.10_windows_arm64.tar.gz",
-            "hash": "0528f5ba586039926d03ce4828c191acc7ce7648a1649e668216c9f384a0361c"
+            "url": "https://github.com/natesales/q/releases/download/v0.19.11/q_0.19.11_windows_arm64.zip",
+            "hash": "9498b008daf22c63dfd3597cdb84c2c73279d9ceb196cff59e7332ee02e56508"
         }
     },
     "bin": "q.exe",
@@ -18,14 +18,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/natesales/q/releases/download/v$version/q_$version_windows_amd64.tar.gz"
+                "url": "https://github.com/natesales/q/releases/download/v$version/q_$version_windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/natesales/q/releases/download/v$version/q_$version_windows_arm64.tar.gz"
+                "url": "https://github.com/natesales/q/releases/download/v$version/q_$version_windows_arm64.zip"
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.txt"
+            "url": "$baseurl/q_$version_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Release [v0.19.11](https://github.com/natesales/q/releases/tag/v0.19.11) changed the Windows package to a ZIP.
This also fixes the hash URL, which was somehow broken.