### PR TITLE
uutils-coreutils(-lean)@0.6.0: Fix extract_dir

### DIFF
--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -34,15 +34,15 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-x86_64-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-x86_64-pc-windows-msvc"
+                "extract_dir": "coreutils-$version-x86_64-pc-windows-msvc"
             },
             "32bit": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-i686-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-i686-pc-windows-msvc"
+                "extract_dir": "coreutils-$version-i686-pc-windows-msvc"
             },
             "arm64": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-aarch64-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-aarch64-pc-windows-msvc"
+                "extract_dir": "coreutils-$version-aarch64-pc-windows-msvc"
             }
         }
     }

--- a/bucket/uutils-coreutils.json
+++ b/bucket/uutils-coreutils.json
@@ -451,15 +451,15 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-x86_64-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-x86_64-pc-windows-msvc"
+                "extract_dir": "coreutils-$version-x86_64-pc-windows-msvc"
             },
             "32bit": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-i686-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-i686-pc-windows-msvc"
+                "extract_dir": "coreutils-$version-i686-pc-windows-msvc"
             },
             "arm64": {
                 "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-aarch64-pc-windows-msvc.zip",
-                "extract_dir": "coreutils-aarch64-pc-windows-msvc"
+                "extract_dir": "coreutils-$version-aarch64-pc-windows-msvc"
             }
         }
     }


### PR DESCRIPTION
Fix `extract_dir` of `uutils-coreutils@0.6.0`.

It looks likes that there is no version string in artifacts now.

See #7593 for detail.


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
