### PR TITLE
yq@4.52.4: Add arm64 support

### DIFF
--- a/bucket/yq.json
+++ b/bucket/yq.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_windows_386.exe#/yq.exe",
             "hash": "fe333fee39b8da25aebaa28aa6f73e1587352172bd438801fd0b94e3feacaf5f"
+        },
+        "arm64": {
+            "url": "https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_windows_arm64.exe#/yq.exe",
+            "hash": "ca8c95235198204b4e74ea79b416367bc373cda6b591ca38d4a8cbc0ea8b9a6e"
         }
     },
     "bin": "yq.exe",
@@ -24,6 +28,9 @@
             },
             "32bit": {
                 "url": "https://github.com/mikefarah/yq/releases/download/v$version/yq_windows_386.exe#/yq.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/mikefarah/yq/releases/download/v$version/yq_windows_arm64.exe#/yq.exe"
             }
         }
     }


### PR DESCRIPTION
The modified manifest are tested to work on my WoA laptop.

```
PS C:\Users\Anthony-Air14sQ\localsend> scoop install anthony/yq
Installing 'yq' (4.52.4) [arm64] from 'anthony' bucket
proxy: https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_windows_arm64.exe
yq_windows_arm64.exe (12.3 MB) [==============================================================================] 100%
Checking hash of yq_windows_arm64.exe ... ok.
Linking ~\scoop\apps\yq\current => ~\scoop\apps\yq\4.52.4
Creating shim for 'yq'.
'yq' (4.52.4) was installed successfully!
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
