### PR TITLE
nbping: Add version 0.6.1

### DIFF
--- a/bucket/nbping.json
+++ b/bucket/nbping.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/hanshuaikang/Nping/blob/HEAD/LICENSE"
     },
     "suggest": {
-        "Microsoft Visual C++ 2015-2022 Redistributable": "extras/vcredist2022"
+        "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
### Summary

Add a manifest for [NBPing](https://github.com/hanshuaikang/Nping) version 0.6.1.

### Related issues or pull requests

- Closes #7430 

### Notes

- Starting from version [0.6.1](https://github.com/hanshuaikang/Nping/pull/106), `Nping` has been officially renamed to `NBPing`. However, the repository name remains `Nping`, and [the author is currently considering whether to rename it to `NBPing` as well](https://github.com/hanshuaikang/Nping/issues/77#issuecomment-3847644722). To avoid unnecessary maintenance in the future, this PR will be temporarily marked as a draft until the author's final decision is confirmed.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App nbping -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket' -f
nbping: 0.6.1 (scoop version is 0.6.1)
Forcing autoupdate!
Autoupdating nbping
DEBUG[1770214792] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1770214792] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1770214792] $substitutions.$urlNoExt                      https://github.com/hanshuaikang/Nping/releases/download/v0.6.1/nbping-x86_64-pc-windows-msvc
DEBUG[1770214792] $substitutions.$minorVersion                  6
DEBUG[1770214792] $substitutions.$cleanVersion                  061
DEBUG[1770214792] $substitutions.$dashVersion                   0-6-1
DEBUG[1770214792] $substitutions.$basenameNoExt                 nbping-x86_64-pc-windows-msvc
DEBUG[1770214792] $substitutions.$dotVersion                    0.6.1
DEBUG[1770214792] $substitutions.$matchTail
DEBUG[1770214792] $substitutions.$majorVersion                  0
DEBUG[1770214792] $substitutions.$underscoreVersion             0_6_1
DEBUG[1770214792] $substitutions.$version                       0.6.1
DEBUG[1770214792] $substitutions.$preReleaseVersion             0.6.1
DEBUG[1770214792] $substitutions.$basename                      nbping-x86_64-pc-windows-msvc.zip
DEBUG[1770214792] $substitutions.$matchHead                     0.6.1
DEBUG[1770214792] $substitutions.$buildVersion
DEBUG[1770214792] $substitutions.$patchVersion                  1
DEBUG[1770214792] $substitutions.$url                           https://github.com/hanshuaikang/Nping/releases/download/v0.6.1/nbping-x86_64-pc-windows-msvc.zip
DEBUG[1770214792] $substitutions.$match1                        0.6.1
DEBUG[1770214792] $substitutions.$baseurl                       https://github.com/hanshuaikang/Nping/releases/download/v0.6.1
DEBUG[1770214792] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1770214794] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/hanshuaikang/Nping/releases/download/v0.6.1/nbping-x86_64-pc-windows-msvc.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: bfea220ba8315b9c37eb54c73546cc39359ad35ebe3c3d008ae3130b9e83ad83 using Github Mode
Writing updated nbping manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket\nbping.json'
Installing 'nbping' (0.6.1) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket\nbping.json'
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 711260|OK  |   5.9MiB/s|100|D:/Software/Scoop/Local/cache/nbping#0.6.1#bdc29aa.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of nbping-x86_64-pc-windows-msvc.zip... OK.
Extracting nbping-x86_64-pc-windows-msvc.zip... Done.
Linking D:\Software\Scoop\Local\apps\nbping\current => D:\Software\Scoop\Local\apps\nbping\0.6.1
Creating shim for 'nbping'.
'nbping' (0.6.1) was installed successfully!
'nbping' suggests installing 'extras/vcredist2022'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)