### PR TITLE
ddev@1.24.10: Expose bundled utilities and add HTTPS setup notes

### DIFF
--- a/bucket/ddev.json
+++ b/bucket/ddev.json
@@ -19,7 +19,6 @@
     },
     "bin": [
         "ddev.exe",
-        "mkcert.exe",
         "ddev-hostname.exe"
     ],
     "checkver": {


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

### Fixed

```text
$ ddev start
Starting laravel-12...
The hostname laravel-12.ddev.site is not currently resolvable, trying to add it to the hosts file
Unable to run ddev-hostname.exe, please check it; err=exec: "ddev-hostname.exe": executable file not found in %PATH%; output=
Failed to start laravel-12: Binary not found: ddev-hostname is not installed, please install it, see https://docs.ddev.com/en/stable/users/usage/commands/#hostname
```


### Summary

This PR updates the `ddev` Scoop manifest to better reflect the contents of the official Windows release and improve the user onboarding experience.

### Changes

* Expose additional bundled executables:

  * `mkcert.exe`
  * `ddev-hostname.exe`
* Add post-installation notes to guide users through HTTPS setup using `mkcert`.

### Rationale

The official Windows release archive already includes `mkcert.exe` and `ddev-hostname.exe`, but they were not previously exposed via the `bin` section of the Scoop manifest. As a result, users could not directly invoke these utilities after installation.

Additionally, HTTPS support in DDEV on Windows requires installing a custom root certificate. Adding explicit notes helps prevent confusion and reduces setup friction for new users.

### User Impact

After this change:

* Users can directly run `mkcert` and `ddev-hostname` from the command line.
* Users receive clear guidance on enabling HTTPS by installing the local root certificate.
