### PR TITLE
surge@0.7.2: Add 32bit support

### DIFF
--- a/bucket/surge.json
+++ b/bucket/surge.json
@@ -8,7 +8,7 @@
             "url": "https://github.com/surge-downloader/Surge/releases/download/v0.7.2/Surge_0.7.2_windows_amd64.zip",
             "hash": "1c65280ce217780c3127af628e2390da8b48f540bc58fcfb24cca67d16744e43"
         },
-        "32bit":{
+        "32bit": {
             "url": "https://github.com/surge-downloader/Surge/releases/download/v0.7.2/Surge_0.7.2_windows_386.zip",
             "hash": "133785783d4da92165844145e0ff7e94e1a4bac5676a3c34c9b34f6f608a1db8"
         },
@@ -23,6 +23,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/surge-downloader/Surge/releases/download/v$version/Surge_$version_windows_amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/surge-downloader/Surge/releases/download/v$version/Surge_$version_windows_386.zip"
             },
             "arm64": {
                 "url": "https://github.com/surge-downloader/Surge/releases/download/v$version/Surge_$version_windows_arm64.zip"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Surge has been added to the main bucket with 64bit and arm64 version (#7736). This pr updates its 32bit version.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
