### PR TITLE
multi-git-status: Add version 2.3

### DIFF
--- a/bucket/multi-git-status.json
+++ b/bucket/multi-git-status.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "notes": "Recommend adding bash.exe from the manifest main/git to the top of the system environment's PATH.",
     "url": "https://github.com/fboender/multi-git-status/archive/refs/tags/2.3.zip",
-    "hash": "B62B9DAC64002E767C6229F0C6F7A51231DBE4475DC765AB3D1E5073D87588D3",
+    "hash": "b62b9dac64002e767c6229f0c6f7a51231dbe4475dc765ab3d1e5073d87588d3",
     "extract_dir": "multi-git-status-2.3",
     "pre_install": [
         "New-Item -Path \"$dir\\mgitstatus.cmd\" -ItemType File -Force",


### PR DESCRIPTION
Closes #7499 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
