### PR TITLE
atuin: Add version 18.11.0

### DIFF
--- a/bucket/atuin.json
+++ b/bucket/atuin.json
@@ -1,6 +1,6 @@
 {
     "version": "18.11.0",
-    "description": "✨ Magical shell history",
+    "description": "Shell history tool featuring advanced context-aware search, along with secure sync and backup.",
     "homepage": "https://atuin.sh",
     "license": "MIT",
     "architecture": {


### PR DESCRIPTION
https://atuin.sh  Closes #7558

Starting from this version, the popular shell history tool atuin provides pre-compiled desktop binaries.

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
