### PR TITLE
fresh: Add version 0.1.99

### DIFF
--- a/bucket/fresh.json
+++ b/bucket/fresh.json
@@ -1,16 +1,12 @@
 {
-    "version": "0.1.98",
-    "description": "Easy, powerful and fast text editor for your terminal",
-    "homepage": "https://github.com/sinelaw/fresh",
-    "license": "GPL-2.0",
+    "version": "0.1.99",
+    "description": "Easy, powerful and fast text editor for your terminal.",
+    "homepage": "https://getfresh.dev",
+    "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/sinelaw/fresh/releases/download/v0.1.98/fresh-editor-x86_64-pc-windows-msvc.zip",
-            "hash": "f7849fd18991ea6ecd3bcf1531729a2a501a6d251a8b6d22da1ad10eda1fb34b",
-            "post_install": [
-                "Remove-Item \"$dir\\CHANGELOG.md\", \"$dir\\README.md\" -Force",
-                "Remove-Item \"$dir\\plugins\\examples\" -Recurse -Force"
-            ]
+            "url": "https://github.com/sinelaw/fresh/releases/download/v0.1.99/fresh-editor-x86_64-pc-windows-msvc.zip",
+            "hash": "1c4751a699e6045aa650dd2dec69f4db93439a7978b9b7c295ccc3153afb01ee"
         }
     },
     "bin": "fresh.exe",
@@ -22,6 +18,9 @@
             "64bit": {
                 "url": "https://github.com/sinelaw/fresh/releases/download/v$version/fresh-editor-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
This PR adds Fresh Terminal editor. It has ~2.9K stars on github and claims to be easy to use, powerful and fast.

- [x] Use conventional PR title: `fresh: Add version 0.1.98`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<img width="1355" height="748" alt="fresh" src="https://github.com/user-attachments/assets/edc788e3-1c5e-4564-82ae-84f25f796f2d" />
