### PR TITLE
eac3to: Update to version 3.59, fix checkver & autoupdate

### DIFF
--- a/bucket/eac3to.json
+++ b/bucket/eac3to.json
@@ -1,16 +1,16 @@
 {
-    "version": "3.52",
+    "version": "3.59",
     "description": "Audio conversion tool",
     "homepage": "https://www.rationalqm.us/eac3to/",
     "license": "Freeware",
-    "url": "https://www.rationalqm.us/eac3to/eac3to_3.52.rar",
-    "hash": "27e7c5990b60a3b9a6969712888c64886bfd578f114675e49f92aaf912b17e34",
+    "url": "https://www.videohelp.com/download/eac3to_3.59.rar",
+    "hash": "c866be84c0cd5de2da3a0978f62bd5e8a336d56f130ef54718b6a0a5e9108c17",
     "bin": "eac3to.exe",
     "checkver": {
-        "url": "https://www.rationalqm.us/eac3to/?C=M;O=D",
+        "url": "https://www.videohelp.com/software/eac3to",
         "regex": "eac3to_([\\d.]+).rar"
     },
     "autoupdate": {
-        "url": "https://www.rationalqm.us/eac3to/eac3to_$version.rar"
+        "url": "https://www.videohelp.com/download/eac3to_$version.rar"
     }
 }


### PR DESCRIPTION
rationalqm seems to be behind cloudflare now, so updates and installs fail with a 403. This PR switches the manifest to videohelp , which mirrors downloads in a timely manner.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Closes #7554 / Closes #7552 / Repeats #7555

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
