### PR TITLE
ladybugdb: Add version 0.15.1

### DIFF
--- a/bucket/ladybugdb.json
+++ b/bucket/ladybugdb.json
@@ -1,9 +1,8 @@
 {
     "version": "0.15.1",
-    "description": "LadybugDB is an embedded graph database built for query speed and scalability.",
-    "homepage": "https://github.com/LadybugDB/ladybug",
+    "description": "An embedded graph database built for query speed and scalability.",
+    "homepage": "https://ladybugdb.com",
     "license": "MIT",
-    "notes": "To use LadybugDB cli run 'lbug' command.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/LadybugDB/ladybug/releases/download/v0.15.1/lbug_cli-windows-x86_64.zip",
@@ -11,7 +10,9 @@
         }
     },
     "bin": "lbug.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/LadybugDB/ladybug"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
LadybugDB is a fast embeddable graph database developed in the tradition of SQLite and DuckDB.

It recently emerged as a maintained community fork of KuzuDB after the original project was discontinued and archived following its acquisition by Apple Inc.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
