### PR TITLE
uutils-coreutils@0.5.0: Add suggest, prune unavailable shims

### DIFF
--- a/bucket/uutils-coreutils.json
+++ b/bucket/uutils-coreutils.json
@@ -1,8 +1,14 @@
 {
     "version": "0.5.0",
-    "description": "Rust implementation of GNU coreutils (binaries compiled with MSVC)",
+    "description": "A cross-platform Rust reimplementation of GNU coreutils (binaries compiled with MSVC), with some options or behaviors potentially differing from GNU coreutils.",
     "homepage": "https://uutils.github.io/coreutils/",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/uutils/coreutils/blob/HEAD/LICENSE"
+    },
+    "suggest": {
+        "Microsoft Visual C++ 2015-2022 Redistributable": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/uutils/coreutils/releases/download/0.5.0/coreutils-0.5.0-x86_64-pc-windows-msvc.zip",
@@ -24,10 +30,6 @@
         "coreutils.exe",
         [
             "coreutils.exe",
-            "uutils"
-        ],
-        [
-            "coreutils.exe",
             "arch",
             "arch"
         ],
@@ -35,11 +37,6 @@
             "coreutils.exe",
             "b2sum",
             "b2sum"
-        ],
-        [
-            "coreutils.exe",
-            "b3sum",
-            "b3sum"
         ],
         [
             "coreutils.exe",
@@ -318,48 +315,13 @@
         ],
         [
             "coreutils.exe",
-            "sha3-224sum",
-            "sha3-224sum"
-        ],
-        [
-            "coreutils.exe",
-            "sha3-256sum",
-            "sha3-256sum"
-        ],
-        [
-            "coreutils.exe",
-            "sha3-384sum",
-            "sha3-384sum"
-        ],
-        [
-            "coreutils.exe",
-            "sha3-512sum",
-            "sha3-512sum"
-        ],
-        [
-            "coreutils.exe",
             "sha384sum",
             "sha384sum"
         ],
         [
             "coreutils.exe",
-            "sha3sum",
-            "sha3sum"
-        ],
-        [
-            "coreutils.exe",
             "sha512sum",
             "sha512sum"
-        ],
-        [
-            "coreutils.exe",
-            "shake128sum",
-            "shake128sum"
-        ],
-        [
-            "coreutils.exe",
-            "shake256sum",
-            "shake256sum"
         ],
         [
             "coreutils.exe",


### PR DESCRIPTION
### Summary

Improves the `uutils-coreutils` manifest by refining metadata fields and removing aliases for commands that are not currently included in the provided binaries.

### Changes

- Update the description to reflect cross-platform nature and possible behavioral differences from GNU coreutils  
- Convert the `license` field into object form including SPDX identifier and upstream license URL  
- Add `suggest` entry for **Microsoft Visual C++ 2015–2022 Redistributable** (`extras/vcredist2022`)  
- Remove aliases/shims for commands not present in distributed binaries (such as `b3sum`, `sha3-*sum`, `shake*sum`) 

### Notes

- The original purpose of the `uutils` alias was to maintain compatibility with the previous naming convention. However, the [official documentation](https://uutils.github.io/coreutils/docs/multicall.html) now uses the name `coreutils`, and the project team has also released separate `findutils` and `diffutils` projects. To avoid potential conflicts if these projects are added to the Main bucket in the future, I believe this alias should be removed.
- The removal of additional aliases is due to the fact that the current Windows MSVC binary releases no longer ship the corresponding applets. 
  - See: https://github.com/uutils/coreutils/pull/9153

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\buckets\Unofficial][ master ≡]
└─> scoop install Unofficial/uutils-coreutils
Installing 'uutils-coreutils' (0.5.0) [64bit] from 'Unofficial' bucket
Loading coreutils-0.5.0-x86_64-pc-windows-msvc.zip from cache.
Checking hash of coreutils-0.5.0-x86_64-pc-windows-msvc.zip ... ok.
Extracting coreutils-0.5.0-x86_64-pc-windows-msvc.zip ... done.
Linking D:\Software\Scoop\Local\apps\uutils-coreutils\current => D:\Software\Scoop\Local\apps\uutils-coreutils\0.5.0
Creating shim for 'coreutils'.
Creating shim for 'arch'.
Creating shim for 'b2sum'.
Creating shim for 'base32'.
Creating shim for 'base64'.
Creating shim for 'basename'.
Creating shim for 'basenc'.
Creating shim for 'cat'.
Creating shim for 'cksum'.
Creating shim for 'comm'.
Creating shim for 'cp'.
Creating shim for 'csplit'.
Creating shim for 'cut'.
Creating shim for 'date'.
Creating shim for 'dd'.
Creating shim for 'df'.
Creating shim for 'dir'.
Creating shim for 'dircolors'.
Creating shim for 'dirname'.
Creating shim for 'du'.
Creating shim for 'echo'.
Creating shim for 'env'.
Creating shim for 'expand'.
Creating shim for 'expr'.
Creating shim for 'factor'.
Creating shim for 'false'.
Creating shim for 'fmt'.
Creating shim for 'fold'.
Creating shim for 'hashsum'.
Creating shim for 'head'.
Creating shim for 'hostname'.
Creating shim for 'join'.
Creating shim for 'link'.
Creating shim for 'ln'.
Creating shim for 'ls'.
Creating shim for 'md5sum'.
Creating shim for 'mkdir'.
Creating shim for 'mktemp'.
Creating shim for 'more'.
Creating shim for 'mv'.
Creating shim for 'nl'.
Creating shim for 'nproc'.
Creating shim for 'numfmt'.
Creating shim for 'od'.
Creating shim for 'paste'.
Creating shim for 'pr'.
Creating shim for 'printenv'.
Creating shim for 'printf'.
Creating shim for 'ptx'.
Creating shim for 'pwd'.
Creating shim for 'readlink'.
Creating shim for 'realpath'.
Creating shim for 'rm'.
Creating shim for 'rmdir'.
Creating shim for 'seq'.
Creating shim for 'sha1sum'.
Creating shim for 'sha224sum'.
Creating shim for 'sha256sum'.
Creating shim for 'sha384sum'.
Creating shim for 'sha512sum'.
Creating shim for 'shred'.
Creating shim for 'shuf'.
Creating shim for 'sleep'.
Creating shim for 'sort'.
Creating shim for 'split'.
Creating shim for 'sum'.
Creating shim for 'sync'.
Creating shim for 'tac'.
Creating shim for 'tail'.
Creating shim for 'tee'.
Creating shim for 'test'.
Creating shim for 'touch'.
Creating shim for 'tr'.
Creating shim for 'true'.
Creating shim for 'truncate'.
Creating shim for 'tsort'.
Creating shim for 'uname'.
Creating shim for 'unexpand'.
Creating shim for 'uniq'.
Creating shim for 'unlink'.
Creating shim for 'vdir'.
Creating shim for 'wc'.
Creating shim for 'whoami'.
Creating shim for 'yes'.
'uutils-coreutils' (0.5.0) was installed successfully!
'uutils-coreutils' suggests installing 'extras/vcredist2022'.
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)