### PR TITLE
pypad: Add version 1.0.0

### DIFF
--- a/bucket/pypad.json
+++ b/bucket/pypad.json
@@ -3,11 +3,13 @@
     "description": "The creation of this app is motivated by nostalgia. Microsoft removed MS-Wordpad in latest Windows releases, so I created an alternate version written in Python with .docx processing (write/read/edit) capabilities.",
     "homepage": "https://github.com/Admin9961/pypad-scoop-bucket",
     "license": "Proprietary",
-    "url": "https://github.com/Admin9961/pypad-scoop-bucket/raw/main/PyPad.exe",
-    "hash": "8BF82E5A97636618988602B8D34FDD7F2C842EA103F01CD4028CD444AF5693B8",
-    "bin": "PyPad.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Admin9961/pypad-scoop-bucket/raw/main/PyPad.exe",
+            "hash": "8BF82E5A97636618988602B8D34FDD7F2C842EA103F01CD4028CD444AF5693B8"
+        }
+    },
     "shortcuts": [
         ["PyPad.exe", "PyPad"]
     ]
-
 }


### PR DESCRIPTION
## New Package: Pypad
This adds Pypad, a lightweight alternative to the deprecated Microsoft WordPad.
It is written in Python and provides basic .docx file processing (write, read, edit) capabilities.

## Motivation
Microsoft removed WordPad from the latest Windows releases. This tool is created to fill that gap for users needing simple rich-text editing without a full office suite.

## Testing
The package is already functional and tested in a personal bucket.
Installation test command: `scoop install https://raw.githubusercontent.com/Admin9961/pypad-scoop-bucket/main/pypad.json`