### PR TITLE
gradle(-bin): Update to version 9.4.1, fix checkver

### DIFF
--- a/bucket/gradle-bin.json
+++ b/bucket/gradle-bin.json
@@ -1,14 +1,14 @@
 {
-    "version": "9.3.1",
+    "version": "9.4.1",
     "description": "An open-source build automation tool focused on flexibility and performance. (Binaries only without documentation)",
     "homepage": "https://gradle.org",
     "license": "Apache-2.0",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://services.gradle.org/distributions/gradle-9.3.1-bin.zip",
-    "hash": "b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06",
-    "extract_dir": "gradle-9.3.1",
+    "url": "https://services.gradle.org/distributions/gradle-9.4.1-bin.zip",
+    "hash": "2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb",
+    "extract_dir": "gradle-9.4.1",
     "post_install": [
         "$current_env = Get-EnvVar -Name GRADLE_USER_HOME -Global:$global",
         "If ($null -eq $current_env) {",
@@ -21,8 +21,8 @@
     "persist": ".gradle",
     "bin": "bin\\gradle.bat",
     "checkver": {
-        "url": "https://gradle.org/install/",
-        "regex": "The current Gradle release is version ([\\d.]+)"
+        "url": "https://gradle.org/releases/",
+        "regex": ">([\\d.]+)</a"
     },
     "autoupdate": {
         "url": "https://services.gradle.org/distributions/gradle-$version-bin.zip",

--- a/bucket/gradle.json
+++ b/bucket/gradle.json
@@ -1,14 +1,14 @@
 {
-    "version": "9.3.1",
+    "version": "9.4.1",
     "description": "An open-source build automation tool focused on flexibility and performance. (Source code and documentation bundled)",
     "homepage": "https://gradle.org",
     "license": "Apache-2.0",
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://services.gradle.org/distributions/gradle-9.3.1-all.zip",
-    "hash": "17f277867f6914d61b1aa02efab1ba7bb439ad652ca485cd8ca6842fccec6e43",
-    "extract_dir": "gradle-9.3.1",
+    "url": "https://services.gradle.org/distributions/gradle-9.4.1-all.zip",
+    "hash": "708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b",
+    "extract_dir": "gradle-9.4.1",
     "post_install": [
         "$current_env = Get-EnvVar -Name GRADLE_USER_HOME -Global:$global",
         "If ($null -eq $current_env) {",
@@ -21,8 +21,8 @@
     "persist": ".gradle",
     "bin": "bin\\gradle.bat",
     "checkver": {
-        "url": "https://gradle.org/install/",
-        "regex": "The current Gradle release is version ([\\d.]+)"
+        "url": "https://gradle.org/releases/",
+        "regex": ">([\\d.]+)</a"
     },
     "autoupdate": {
         "url": "https://services.gradle.org/distributions/gradle-$version-all.zip",


### PR DESCRIPTION
### Summary

Updates `gradle` and `gradle-bin` to version **9.4.1** and migrates the version detection source to the official releases page for better reliability.

### Related issues or pull requests

- Closes #7764 

### Changes

- **Update version to 9.4.1**: Applied to both `gradle` (full) and `gradle-bin` (binary-only) manifests.
- **Refine checkver logic**:
  - Change source URL from `/install/` to `/releases/`.
  - Simplify the `regex` to `>([\d.]+)</a` to target the version anchors on the release page more directly.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App gradle* -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket' -f
gradle-bin: 9.4.1 (scoop version is 9.4.1)
Forcing autoupdate!
Autoupdating gradle-bin
DEBUG[1774100883] [$updatedProperties] = [url hash extract_dir] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1774100883] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1774100883] $substitutions.$version                       9.4.1
DEBUG[1774100883] $substitutions.$minorVersion                  4
DEBUG[1774100883] $substitutions.$basenameNoExt                 gradle-9.4.1-bin
DEBUG[1774100883] $substitutions.$matchTail
DEBUG[1774100883] $substitutions.$patchVersion                  1
DEBUG[1774100883] $substitutions.$url                           https://services.gradle.org/distributions/gradle-9.4.1-bin.zip
DEBUG[1774100883] $substitutions.$match1                        9.4.1
DEBUG[1774100883] $substitutions.$urlNoExt                      https://services.gradle.org/distributions/gradle-9.4.1-bin
DEBUG[1774100883] $substitutions.$cleanVersion                  941
DEBUG[1774100883] $substitutions.$preReleaseVersion             9.4.1
DEBUG[1774100883] $substitutions.$underscoreVersion             9_4_1
DEBUG[1774100883] $substitutions.$dotVersion                    9.4.1
DEBUG[1774100883] $substitutions.$baseurl                       https://services.gradle.org/distributions
DEBUG[1774100883] $substitutions.$dashVersion                   9-4-1
DEBUG[1774100883] $substitutions.$majorVersion                  9
DEBUG[1774100883] $substitutions.$matchHead                     9.4.1
DEBUG[1774100883] $substitutions.$buildVersion
DEBUG[1774100883] $substitutions.$basename                      gradle-9.4.1-bin.zip
DEBUG[1774100883] $hashfile_url = https://services.gradle.org/distributions/gradle-9.4.1-bin.zip.sha256 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for gradle-9.4.1-bin.zip in https://services.gradle.org/distributions/gradle-9.4.1-bin.zip.sha256
DEBUG[1774100883] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:80:9
Found: 2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb using Extract Mode
Writing updated gradle-bin manifest
gradle: 9.4.1 (scoop version is 9.4.1)
Forcing autoupdate!
Autoupdating gradle
DEBUG[1774100883] [$updatedProperties] = [url hash extract_dir] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1774100883] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1774100883] $substitutions.$version                       9.4.1
DEBUG[1774100883] $substitutions.$minorVersion                  4
DEBUG[1774100883] $substitutions.$basenameNoExt                 gradle-9.4.1-all
DEBUG[1774100883] $substitutions.$matchTail
DEBUG[1774100883] $substitutions.$patchVersion                  1
DEBUG[1774100883] $substitutions.$url                           https://services.gradle.org/distributions/gradle-9.4.1-all.zip
DEBUG[1774100883] $substitutions.$match1                        9.4.1
DEBUG[1774100883] $substitutions.$urlNoExt                      https://services.gradle.org/distributions/gradle-9.4.1-all
DEBUG[1774100883] $substitutions.$cleanVersion                  941
DEBUG[1774100883] $substitutions.$preReleaseVersion             9.4.1
DEBUG[1774100883] $substitutions.$underscoreVersion             9_4_1
DEBUG[1774100883] $substitutions.$dotVersion                    9.4.1
DEBUG[1774100883] $substitutions.$baseurl                       https://services.gradle.org/distributions
DEBUG[1774100883] $substitutions.$dashVersion                   9-4-1
DEBUG[1774100883] $substitutions.$majorVersion                  9
DEBUG[1774100883] $substitutions.$matchHead                     9.4.1
DEBUG[1774100883] $substitutions.$buildVersion
DEBUG[1774100883] $substitutions.$basename                      gradle-9.4.1-all.zip
DEBUG[1774100883] $hashfile_url = https://services.gradle.org/distributions/gradle-9.4.1-all.zip.sha256 -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for gradle-9.4.1-all.zip in https://services.gradle.org/distributions/gradle-9.4.1-all.zip.sha256
DEBUG[1774100884] $regex = ^\s*([a-fA-F0-9]+)\s*$ -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:80:9
Found: 708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b using Extract Mode
Writing updated gradle manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/gradle-bin
Installing 'gradle-bin' (9.4.1) [64bit] from 'Unofficial' bucket
Loading gradle-9.4.1-bin.zip from cache.
Checking hash of gradle-9.4.1-bin.zip... OK.
Extracting gradle-9.4.1-bin.zip... Done.
Linking D:\Software\Scoop\Local\apps\gradle-bin\current => D:\Software\Scoop\Local\apps\gradle-bin\9.4.1
Creating shim for 'gradle'.
Persisting .gradle
Running post_install script... Done.
'gradle-bin' (9.4.1) was installed successfully!
'gradle-bin' suggests installing 'java/openjdk'.

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)