### PR TITLE
git: Persist system-wide config

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -26,7 +26,7 @@
             "hash": "dc59b7383104d57110e370638854cc1b1fd50de0fa6d293dc941f35094594298"
         }
     },
-    "pre_install" : [
+    "pre_install": [
         "# Hardlinks cannot work properly here, as this app would create a new file instead of writing the existing config file.",
         "$config_path = Join-Path -Path $dir -ChildPath 'etc\\gitconfig'",
         "$config_path_persisted = Join-Path -Path $persist_dir -ChildPath 'etc\\gitconfig'",


### PR DESCRIPTION
Fixes #7631. This adds 'etc/gitconfig' to the persist field to ensure user configurations are preserved during updates.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Closes #7631

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git configuration is now automatically saved before uninstallation and restored during installation, preserving user git settings across updates.
  * The process creates required directories and checks for existing configurations to ensure a safe restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->