### PR TITLE
ruby: Update to version 4.0.0-1 and remove "32bit"

### DIFF
--- a/bucket/ruby.json
+++ b/bucket/ruby.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.8-1",
+    "version": "4.0.0-1",
     "description": "A dynamic programming language with a focus on simplicity and productivity.",
     "homepage": "https://rubyinstaller.org",
     "license": "BSD-3-Clause",
@@ -9,14 +9,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.8-1/rubyinstaller-3.4.8-1-x64.7z",
-            "hash": "d1c3ba83ae748c08e35e0b1d9939d45dbca7925e0a8bf84a42860bf19847e0d6",
-            "extract_dir": "rubyinstaller-3.4.8-1-x64"
+            "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-4.0.0-1/rubyinstaller-4.0.0-1-x64.7z",
+            "hash": "4ca3a8a725d204accc4919bf1103a10acee609b67bf2d6ec8ac692eb18dfb780",
+            "extract_dir": "rubyinstaller-4.0.0-1-x64"
         },
-        "32bit": {
-            "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.4.8-1/rubyinstaller-3.4.8-1-x86.7z",
-            "hash": "6635cd7a0a4be880ab781aef60dcbd8803e2d6e60455e62915f69f836b17f299",
-            "extract_dir": "rubyinstaller-3.4.8-1-x86"
+        "arm64": {
+            "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-4.0.0-1/rubyinstaller-4.0.0-1-arm.7z",
+            "hash": "32fd28e78174bcd3c66dbb843afa6ff295088bd4dbad3cdb4aa3bb1e5a2bd95f",
+            "extract_dir": "rubyinstaller-4.0.0-1-arm"
         }
     },
     "post_install": "gem install rake",
@@ -39,9 +39,9 @@
                 "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-$version/rubyinstaller-$version-x64.7z",
                 "extract_dir": "rubyinstaller-$version-x64"
             },
-            "32bit": {
-                "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-$version/rubyinstaller-$version-x86.7z",
-                "extract_dir": "rubyinstaller-$version-x86"
+            "arm64": {
+                "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-$version/rubyinstaller-$version-arm.7z",
+                "extract_dir": "rubyinstaller-$version-arm"
             }
         },
         "hash": {


### PR DESCRIPTION
RubyInstaller.org doesn't provide 32-bit binary now.

See: https://rubyinstaller.org/downloads/archives/

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
