### PR TITLE
dotnet-core-uninstall@1.7.661902: Fix extract_dir

### DIFF
--- a/bucket/dotnet-core-uninstall.json
+++ b/bucket/dotnet-core-uninstall.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/dotnet/cli-lab/releases/download/1.7.661902/dotnet-core-uninstall.msi",
     "hash": "10f6bbacfaae062dcfcde8311cf8aaa3f8b6523e724e9bbc221c17adb59de65c",
-    "extract_dir": "dotnet-core-uninstall",
+    "extract_dir": "PFiles/dotnet-core-uninstall",
     "bin": "dotnet-core-uninstall.exe",
     "checkver": {
         "github": "https://github.com/dotnet/cli-lab"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The package couldn't be installed because `dotnet-core-uninstall.exe` is inside `PFiles\dotnet-core-uninstall` instead of `dotnet-core-uninstall`. This PR fixes the issue
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->
<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #7506
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
