### PR TITLE
scooter: Add version 0.8.5

### DIFF
--- a/bucket/scooter.json
+++ b/bucket/scooter.json
@@ -1,6 +1,6 @@
 {
     "version": "0.8.5",
-    "description": "Blazing fast find-and-replace terminal UI app written in Rust.",
+    "description": "An interactive TUI tool for finding and replacing text.",
     "homepage": "https://github.com/thomasschafer/scooter",
     "license": "MIT",
     "architecture": {
@@ -16,6 +16,9 @@
             "64bit": {
                 "url": "https://github.com/thomasschafer/scooter/releases/download/v$version/scooter-v$version-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
Scooter is a blazing fast find-and-replace terminal UI app written in Rust.

- Add manifest for scooter package (v0.8.5).
- Supports x86_64 architecture
- ncludes checkver and autoupdate configuration

Closes https://github.com/ScoopInstaller/Main/issues/7656

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
