### PR TITLE
ctf-tui: Add version 0.1.2

### DIFF
--- a/bucket/ctf-tui.json
+++ b/bucket/ctf-tui.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1.2",
+  "description": "CTF TUI launcher for challenge environment workflows",
+  "homepage": "https://github.com/gandli/ctf-tui-launcher",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/gandli/ctf-tui-launcher/releases/download/v0.1.2/ctf-tui-windows-x86_64.zip",
+      "hash": "02ca639a6f6067b07f44aae47144ae78664c7516579d037dc02faa4d9b194f5b"
+    }
+  },
+  "depends": "docker",
+  "bin": "ctf-tui.exe",
+  "checkver": "github",
+  "autoupdate": {
+    "url": "https://github.com/gandli/ctf-tui-launcher/releases/download/v$version/ctf-tui-windows-x86_64.zip"
+  }
+}


### PR DESCRIPTION
Adds  manifest (v0.1.2).\n\n- URL: https://github.com/gandli/ctf-tui-launcher/releases/download/v0.1.2/ctf-tui-windows-x86_64.zip\n- SHA256: 02ca639a6f6067b07f44aae47144ae78664c7516579d037dc02faa4d9b194f5b\n- Dependency: docker