### PR TITLE
confluent-cli: Update to version 4.52.0, fix checkver

### DIFF
--- a/bucket/confluent-cli.json
+++ b/bucket/confluent-cli.json
@@ -1,8 +1,12 @@
 {
+    "##": "Please keep the checkver field as is. The default GITHUB_TOKEN lacks the necessary permissions to access the latest release endpoint for confluentinc/cli.",
     "version": "4.52.0",
     "description": "The Confluent command-line interface (CLI)",
-    "license": "https://github.com/confluentinc/cli/blob/main/LICENSE",
     "homepage": "https://docs.confluent.io/confluent-cli/current/overview.html",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://github.com/confluentinc/cli/blob/main/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/confluentinc/cli/releases/download/v4.52.0/confluent_4.52.0_windows_amd64.zip",
@@ -13,7 +17,7 @@
     "bin": "confluent.exe",
     "checkver": {
         "url": "https://github.com/confluentinc/cli/releases/latest",
-        "regex": "tag/v([\\d.]+)\""
+        "regex": "(?i)tag/v([\\d.]+)(?=\")"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
> Looks like there's a permission issue with the default GITHUB_TOKEN, which lacks sufficient scopes to access this endpoint.

Update the confluent-cli to the latest available version. Change the autoupdate mechanism to RegEx instead of github.

Closes #7637

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
