### PR TITLE
git-xet: Update checkver

### DIFF
--- a/bucket/git-xet.json
+++ b/bucket/git-xet.json
@@ -20,9 +20,9 @@
     },
     "bin": "git-xet.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/huggingface/xet-core/releases?per_page=100",
-        "jsonpath": "$..tag_name",
-        "regex": "git-xet-v([\\d.]+)"
+        "url": "https://api.github.com/repos/huggingface/xet-core/releases?per_page=45",
+        "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /git-xet/i)].browser_download_url",
+        "regex": "(?i)download/git-xet-v([\\d.]+)/git-xet"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
### Summary

Refines the `checkver` logic for `git-xet` to improve detection accuracy and ensure only stable releases are tracked.

### Related issues or pull requests

- Relates to #7563 

### Changes

- **Update checkver logic**:
  - Switch from a simple tag scan to a filtered GitHub API query.
  - Add `jsonpath` filtering to explicitly exclude `prerelease` versions.
  - Improve `regex` to match the version string directly from the `browser_download_url`, ensuring the detected version actually has associated assets.
- **Optimization**: Reduce `per_page` from 100 to 45 to minimize API payload while still covering a sufficient release history.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App git-xet -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket' -f
git-xet: 0.2.1 (scoop version is 0.2.1)
Forcing autoupdate!
Autoupdating git-xet
DEBUG[1772091243] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1772091243] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1772091243] $substitutions.$cleanVersion                  021
DEBUG[1772091243] $substitutions.$dotVersion                    0.2.1
DEBUG[1772091243] $substitutions.$basename                      git-xet-windows-x86_64.zip
DEBUG[1772091243] $substitutions.$matchTail
DEBUG[1772091243] $substitutions.$match1                        0.2.1
DEBUG[1772091243] $substitutions.$basenameNoExt                 git-xet-windows-x86_64
DEBUG[1772091243] $substitutions.$dashVersion                   0-2-1
DEBUG[1772091243] $substitutions.$majorVersion                  0
DEBUG[1772091243] $substitutions.$patchVersion                  1
DEBUG[1772091243] $substitutions.$preReleaseVersion             0.2.1
DEBUG[1772091243] $substitutions.$underscoreVersion             0_2_1
DEBUG[1772091243] $substitutions.$buildVersion
DEBUG[1772091243] $substitutions.$minorVersion                  2
DEBUG[1772091243] $substitutions.$urlNoExt                      https://github.com/huggingface/xet-core/releases/download/git-xet-v0.2.1/git-xet-windows-x86_64
DEBUG[1772091243] $substitutions.$url                           https://github.com/huggingface/xet-core/releases/download/git-xet-v0.2.1/git-xet-windows-x86_64.zip
DEBUG[1772091243] $substitutions.$baseurl                       https://github.com/huggingface/xet-core/releases/download/git-xet-v0.2.1
DEBUG[1772091243] $substitutions.$matchHead                     0.2.1
DEBUG[1772091243] $substitutions.$version                       0.2.1
DEBUG[1772091243] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1772091245] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/huggingface/xet-core/releases/download/git-xet-v0.2.1/git-xet-windows-x86_64.zip')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 427179c2f410bb0a1da28df590adcfbdc8fff50369f295da148fb1c9c27d2cea using Github Mode
Writing updated git-xet manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)