### PR TITLE
tea: Update to version 0.12.0, add arm64 support

### DIFF
--- a/bucket/tea.json
+++ b/bucket/tea.json
@@ -1,12 +1,16 @@
 {
-    "version": "0.11.1",
+    "version": "0.12.0",
     "description": "Official command-line tool to interact with Gitea servers",
     "homepage": "https://gitea.com/gitea/tea",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://gitea.com/gitea/tea/releases/download/v0.11.1/tea-0.11.1-windows-amd64.exe.xz",
-            "hash": "d91fb10c5fcb6eab45d79f140f1a0aa36dccb678e5171fe8a51f9bfb4a05065d"
+            "url": "https://dl.gitea.com/tea/0.12.0/tea-0.12.0-windows-amd64.exe.xz",
+            "hash": "e97557168447bf5adf4265322dfbef49172a8b422c35d35af5d4b47af0d8df38"
+        },
+        "arm64": {
+            "url": "https://dl.gitea.com/tea/0.12.0/tea-0.12.0-windows-arm64.exe.xz",
+            "hash": "4cc12659544d45d56e491e2df369189f6e0dba46517076cc41a718e1293d806e"
         }
     },
     "pre_install": "Get-Item \"$dir\\tea-*.exe\" | Rename-Item  -NewName \"$dir\\tea.exe\"",
@@ -17,7 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://gitea.com/gitea/tea/releases/download/v$version/tea-$version-windows-amd64.exe.xz"
+                "url": "https://dl.gitea.com/tea/$version/tea-$version-windows-amd64.exe.xz"
+            },
+            "arm64": {
+                "url": "https://dl.gitea.com/tea/$version/tea-$version-windows-arm64.exe.xz"
             }
         },
         "hash": {


### PR DESCRIPTION
Changelog: https://gitea.com/gitea/tea/releases/tag/v0.12.0

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
