### PR TITLE
cygwin: Switch to version-specific URLs, add hash extraction

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -6,7 +6,6 @@
         "identifier": "GPL-3.0-or-later,X11,Public Domain",
         "url": "https://cygwin.com/faq.html#faq.what.free"
     },
-    "notes": "To start a Cygwin shell, type \"cygwin\".",
     "architecture": {
         "64bit": {
             "url": "https://cygwin.com/setup/setup-2.936.x86_64.exe#/cygwin-setup.exe",
@@ -31,6 +30,11 @@
         ]
     },
     "bin": [
+        [
+            "cygwin-setup.exe",
+            "cygwin-setup",
+            "--no-admin --no-shortcuts --no-version-check --local-package-dir \"$persist_dir\\packages\" --root \"$persist_dir\\root\""
+        ],
         [
             "root\\bin\\bash.exe",
             "cygwin",


### PR DESCRIPTION
### Summary

Refactors the `cygwin` manifest to implement **version-specific hash extraction** and improves persistence logic for better reliability across different architectures.

### Related issues or pull requests

- Relates to #4899 
- Relates to #6747 
- Relates to #6833 
- Relates to #7590 
- Too many...

### Changes

- **URL Refactoring**: Switched from rolling/generic URLs to version-specific URLs to ensure installation reproducibility.
- **Version-specific Hash Extraction**: 
  - Update `autoupdate` to parse `sha512.sum` dynamically.
  - Use architecture-specific regex in the `hash` field to ensure the 64-bit hash is matched against `setup-$version.x86_64.exe` and the 32-bit hash against `setup-$version.x86.exe`.
- **Persistence & Permission Fixes**:
  - Integrate `persist_permission` to maintain Cygwin's critical POSIX file attributes.
  - Move directory setup to a robust `installer` script with `ensure` checks.
- **UX Improvements**: Organized shortcuts into a `Cygwin` subfolder and added `--upgrade-also` to the installation arguments.

### Notes

- When a new version is detected, the version referenced by the previous download link may not necessarily be the latest, which has led to [a large number of related issues](https://github.com/ScoopInstaller/Main/issues?q=is%3Aissue%20state%3Aclosed%20cygwin%20hash).
- A comparison of the [shortlog](https://cygwin.com/git/?p=cygwin-apps/setup.git;a=shortlog) and [tags](https://cygwin.com/git/?p=cygwin-apps/setup.git;a=tags) shows that the binary files for the latest release are published some time before the corresponding information appears in the [tags](https://cygwin.com/git/?p=cygwin-apps/setup.git;a=tags). Since it is unclear how long after the [shortlog](https://cygwin.com/git/?p=cygwin-apps/setup.git;a=shortlog) is published the corresponding version becomes available at the [release URL](https://cygwin.com/setup/), the [release URL](https://cygwin.com/setup/) is used as the `checkver` source to avoid auto-update failures.
- Use the `--upgrade-also` option in the `installer` script to ensure the installed application is upgraded to the latest version simultaneously. Add the `--no-version-check` option to the `Cygwin Setup` shortcut to prevent version update prompts during use. The options used in this PR are explained as follows:

  ```powershell
  ┏[ D:\Software\Scoop\Global\apps\Cygwin\current]
  └─> .\cygwin-setup.exe --help

  Cygwin setup 2.936

  Command Line Options:

   -l --local-package-dir            Local package directory
   -B --no-admin                     Do not check for and enforce running as
                                     Administrator
   -n --no-shortcuts                 Disable creation of desktop and start menu
                                     shortcuts
      --no-version-check             Suppress checking if a newer version of
                                     setup is available
   -q --quiet-mode                   Unattended setup mode (unattended, noinput,
                                     hidden)
   -R --root                         Root installation directory
   -s --site                         Download site URL, path or UNC path
   -g --upgrade-also                 Also upgrade installed packages

  The default is to both download and install packages, unless either --download or --local-install is specified.

  ```

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App cygwin -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket' -f
cygwin: 2.936 (scoop version is 2.936)
Forcing autoupdate!
Autoupdating cygwin
DEBUG[1771171539] $substitutions.$url                           https://cygwin.com/setup/setup-2.936.x86_64.exe
DEBUG[1771171539] $substitutions.$urlNoExt                      https://cygwin.com/setup/setup-2.936.x86_64
DEBUG[1771171539] $substitutions.$basenameNoExt                 setup-2.936.x86_64
DEBUG[1771171539] $substitutions.$version                       2.936
DEBUG[1771171539] $substitutions.$dashVersion                   2-936
DEBUG[1771171539] $substitutions.$match1                        2.936
DEBUG[1771171539] $substitutions.$preReleaseVersion             2.936
DEBUG[1771171539] $substitutions.$minorVersion                  936
DEBUG[1771171539] $substitutions.$underscoreVersion             2_936
DEBUG[1771171539] $substitutions.$dotVersion                    2.936
DEBUG[1771171539] $substitutions.$cleanVersion                  2936
DEBUG[1771171539] $substitutions.$baseurl                       https://cygwin.com/setup
DEBUG[1771171539] $substitutions.$patchVersion
DEBUG[1771171539] $substitutions.$matchHead                     2.936
DEBUG[1771171539] $substitutions.$basename                      setup-2.936.x86_64.exe
DEBUG[1771171539] $substitutions.$matchTail
DEBUG[1771171539] $substitutions.$buildVersion
DEBUG[1771171539] $substitutions.$majorVersion                  2
DEBUG[1771171539] $hashfile_url = https://cygwin.com/setup/sha512.sum -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for setup-2.936.x86_64.exe in https://cygwin.com/setup/sha512.sum
DEBUG[1771171540] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*setup-2\.936\.x86_64\.exe(?:\s|$)|setup-2\.936\.x86_64\.exe[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: sha512:a5a5c8dac943dd70363fc96f6da23486c1f45f3f8077eab72566a323df61aed8197aedd3453dabe8308cde65d40589030ed428c50760fc72482af322fbbc8ed9 using Extract Mode
Writing updated cygwin manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> `scoop download Unofficial/cygwin
INFO  Downloading 'cygwin' [64bit] from Unofficial bucket
Starting download with aria2...
Download: Download Results:
Download: gid   |stat|avg speed  |  %|path/URI
Download: ======+====+===========+===+===================================================
Download: 9a76f4|OK  |   1.0MiB/s|100|D:/Software/Scoop/Local/cache/cygwin#2.936#d591dc6.exe
Download: Status Legend:
Download: (OK):download completed.
Checking hash of setup-2.936.x86_64.exe... OK.
'cygwin' (2.936) was downloaded successfully!

┏[ D:\Software\Scoop\Local\cache]
└─> .\cygwin#2.936#d591dc6.exe --version | Write-Output
Cygwin setup 2.936

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)