### PR TITLE
whisper-cpp@1.8.3: Update shims

### DIFF
--- a/bucket/whisper-cpp.json
+++ b/bucket/whisper-cpp.json
@@ -9,12 +9,14 @@
     ],
     "bin": [
         "whisper-bench.exe",
-        "whisper-command.exe",
         "whisper-cli.exe",
+        "whisper-command.exe",
+        "whisper-lsp.exe",
+        "whisper-quantize.exe",
         "whisper-server.exe",
         "whisper-stream.exe",
         "whisper-talk-llama.exe",
-        "quantize.exe"
+        "whisper-vad-speech-segments.exe"
     ],
     "architecture": {
         "64bit": {


### PR DESCRIPTION
The whisper project recently renamed the quantize binary to whisper-quantize. While we are updating binary names, I also created shims of all whisper-* binaries in the release.

Closes #7543 
Relates to #5039

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
