### PR TITLE
cheat: Prevent overwriting existing config

### DIFF
--- a/bucket/cheat.json
+++ b/bucket/cheat.json
@@ -23,6 +23,7 @@
         "}"
     ],
     "post_install": [
+        "# For the cheatsheets path to be set correctly, the configuration file should be initialized after the environment variables are set.",
         "$file = 'conf.yml'",
         "if ((Get-Item \"$dir\\$file\").Length -eq 0) {",
         "    $CONT = $(& \"$dir\\cheat\" --init) -replace 'editor: EDITOR_PATH', 'editor: notepad' -replace 'pager: PAGER_PATH', 'pager: more'",


### PR DESCRIPTION
Change the `post_install` script of the manifest so that the contents of `conf.yml` are overwritten with a newly generated cheat config only if `conf.yml` is empty.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Relates to #4043
Closes #7646 
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
