### PR TITLE
kubefwd: Update to version 1.25.8, fix autoupdate

### DIFF
--- a/bucket/kubefwd.json
+++ b/bucket/kubefwd.json
@@ -1,7 +1,7 @@
 {
     "version": "1.25.8",
     "description": "Bulk port forwarding Kubernetes services for local development",
-    "homepage": "https://kubefwd.com",
+    "homepage": "https://github.com/txn2/kubefwd",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Updates kubefwd from 1.22.5 to 1.25.8 and fixes the autoupdate URL pattern.

### Changes

- **Version**: 1.22.5 → 1.25.8
- **URL pattern fix**: Changed `$version` to `v$version` in autoupdate URLs

The previous manifest used URLs like `/download/1.22.5/` but kubefwd releases use the `v` prefix (`/download/v1.25.8/`). This was preventing autoupdate from working correctly.

### v1.25.8 Highlights

- Windows hosts path auto-detection: kubefwd now automatically uses the correct hosts file path on Windows (`C:\Windows\System32\drivers\etc\hosts`) instead of defaulting to `/etc/hosts`

---

## PR Template

Closes #7480

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
