### PR TITLE
git(-with-openssh): Restore `git` shim

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -40,6 +40,7 @@
     },
     "bin": [
         "bin\\sh.exe",
+        "bin\\git.exe",
         "git-bash.exe",
         "usr\\bin\\gpg.exe",
         "usr\\bin\\gpg-agent.exe",

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -40,6 +40,7 @@
     },
     "bin": [
         "bin\\sh.exe",
+        "bin\\git.exe",
         "git-bash.exe",
         "usr\\bin\\gpg.exe",
         "usr\\bin\\gpg-agent.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The recent update of the git.json and git-with-openssh.json remove the shim for git.exe which was previously there. This update returns it back an not only git-bash.exe should be exposed in the shims

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->
Relates to #7459
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
