### PR TITLE
git-flow-next: Add version 1.0.0

### DIFF
--- a/bucket/git-flow-next.json
+++ b/bucket/git-flow-next.json
@@ -1,0 +1,34 @@
+{
+    "version": "1.0.0",
+    "description": "A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh.",
+    "homepage": "https://git-flow.sh",
+    "license": "BSD-2-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gittower/git-flow-next/releases/download/v1.0.0/git-flow-next-v1.0.0-windows-amd64.zip",
+            "hash": "ca0ccb362d3aeddf88287241e7d62544378675c84aca2a41864d7868c957ea0a"
+        },
+        "32bit": {
+            "url": "https://github.com/gittower/git-flow-next/releases/download/v1.0.0/git-flow-next-v1.0.0-windows-386.zip",
+            "hash": "5863ea1723077afa8578ab9860637467ef30749fadc4aa370b1d16a055cd62f3"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\\git-flow*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'git-flow.exe'",
+    "bin": "git-flow.exe",
+    "checkver": {
+        "github": "https://github.com/gittower/git-flow-next"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-windows-386.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Relates to:
- https://github.com/ScoopInstaller/Versions/pull/2530
- https://github.com/gittower/git-flow-next/issues/84
- Closes #7684
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Windows platform configuration enabling automatic updates and version checking for both 32-bit and 64-bit architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->