### PR TITLE
speedtest-go: Add version 1.7.10

### DIFF
--- a/bucket/speedtest-go.json
+++ b/bucket/speedtest-go.json
@@ -18,9 +18,7 @@
         }
     },
     "bin": "speedtest-go.exe",
-    "checkver": {
-        "github": "https://github.com/showwin/speedtest-go"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Adds new manifest speedtest-go version 1.7.10

Closes: https://github.com/ScoopInstaller/Main/issues/7581

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
