### PR TITLE
modern7z: Update description & license, improve installer/uninstaller script logic

### DIFF
--- a/bucket/modern7z.json
+++ b/bucket/modern7z.json
@@ -1,36 +1,50 @@
 {
     "version": "1.9.2",
-    "description": "7-Zip plugin for the leading-edge compression methods; zstd, Brotli, LZ4, LZ5, Lizard, and Fast LZMA2.",
+    "description": "A plugin for 7-Zip that provides support for leading-edge compression methods—including Zstandard, Brotli, LZ4, LZ5, Lizard, and Fast LZMA2—while enhancing compatibility with modern single-file compression formats.",
     "homepage": "https://www.tc4shell.com/en/7zip/modern7z/",
-    "license": "Unknown",
-    "depends": "7zip",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.tc4shell.com/en/termsofuse/"
+    },
     "url": "https://www.tc4shell.com/binary/Modern7z.zip",
     "hash": "3cd202da38024c85512822a42da2897095334bedd910f34c3339c54b7c88f5f0",
     "architecture": {
         "64bit": {
-            "extract_dir": "64"
+            "pre_install": [
+                "Copy-Item -Path \"$dir\\64\\*\" -Destination $dir -Force -Recurse",
+                "'32', '64' | ForEach-Object { Remove-Item -Path \"$dir\\$_\" -Recurse -Force -ErrorAction SilentlyContinue }"
+            ]
         },
         "32bit": {
-            "extract_dir": "32"
+            "pre_install": [
+                "Copy-Item -Path \"$dir\\32\\*\" -Destination $dir -Force -Recurse",
+                "'32', '64' | ForEach-Object { Remove-Item -Path \"$dir\\$_\" -Recurse -Force -ErrorAction SilentlyContinue }"
+            ]
         }
     },
     "installer": {
         "script": [
-            "$7zcodecs = \"$(persistdir '7zip' $global)\\Codecs\"",
-            "if (-not (Test-Path \"$7zcodecs\")) {",
-            "  New-Item -Path \"$7zcodecs\" -ItemType Directory | Out-Null",
-            "  New-Item -Path \"$(versiondir '7zip' 'current')\\Codecs\" -Value \"$7zcodecs\" -ItemType Junction | Out-Null",
+            "$7z_path = Get-CommandPath -Command '7z.exe'",
+            "if ($null -eq $7z_path) { abort \"`nCould not locate '7z.exe' in system PATH. Abort installation.\" }",
+            "$codecs_dir = Join-Path -Path $(Split-Path -Path $7z_path -Parent) -ChildPath 'Codecs'",
+            "if (-not (Test-Path -Path $codecs_dir -PathType Container)) {",
+            "    New-Item -Path $codecs_dir -ItemType Directory -Force | Out-Null",
             "}",
-            "Copy-Item -Path \"$dir\\*\" -Destination \"$7zcodecs\" -Recurse -Force -ErrorAction SilentlyContinue"
+            "Copy-Item -Path \"$dir\\*\" -Destination $codecs_dir -Exclude '*.json', 'ReadMe.txt' -Force -Recurse"
         ]
     },
     "uninstaller": {
         "script": [
-            "$7zcodecs = \"$(persistdir '7zip' $global)\\Codecs\"",
-            "Get-ChildItem -Path \"$dir\" -Exclude *.json | ForEach-Object { Remove-Item -LiteralPath \"$7zcodecs\\$($_.Name)\" -Recurse -Force -ErrorAction SilentlyContinue }"
+            "$7z_path = Get-CommandPath -Command '7z.exe'",
+            "if ($null -ne $7z_path) {",
+            "    $codecs_dir = Join-Path -Path $(Split-Path -Path $7z_path -Parent) -ChildPath 'Codecs'",
+            "    Get-ChildItem -Path $dir -Exclude '*.json', 'ReadMe.txt' | ForEach-Object -Process {",
+            "        Remove-Item -Path \"$codecs_dir\\$($_.Name)\" -Recurse -Force -ErrorAction SilentlyContinue",
+            "    }",
+            "}"
         ]
     },
-    "checkver": "Plugin version: ([\\d.]+)",
+    "checkver": "Plugin version:\\s*([\\d.]+)",
     "autoupdate": {
         "url": "https://www.tc4shell.com/binary/Modern7z.zip"
     }


### PR DESCRIPTION
### Summary

Refines the `modern7z` manifest to improve metadata quality and significantly harden codec-installation logic by resolving the actual `7z.exe` location and managing the `Codecs` directory directly.

### Related issues or pull requests

- Relates to #7476
- Relates to https://github.com/ScoopInstaller/Extras/pull/16918

### Changes

- Rewrite `description` for precision and technical completeness
- Add structured `license` field with identifier and terms-of-use URL
- Rework architecture handling:
  - unify content layout by copying architecture-specific payload to root
  - remove residual `32`/`64` directories after deployment
- Reimplement `installer.script` to:
  - resolve `7z.exe` path dynamically
  - ensure existence of the `Codecs` directory
  - copy codec binaries safely while excluding manifest files
- Reimplement `uninstaller.script` to:
  - locate the active `7z.exe`
  - remove only plugin files installed by this manifest
- Remove deprecated junction-based logic and reliance on `persistdir`

### Notes

- Using the `persistdir` function is only applicable when 7-Zip is installed via Scoop and cannot accommodate scenarios where users enable `use_external_7zip`. Moreover, the installation location depends on the installation path of 7-Zip, meaning that the value of `$global` must be consistent at installation time.
- In addition, when using `scoop which 7z`, if `7z` cannot be found through the `Path` environment variable, it will unavoidably output: `'7z' not found, not a scoop shim, or a broken shim.`
- Neither of these approaches is optimal. This pull request resolves the above issues by using `Get-CommandPath -Command '7z.exe'`.

https://github.com/ScoopInstaller/Extras/blob/058e9652b53bb7d361620ed10cf0a26ed64c0ec7/bucket/asar7z.json#L8-L13

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ ~]
└─> 7z i

7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03

Libs:
 0 : 25.01 : D:\Software\Scoop\Local\apps\7zip\current\7z.dll

┏[ ~]
└─> scoop install Unofficial/modern7z
Installing 'modern7z' (1.9.2) [64bit] from 'Unofficial' bucket
Loading Modern7z.zip from cache.
Checking hash of Modern7z.zip ... ok.
Extracting Modern7z.zip ... done.
Running pre_install script...done.
Running installer script...done.
Linking D:\Software\Scoop\Local\apps\modern7z\current => D:\Software\Scoop\Local\apps\modern7z\1.9.2
'modern7z' (1.9.2) was installed successfully!

┏[ 01/03/2026 @ 8:14:37 PM CST][ Zertw ::  ASUS][ RAM: 10/15GB][ 95][ 0.613s]
┣[ ~]
└─> 7z i

7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03

Libs:
 0 : 25.01 : D:\Software\Scoop\Local\apps\7zip\current\7z.dll
 1 : 0.00 : D:\Software\Scoop\Local\apps\7zip\current\Codecs\Modern7z.64.dll

┏[ ~]
└─> scoop uninstall modern7z
Uninstalling 'modern7z' (1.9.2).
Running uninstaller script...done.
Unlinking D:\Software\Scoop\Local\apps\modern7z\current
'modern7z' was uninstalled.

┏[ ~]
└─> 7z i

7-Zip 25.01 (x64) : Copyright (c) 1999-2025 Igor Pavlov : 2025-08-03

Libs:
 0 : 25.01 : D:\Software\Scoop\Local\apps\7zip\current\7z.dll

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
