### PR TITLE
Lua@5.4.8-1: Remove troublesome environment variables

### DIFF
--- a/bucket/lua.json
+++ b/bucket/lua.json
@@ -24,10 +24,6 @@
         "bin\\lua.exe",
         "bin\\luac.exe"
     ],
-    "env_set": {
-        "LUA_EXE_PATH": "$dir\\bin",
-        "LUA_CPATH": "$dir\\bin"
-    },
     "checkver": {
         "url": "https://packages.msys2.org/api/search?query=lua&qtype=binpkg",
         "jsonpath": "$.results.exact.version"


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

I have been having issues with LUA_CPATH causing trouble, because it was being set to a wrong value, so I investigated why it even was added to the lua manifest here:

It was first added in #2931 and I can't find a reason why, the directories for it don't make any sense too, since LUA_PATH and LUA_CPATH (which replace `package.path` and `package.cpath` default values) must include the current directory (`.\?.lua` and `.\?.dll`) to be able to load modules via `require "my_module"`, which is the most common way to include files.

We can see those env vars didn't make sense because it caused issues in #3829, but the PR for it wasn't a proper fix, it just renamed LUA_PATH to a random environment path that isn't used anywhere (in the stack overflow page mentioned, the person that renamed it, was because they wanted to have an env var to the lua executable, not because it was used anywhere by any program), it kinda solved the issue though, because LUA_PATH isn't being set to wrong values anymore by scoop.


The proper solution is to just remove the LUA_PATH and LUA_CPATH so lua can use its default paths which work normally.