### PR TITLE
winpython: fix checkver regex

### DIFF
--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -1,14 +1,14 @@
 {
-    "version": "3.12.10.1",
+    "version": "3.13.7.0",
     "description": "Free, open-source and portable Python distribution for Windows",
     "homepage": "https://winpython.github.io",
     "license": "MIT",
     "notes": "For 32bit, please install 'versions/winpython3741'",
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/winpython/WinPython_3.12/3.12.10.1/Winpython64-3.12.10.1slim.7z",
-            "hash": "a320f799843712b0c3aa5bcb0fb472cd36dc74615a1436c976c4bf6e8a4ac29f",
-            "extract_dir": "WPy64-312101"
+            "url": "https://sourceforge.net/projects/winpython/WinPython_3.13/3.13.7.0/WinPython64-3.13.7.0slim.7z",
+            "hash": "5adc17d32782637ed7c2aea62fcd43695dfc0e404022a749ec66511807b34a9c",
+            "extract_dir": "WPy64-31370"
         }
     },
     "bin": [


### PR DESCRIPTION
WinPython adjusted the case of the "P" in the binary name, so Scoop couldn't find the new version anymore. This fixes that.

```powershell
PS ~\scoop\apps\scoop\current> .\bin\checkver.ps1 -Dir ~\Desktop -App winpython -u
winpython: 3.13.7.0 (scoop version is 3.12.10.1) autoupdate available
Autoupdating winpython
Searching hash for Winpython64-3.13.7.0slim.7z in https://winpython.github.io/md5_sha1.txt
Found: 5adc17d32782637ed7c2aea62fcd43695dfc0e404022a749ec66511807b34a9c using Extract Mode
Writing updated winpython manifest
```

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #7442

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
