### PR TITLE
y-cruncher@0.8.7.9547b: Fix extraction, switch to GitHub releases

### DIFF
--- a/bucket/y-cruncher.json
+++ b/bucket/y-cruncher.json
@@ -6,13 +6,17 @@
         "identifier": "Freeware",
         "url": "https://www.numberworld.org/y-cruncher/license.html"
     },
-    "url": "https://www.numberworld.org/y-cruncher/y-cruncher%20v0.8.7.9547b.zip",
+    "url": "https://github.com/Mysticial/y-cruncher/releases/download/v0.8.7.9547b/y-cruncher.v0.8.7.9547b.zip",
     "hash": "3be696c1cc44907f2ea73aac35de4a5d45048255308f34ed4410a743163a4f87",
-    "extract_dir": "y-cruncher v0.8.7.9547",
+    "extract_dir": "y-cruncher v0.8.7.9547b",
     "bin": "y-cruncher.exe",
-    "checkver": "y-cruncher v((?<ver>[\\d.]+)(?<rel>\\w{0,1}))\\.zip",
+    "checkver": {
+        "url": "https://api.github.com/repositories/108079709/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "\\Av(\\S+)\\Z"
+    },
     "autoupdate": {
-        "url": "https://www.numberworld.org/y-cruncher/y-cruncher%20v$version.zip",
-        "extract_dir": "y-cruncher v$matchVer"
+        "url": "https://github.com/Mysticial/y-cruncher/releases/download/v$version/y-cruncher.v$version.zip",
+        "extract_dir": "y-cruncher v$version"
     }
 }


### PR DESCRIPTION
I also moved `checkver`/`autoupdate` to GitHub.
```
Installing 'y-cruncher' (0.8.7.9547b) [64bit] from 'main' bucket
Loading y-cruncher%20v0.8.7.9547b.zip from cache.
Extracting y-cruncher%20v0.8.7.9547b.zip ... DEBUG[1764570792] $stdoutTask.Result = -------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : Monday, December 1, 2025 1:33:12 AM
   Source : C:\Users\brian\scoop\apps\y-cruncher\0.8.7.9547b\y-cruncher v0.8.7.9547\
     Dest : C:\Users\brian\scoop\apps\y-cruncher\0.8.7.9547b\

    Files : *.*
	
  Options : *.* /S /E /DCOPY:DA /COPY:DAT /MOVE /R:1000000 /W:30

------------------------------------------------------------------------------

2025/12/01 01:33:12 ERROR 2 (0x00000002) Accessing Source Directory ~\scoop\apps\y-cruncher\0.8.7.9547b\y-cruncher v0.8.7.9547\
The system cannot find the file specified. -> ~\scoop\apps\scoop\current\lib\core.ps1:821:9
Exception: ~\scoop\apps\scoop\current\lib\core.ps1:822
Line |
 822 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'y-cruncher v0.8.7.9547'! (error 16)
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->