### PR TITLE
vim: Update to version 9.1.2094, fix checkver & autoupdate

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -108,13 +108,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/$matchTag/gvim_$version_x64_signed.zip"
+                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x64_signed.zip"
             },
             "32bit": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/$matchTag/gvim_$version_x86_signed.zip"
+                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_x86_signed.zip"
             },
             "arm64": {
-                "url": "https://github.com/vim/vim-win32-installer/releases/download/$matchTag/gvim_$version_arm64_signed.zip"
+                "url": "https://github.com/vim/vim-win32-installer/releases/download/v$version/gvim_$version_arm64_signed.zip"
             }
         },
         "extract_dir": "vim/vim$majorVersion$minorVersion"


### PR DESCRIPTION
### Summary

Updates `vim` to version **9.1.2094** and refactors the `checkver` logic to use the GitHub API for more reliable signed asset detection.

### Related issues or pull requests

- Relates to #5727 
- Relates to #7305 

### Changes

- **Update** version to **9.1.2094**.
- **Switch** download assets to the `_signed.zip` variants for enhanced security and verification.
- **Refactor** `checkver` to query the GitHub API instead of the Vim homepage:
  - Implemente `jsonpath` to filter for non-prerelease releases and assets containing `signed.zip`.
  - Add `matchTag` capture to handle discrepancies between version numbers and git tags.
- **Update** `autoupdate` logic to use `$matchTag` and the new `_signed.zip` naming convention across all architectures (64bit, 32bit, and arm64).

### Notes

- The official download page has been used for `checkver` for nearly three months. Even though multiple signed releases have been published in the GitHub repository, the official page has still not been updated to those versions.
- On the Windows platform, there may not be a so-called "stable" version of Vim. Signed releases in the GitHub repository are published roughly once per month, which can be further distinguished from `vim-nightly`.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App vim -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket' -f
vim: 9.1.2094 (scoop version is 9.1.2094)
Forcing autoupdate!
Autoupdating vim
DEBUG[1770557204] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1770557204] $substitutions.$dotVersion                    9.1.2094
DEBUG[1770557204] $substitutions.$underscoreVersion             9_1_2094
DEBUG[1770557204] $substitutions.$version                       9.1.2094
DEBUG[1770557204] $substitutions.$minorVersion                  1
DEBUG[1770557204] $substitutions.$patchVersion                  2094
DEBUG[1770557204] $substitutions.$buildVersion
DEBUG[1770557204] $substitutions.$matchTail
DEBUG[1770557204] $substitutions.$urlNoExt                      https://github.com/vim/vim-win32-installer/releases/download/v9.1.2094/gvim_9.1.2094_arm64_signed
DEBUG[1770557204] $substitutions.$url                           https://github.com/vim/vim-win32-installer/releases/download/v9.1.2094/gvim_9.1.2094_arm64_signed.zip
DEBUG[1770557204] $substitutions.$dashVersion                   9-1-2094
DEBUG[1770557204] $substitutions.$basenameNoExt                 gvim_9.1.2094_arm64_signed
DEBUG[1770557204] $substitutions.$matchHead                     9.1.2094
DEBUG[1770557204] $substitutions.$basename                      gvim_9.1.2094_arm64_signed.zip
DEBUG[1770557204] $substitutions.$preReleaseVersion             9.1.2094
DEBUG[1770557204] $substitutions.$cleanVersion                  912094
DEBUG[1770557204] $substitutions.$majorVersion                  9
DEBUG[1770557204] $substitutions.$baseurl                       https://github.com/vim/vim-win32-installer/releases/download/v9.1.2094
DEBUG[1770557204] $substitutions.$matchTag                      v9.1.2094
DEBUG[1770557204] $substitutions.$match1                        9.1.2094
DEBUG[1770557204] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1770557206] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/vim/vim-win32-installer/releases/download/v9.1.2094/gvim_9.1.2094_arm64_signed.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 37eca9897d181bbbdbd6066262aa0c28c442a4b72338e4483b7407540fe5d19a using Github Mode
Writing updated vim manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> '64bit', '32bit', 'arm64' | ForEach-Object {
     scoop download vim --arch $_
 }
INFO  Downloading 'vim' [64bit] from Unofficial bucket
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 5695f3|OK  |    31MiB/s|100|D:/Software/Scoop/Local/cache/vim#9.1.2094#d1656eb.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of gvim_9.1.2094_x64_signed.zip... OK.
'vim' (9.1.2094) was downloaded successfully!
INFO  Downloading 'vim' [32bit] from Unofficial bucket
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: c66f1d|OK  |    14MiB/s|100|D:/Software/Scoop/Local/cache/vim#9.1.2094#7726fd9.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of gvim_9.1.2094_x86_signed.zip... OK.
'vim' (9.1.2094) was downloaded successfully!
INFO  Downloading 'vim' [arm64] from Unofficial bucket
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: aeed12|OK  |   8.3MiB/s|100|D:/Software/Scoop/Local/cache/vim#9.1.2094#7eea824.zip
Download: Status Legend:
Download: (OK):download completed.
Checking hash of gvim_9.1.2094_arm64_signed.zip... OK.
'vim' (9.1.2094) was downloaded successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)