### PR TITLE
tlrc: Persist data

### DIFF
--- a/bucket/tlrc.json
+++ b/bucket/tlrc.json
@@ -1,16 +1,48 @@
 {
     "version": "1.12.0",
-    "description": "a tldr client written in rust",
+    "description": "A tldr client written in rust.",
     "homepage": "https://github.com/tldr-pages/tlrc",
-    "license": "MIT",
-    "notes": "pages not bundled with app, they will be downloaded the first time you use tldr",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/tldr-pages/tlrc/blob/HEAD/LICENSE"
+    },
+    "notes": "Pages are not bundled with the application and will be automatically downloaded on first use.",
+    "suggest": {
+        "Microsoft Visual C++ 2015-2022 Redistributable": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/tldr-pages/tlrc/releases/download/v1.12.0/tlrc-v1.12.0-x86_64-pc-windows-msvc.zip",
             "hash": "2de760afeba2d9cf1cc999714942263098d93c4e56fd4260f7c64e5a50956b7e"
         }
     },
+    "pre_install": [
+        "$original_cfg_dir = $env:TLRC_CONFIG, \"$env:APPDATA\\tlrc\\config.toml\" | Select-Object -First 1",
+        "$is_different = $original_cfg_dir -ne \"$persist_dir\\config.toml\"",
+        "if ($is_different -and (Test-Path -Path $original_cfg_dir -PathType Leaf)) {",
+        "    Copy-Item -Path $original_cfg_dir -Destination \"$dir\\config.toml\"",
+        "}",
+        "$remove_list = $env:APPDATA, $env:LOCALAPPDATA | ForEach-Object { \"$_\\$app\" }",
+        "$remove_list + @($original_cfg_dir) * $is_different | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue"
+    ],
+    "installer": {
+        "script": [
+            "$cfg_dir = \"$dir\\config.toml\"",
+            "if (Test-Path -Path \"$persist_dir\\config.toml\" -PathType Leaf) { return }",
+            "if (-not (Test-Path -Path $cfg_dir -PathType Leaf)) {",
+            "    $output_options = @{ NoNewWindow = $true; RedirectStandardOutput = $cfg_dir }",
+            "    Start-Process -FilePath \"$dir\\tldr.exe\" -ArgumentList '--gen-config' @output_options -Wait",
+            "}",
+            "$cfg = Get-Content -Path $cfg_dir -Encoding ascii",
+            "$cfg = $cfg -replace '(?<=dir = '').+(?='')', \"$persist_dir\\.cache\"",
+            "$cfg -join \"`n\" | Set-Content -Path $cfg_dir -Encoding ascii"
+        ]
+    },
+    "env_set": {
+        "TLRC_CONFIG": "$persist_dir\\config.toml"
+    },
     "bin": "tldr.exe",
+    "persist": "config.toml",
     "checkver": "github",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
### Summary

Improves configuration persistence behavior and enhances manifest metadata and install scripts to provide a more predictable user experience.

### Related issues or pull requests

- Relates to configuration persistence expectations of Scoop users

### Changes

- Refine `description` to a formal form
- Replace simple `license` string with structured `license` object including `identifier` and `url`
- Add `suggest` field for MSVC runtime dependency hint
- Update `notes` to a formal tone indicating automatic page download behavior
- Persist data

### Notes

- Because the `--config` parameter cannot be specified multiple times, this PR adopts the use of an environment variable to avoid conflicts in cases where users may have previously defined shell aliases for `tldr`.

  ```powershell
  ┏[ ~]
  └─> tldr --config ".\config.toml" --config '..\config.toml' tar
  error: the argument '--config <FILE>' cannot be used multiple times
  
  Usage: tldr [OPTIONS] [PAGE]...
  
  For more information, try '--help'.
  ```
- In addition, since `--config` has the [highest precedence](https://tldr.sh/tlrc/#options:~:text=%2D%2Dconfig%20%3CFILE%3E,for%20your%20system\)), the data-migration scripts introduced in this PR do not affect users who explicitly invoke `tldr` with the `--config` parameter.
 

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ ~]
└─> tldr --info
Cache: $env:LOCALAPPDATA\tlrc (last update: 4min, 58s ago)
Automatic update in 13d, 23h
Installed languages:
en    : 6744
total : 6744 pages

┏[ ~]
└─> tldr --config-path
$env:APPDATA\tlrc\config.toml

# Reinstall after uninstalling
┏[ ~]
└─> scoop install Unofficial/tlrc -g
Installing 'tlrc' (1.12.0) [64bit] from 'Unofficial' bucket
Loading tlrc-v1.12.0-x86_64-pc-windows-msvc.zip from cache.
Checking hash of tlrc-v1.12.0-x86_64-pc-windows-msvc.zip ... ok.
Extracting tlrc-v1.12.0-x86_64-pc-windows-msvc.zip ... done.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Global\apps\tlrc\current => D:\Software\Scoop\Global\apps\tlrc\1.12.0
Creating shim for 'tldr'.
Persisting config.toml
'tlrc' (1.12.0) was installed successfully!
Notes
-----
Pages are not bundled with the application and will be automatically downloaded on first use.
'tlrc' suggests installing 'extras/vcredist2022'.

┏[ ~]
└─> tldr --info
info: cache is empty, downloading...
info: downloading 'tldr.sha256sums'... 3.35 KiB
info: downloading 'tldr-pages.en.zip'... 2.86 MiB
info: validating sha256sums... OK
info: extracting 'pages.en'... 6744 pages, 6744 new
info: cache update successful (total: 6744 pages, 6744 new).
Cache: D:\Software\Scoop\Global\persist\tlrc\.cache (last update: 2s ago)
Automatic update in 13d, 23h
Installed languages:
en    : 6744
total : 6744 pages

┏[ ~]
└─> tldr --config-path
D:\Software\Scoop\Global\persist\tlrc\config.toml
```

</details>


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)