### PR TITLE
saki-vi: Add version 1.0.0

### DIFF
--- a/bucket/saki-vi.json
+++ b/bucket/saki-vi.json
@@ -3,7 +3,7 @@
     "description": "Vi — the original POSIX standard text editor, not Vim. Native Win64, trilingual (繁中/日本語/EN).",
     "homepage": "https://saki-studio.com.tw/vi/",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/Saki-tw/Vi-SakiWin64/releases/download/v$version/vi.exe",
+    "url": "https://github.com/Saki-tw/Vi-SakiWin64/releases/download/v1.0.0/vi.exe",
     "hash": "f8235794d90eb100ced49bf6532a678c0dae5f5b53e132659817c920d88adf3b",
     "bin": "vi.exe",
     "checkver": {


### PR DESCRIPTION
Closes #7642

## Changes
- Add `saki-vi` manifest for Vi 1.0.0

Vi — the POSIX standard text editor (IEEE Std 1003.1), native Win64 build from busybox-w32. See also: [Traditional Vi](https://ex-vi.sourceforge.net) — the original vi source on current Unix systems. Single 178KB binary, zero dependencies.

- **checkver**: GitHub releases
- **autoupdate**: GitHub releases URL pattern
- **License**: GPL-2.0-only