### PR TITLE
maestro: Add version 2.2.0

### DIFF
--- a/bucket/maestro.json
+++ b/bucket/maestro.json
@@ -1,21 +1,26 @@
 {
     "version": "2.2.0",
-    "description": "Painless E2E Automation for Mobile and Web",
+    "description": "An open-source framework that makes UI and end-to-end testing for Android, iOS, and web apps simple and fast.",
     "homepage": "https://maestro.dev",
     "license": "Apache-2.0",
+    "suggest": {
+        "Java": "java/openjdk"
+    },
     "url": "https://github.com/mobile-dev-inc/Maestro/releases/download/cli-2.2.0/maestro.zip",
     "hash": "6de501d2e8adf2d60f4b6b3174dc4b5e393f2f2617245d350a659627dccb0922",
     "extract_dir": "maestro",
-    "bin": "bin\\maestro.bat",
     "env_set": {
         "MAESTRO_HOME": "$dir"
     },
+    "bin": "bin\\maestro.bat",
     "checkver": {
         "github": "https://github.com/mobile-dev-inc/Maestro",
         "regex": "cli-([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/mobile-dev-inc/Maestro/releases/download/cli-$version/maestro.zip",
-        "extract_dir": "maestro"
+        "hash": {
+            "url": "$baseurl/checksums_sha256.txt"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add new package `maestro` (version 2.2.0)
- Maestro is a painless E2E automation framework for Mobile and Web apps

## References

- Closes https://github.com/ScoopInstaller/Main/issues/7668