### PR TITLE
php(-nts): Update to version 8.5.2, fix checkver & autoupdate

### DIFF
--- a/bucket/php-nts.json
+++ b/bucket/php-nts.json
@@ -43,7 +43,7 @@
     ],
     "checkver": {
         "url": "https://www.php.net/releases/branches.php",
-        "jsonpath": "$..latest"
+        "jsonpath": "$[0].latest"
     },
     "autoupdate": {
         "architecture": {
@@ -55,7 +55,6 @@
             }
         },
         "hash": {
-            "mode": "json",
             "url": "https://www.php.net/backend/win-releases.json",
             "jsonpath": "$..[?(@.path == '$basename')].sha256"
         }

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -43,7 +43,7 @@
     ],
     "checkver": {
         "url": "https://www.php.net/releases/branches.php",
-        "jsonpath": "$..latest"
+        "jsonpath": "$[0].latest"
     },
     "autoupdate": {
         "architecture": {
@@ -55,7 +55,6 @@
             }
         },
         "hash": {
-            "mode": "json",
             "url": "https://www.php.net/backend/win-releases.json",
             "jsonpath": "$..[?(@.path == '$basename')].sha256"
         }


### PR DESCRIPTION
Migrate download source to `downloads.php.net` since `windows.php.net` is going to shut down.
See: https://news-web.php.net/php.windows/31542

> > On 20 January 2026 16:30:24 GMT, Michele Locati <michele@locati.it> wrote:
> >I used to download PHP binaries for Windows from the windows.php.net website.
> >
> >At the moment it seems that it's outdated: the most recent versions
> >can be found at downloads.php.net/~windows instead...
> >
> >For example, the latest 8.5 version is:
> >- 8.5.1 at https://windows.php.net/downloads/releases/
> >- 8.5.2 at https://downloads.php.net/~windows/releases/
> >
> >Which one should we use?
> >Is there any official info regarding the relationship between the two websites?
> >
> >Thanks,
> >Michele
> 
> The one to use is downloads.php.net/~windows, and windows.php.net as a separate site is going to
> disappear. 
> 
> cheers
> Derick 

Closes #7559

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
