### PR TITLE
zeebe: Update to version 8.8.8, fix checkver & autoupdate

### DIFF
--- a/bucket/zeebe.json
+++ b/bucket/zeebe.json
@@ -39,10 +39,6 @@
                 "url": "https://github.com/camunda/camunda/releases/download/$version/camunda-zeebe-$version.zip"
             }
         },
-        "hash": {
-            "url": "https://api.github.com/repos/camunda/camunda/releases/tags/$version",
-            "regex": "sha256:([0-9a-z]+)[^}]+$url"
-        },
         "extract_dir": "camunda-zeebe-$version"
     }
 }


### PR DESCRIPTION
### Changes
✅ Fixes the checkver by switching to the new repository

> Since Camunda 8.7 (April 2025), this repository is used only for the release notes of Camunda <= 8.5, for Camunda >= 8.6 please check [camunda/camunda](https://github.com/camunda/camunda) repository. [(source)](https://github.com/camunda/camunda-platform)

✅ Fixes autoupdate hash extraction to api with SHA256
✅ Update to version 8.8.8
⚠️ Removes `zbctl.exe`from shim, because it is no longer present in this release


### Process
↩️ Relates: https://github.com/ScoopInstaller/Main/issues/7394
✅ Verified there are no other open issues for this application in scoop
✅ Verified there are no other open pull requests for this application
✅ Use conventional PR title
✅ I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
✅ Follows general order of fields and ran `.\bin\formatjson.ps1`
✅ Tab width 4 spaces

### Checkver OK
```
PS C:\Users\WDAGUtilityAccount\scoop\buckets\main> .\bin\checkver.ps1 zeebe
zeebe: 8.8.8
```

### Autoupdate OK:
```
PS C:\Users\WDAGUtilityAccount\scoop\buckets\main> .\bin\checkver.ps1 zeebe -f
zeebe: 8.8.8 (scoop version is 8.8.8)
Forcing autoupdate!
Autoupdating zeebe
DEBUG[1766439663.64454] [$updatedProperties] = [hash extract_dir url] -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1766439663.64454] $substitutions (hashtable) -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1766439663.64454] $substitutions.$buildVersion                                                                                                                                                           
DEBUG[1766439663.64454] $substitutions.$match1                        8.8.8                                                                                                                                    
DEBUG[1766439663.64454] $substitutions.$preReleaseVersion             8.8.8                                                                                                                                    
DEBUG[1766439663.64454] $substitutions.$version                       8.8.8                                                                                                                                    
DEBUG[1766439663.64454] $substitutions.$patchVersion                  8                                                                                                                                        
DEBUG[1766439663.64454] $substitutions.$urlNoExt                      https://github.com/camunda/camunda/releases/download/8.8.8/camunda-zeebe-8.8.8                                                           
DEBUG[1766439663.64454] $substitutions.$dotVersion                    8.8.8                                                                                                                                    
DEBUG[1766439663.64454] $substitutions.$cleanVersion                  888                                                                                                                                      
DEBUG[1766439663.64454] $substitutions.$underscoreVersion             8_8_8                                                                                                                                    
DEBUG[1766439663.64454] $substitutions.$minorVersion                  8                                                                                                                                        
DEBUG[1766439663.64454] $substitutions.$url                           https://github.com/camunda/camunda/releases/download/8.8.8/camunda-zeebe-8.8.8.zip                                                       
DEBUG[1766439663.64454] $substitutions.$majorVersion                  8                                                                                                                                        
DEBUG[1766439663.64454] $substitutions.$matchTail                                                                                                                                                              
DEBUG[1766439663.64454] $substitutions.$basenameNoExt                 camunda-zeebe-8.8.8                                                                                                                      
DEBUG[1766439663.64454] $substitutions.$basename                      camunda-zeebe-8.8.8.zip                                                                                                                  
DEBUG[1766439663.64454] $substitutions.$dashVersion                   8-8-8                                                                                                                                    
DEBUG[1766439663.64454] $substitutions.$baseurl                       https://github.com/camunda/camunda/releases/download/8.8.8                                                                               
DEBUG[1766439663.64454] $substitutions.$matchHead                     8.8.8                                                                                                                                    
DEBUG[1766439663.67621] $hashfile_url = https://api.github.com/repos/camunda/camunda/releases/tags/8.8.8 -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for camunda-zeebe-8.8.8.zip in https://api.github.com/repos/camunda/camunda/releases/tags/8.8.8
DEBUG[1766439673.28555] $regex = sha256:([0-9a-z]+)[^}]+https://github\.com/camunda/camunda/releases/download/8\.8\.8/camunda-zeebe-8\.8\.8\.zip -> C:\Users\WDAGUtilityAccount\scoop\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: b6f5a9fe911015eb31f07f1866f093c1fbe5e4c6e80233f51bc13dfc3e42b077 using Extract Mode
Writing updated zeebe manifes
```

### Virustotal Check
https://www.virustotal.com/gui/url/2a543504458c573a209962c50f91e011f86502422df56242f92b7280a2d0a127
✅ Score: 0/98
✅ SHA256 matches

### Tests
✅ update tested from previous 8.5.0 to this 8.8.8
✅ uninstall succeeded
✅ application seems to run fine in a minimal test

### Other Observations
none
