### PR TITLE
bundletool: Add version 1.18.3

### DIFF
--- a/bucket/bundletool.json
+++ b/bucket/bundletool.json
@@ -1,32 +1,18 @@
 {
     "version": "1.18.3",
-    "description": "bundletool can convert an app bundle into the various APKs that are deployed to devices",
+    "description": "A CLI tool to manipulate Android App Bundles and Android SDK Bundles.",
     "homepage": "https://developer.android.google.cn/tools/bundletool",
     "license": "Apache-2.0",
     "suggest": {
-        "JRE": "java/temurin11-jre"
+        "JDK": "java/openjdk"
     },
     "url": "https://github.com/google/bundletool/releases/download/1.18.3/bundletool-all-1.18.3.jar#/bundletool.jar",
     "hash": "a099cfa1543f55593bc2ed16a70a7c67fe54b1747bb7301f37fdfd6d91028e29",
-    "pre_install": "Set-Content \"$dir\\bundletool.bat\" '@java.exe -jar \"%~dp0bundletool.jar\" %*' -Encoding Ascii",
     "bin": "bundletool.jar",
-    "shortcuts": [
-        [
-            "bundletool.bat",
-            "bundletool"
-        ]
-    ],
     "checkver": {
-        "url": "https://api.github.com/repos/google/bundletool/releases/latest",
-        "jsonpath": "$.tag_name"
+        "github": "https://github.com/google/bundletool"
     },
     "autoupdate": {
-        "url": "https://github.com/google/bundletool/releases/download/$version/bundletool-all-$version.jar#/bundletool.jar",
-        "hash": {
-            "mode": "json",
-            "url": "https://api.github.com/repos/google/bundletool/releases/latest",
-            "jsonpath": "$.assets[?(@.name == \"bundletool-all-$version.jar\")].digest",
-            "regex": "sha256:([a-fA-F0-9]{64})"
-        }
+        "url": "https://github.com/google/bundletool/releases/download/$version/bundletool-all-$version.jar#/bundletool.jar"
     }
 }


### PR DESCRIPTION
Bundletool is a tool to manipulate Android App Bundles and Android SDK Bundles.

Closes https://github.com/ScoopInstaller/Main/issues/7749
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `bundletool: Add bundletool.json configuration for bundletool 1.18.3`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
