### PR TITLE
aws-vault: Update to version 7.9.7, switch to recommended fork

### DIFF
--- a/bucket/aws-vault.json
+++ b/bucket/aws-vault.json
@@ -23,6 +23,9 @@
             "arm64": {
                 "url": "https://github.com/ByteNess/aws-vault/releases/download/v$version/aws-vault-windows-arm64.exe#/aws-vault.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/aws-vault_sha256_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
https://github.com/99designs/aws-vault?tab=readme-ov-file#aws-vault

> This project has been abandoned and it's not receiving any more updates. If you want to continue to receive updates or contribute, please feel free to look at the active fork at: https://github.com/ByteNess/aws-vault

Relates to: https://github.com/99designs/aws-vault/issues/1269

* Switching the upstream source to the `ByteNess/aws-vault` fork. 
* The original `99designs` repository is stale and hasn't seen a release since v7.2.0. 
* The `ByteNess` fork is currently the actively maintained and recommended by `99designs`
* Added `arm64` architecture support alongside `64bit`.
* Locally tested and successfully verified using `scoop install .\aws-vault.json`.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)