### PR TITLE
git-xet: Add version 0.2.1

### DIFF
--- a/bucket/git-xet.json
+++ b/bucket/git-xet.json
@@ -20,8 +20,9 @@
     },
     "bin": "git-xet.exe",
     "checkver": {
-        "url": "https://github.com/huggingface/xet-core/raw/refs/heads/main/git_xet/windows_installer/Package.wxs",
-        "regex": "Version=\"([\\w.]+)\""
+        "url": "https://api.github.com/repos/huggingface/xet-core/releases?per_page=100",
+        "jsonpath": "$..tag_name",
+        "regex": "git-xet-v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
git-xet: Add version v0.2.0

- Can't use traditional Github checkver, because the repository contains releases for multiple different topics and no latest tag

Closes: https://github.com/ScoopInstaller/Main/issues/7516

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Xet protocol as a Git LFS custom transfer agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->