### PR TITLE
podman: add gvproxy.exe and win-sshproxy.exe to bin so Scoop creates shims

### DIFF
--- a/bucket/podman.json
+++ b/bucket/podman.json
@@ -9,7 +9,11 @@
             "hash": "2663b94183d36d21a3958e03580bc2dd174ffaa9ae6dc567d40429b7a5da17cc"
         }
     },
-    "bin": "podman.exe",
+    "bin": [
+        "gvproxy.exe",
+        "podman.exe",
+        "win-sshproxy.exe"
+    ],
     "pre_install": [
         "if (Get-Command -ErrorAction SilentlyContinue podman) {",
         "    if ((podman machine info --format '{{.Host.MachineState}}') -like '*ing') {",


### PR DESCRIPTION
Problem:
Podman on Windows expects helper binaries (gvproxy.exe, win-sshproxy.exe) to be
discoverable. Scoop only creates shims for executables listed in a manifest's `bin`
array; these helpers were not listed, causing Podman startup warnings and missing
API forwarding.

Change:
Add "gvproxy.exe" and "win-sshproxy.exe" to the podman manifest `bin` array so
Scoop will create shims in %USERPROFILE%\scoop\shims automatically.

Testing:
- After install/update, verify shims exist:
  Test-Path "$env:USERPROFILE\scoop\shims\win-sshproxy.exe"
  Test-Path "$env:USERPROFILE\scoop\shims\gvproxy.exe"
- Start/stop podman machine to confirm helper warnings are resolved.

Notes:
This is a non-breaking, Windows-specific improvement that prevents fragile PATH workarounds.