### PR TITLE
crc@2.58.0: Fix extraction

### DIFF
--- a/bucket/crc.json
+++ b/bucket/crc.json
@@ -1,23 +1,16 @@
 {
     "version": "2.58.0",
     "description": "Manages a local OpenShift 4.x cluster optimized for testing and development purposes.",
-    "homepage": "https://code-ready.github.io/crc/",
+    "homepage": "https://crc.dev/blog/",
     "license": "Apache-2.0",
     "notes": "To acquire a pull secret, visit: https://cloud.redhat.com/openshift/install/crc/installer-provisioned",
-    "depends": "lessmsi",
     "architecture": {
         "64bit": {
             "url": "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/2.58.0/crc-windows-installer.zip",
             "hash": "7281f8ef460f1fddc5bf897388a07cb5233ec11bbccf23658ccf1d3a6f8c03be",
-            "pre_install": [
-                "# The trailing backslash(\\) in $dir\\ is required by lessmsi.",
-                "Invoke-ExternalCommand lessmsi -ArgumentList @('x', \"$dir\\crc-windows-amd64.msi\", \"$dir\\\") | Out-Null",
-                "# Find the app directory dynamically",
-                "$appDir = Get-ChildItem -Path \"$dir\" -Filter 'Red Hat OpenShift Local' -Recurse -Directory | Select-Object -ExpandProperty FullName -First 1",
-                "if (-not $appDir) { throw 'Expected directory not found in extracted MSI content.' }",
-                "Copy-Item \"$appDir\\*\" \"$dir\" -Force -Recurse | Out-Null",
-                "Remove-Item \"$dir\\SourceDir\" -Force -Recurse | Out-Null"
-            ]
+            "installer": {
+                "script": "Expand-MsiArchive -Path \"$dir\\crc-windows-amd64.msi\" -DestinationPath $dir -ExtractDir 'PFiles64\\Red Hat OpenShift Local' -Removal"
+            }
         }
     },
     "bin": "crc.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The CRC 2.58.0 installer added a `PFiles64` intermediate directory, which broke the existing `pre_install` logic which uses a fixed path:
- old: SourceDir\\Red Hat OpenShift Local\\\*
- now: SourceDir\\**PFiles64**\\Red Hat OpenShift Local\\\*

**Changes:**
- This fix does a recursive search to find the 'Red Hat OpenShift Local' directory' and only on success it will then copy items.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->