### PR TITLE
c3@0.7.9: Fix extract_dir

### DIFF
--- a/bucket/c3.json
+++ b/bucket/c3.json
@@ -17,7 +17,7 @@
             "hash": "c06cd75fdd0dd4adee39e91aeb11beaf04e44f4825f4ba6a4f63a77f51dfa7ac"
         }
     },
-    "extract_dir": "c3-windows-Release",
+    "extract_dir": "c3",
     "bin": "c3c.exe",
     "checkver": {
         "github": "https://github.com/c3lang/c3c"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

Change extract directory name from 'c3-windows-Release' to 'c3'

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
