### PR TITLE
z.lua: Update to version 1.8.25, fix checkver & autoupdate

### DIFF
--- a/bucket/z.lua.json
+++ b/bucket/z.lua.json
@@ -1,16 +1,22 @@
 {
-    "version": "1.8.24",
-    "description": "cd command replacement",
+    "version": "1.8.25",
+    "description": "A command-line cd replacement that accelerates directory navigation by learning user access patterns.",
     "homepage": "https://github.com/skywind3000/z.lua",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/skywind3000/z.lua/blob/HEAD/LICENSE"
+    },
     "notes": "Configure accordingly to 'https://github.com/skywind3000/z.lua#install'",
     "depends": "lua",
-    "url": "https://github.com/skywind3000/z.lua/archive/1.8.24.zip",
-    "hash": "569571445cc837d5da4335aabc32de56b3ccf836cf54dd7ca02fb1a14e1fde6c",
-    "extract_dir": "z.lua-1.8.24",
-    "checkver": "github",
+    "url": "https://github.com/skywind3000/z.lua/archive/refs/tags/v1.8.25.zip",
+    "hash": "eb873632e37bbf96fb0255db9a9e27b14b3e06e0264b1e69bc30da13e912dbc8",
+    "extract_dir": "z.lua-1.8.25",
+    "checkver": {
+        "url": "https://api.github.com/repos/skywind3000/z.lua/releases/latest",
+        "regex": "(?i)tag/(?<tag>v?([\\d.]+))(?=\")"
+    },
     "autoupdate": {
-        "url": "https://github.com/skywind3000/z.lua/archive/$version.zip",
+        "url": "https://github.com/skywind3000/z.lua/archive/refs/tags/$matchTag.zip",
         "extract_dir": "z.lua-$version"
     }
 }


### PR DESCRIPTION
### Summary

Updates `z.lua` to version **1.8.25**, refines the project description, and modernizes the `checkver` logic for more robust tag handling.

### Changes

- **Update version to 1.8.25**: Bump version and update corresponding hashes.
- **Refine Description**: Expand the description to better explain the tool's core functionality (learning user access patterns).
- **Improve License Field**: Migrate from a simple string to a structured object with the SPDX identifier `MIT` and a direct link to the license file.
- **Robust checkver**: 
  - Replace the basic `github` helper with a GitHub API call to the `/releases/latest` endpoint.
  - Implement a regex with a named capture group `tag` to correctly extract and store the tag (handling the optional `v` prefix).
- **Standardize autoupdate**: Update the URL template to use the `refs/tags/` path and `$matchTag` for better consistency with GitHub's current distribution structure.

### Notes

- The use of `$matchTag` in `autoupdate` prevents potential download failures when upstream tags don't perfectly align with the version string.
  - The upstream `tag_name` is manually defined, making it impossible to determine whether it will include a `v`. Instead of adding or removing `v` in the download URL, it is preferable to use a captured variable directly.

```
[
  "v1.8.25",
  "1.8.24",
  ... ...
  "v1.7.4",
  ... ...
  "v1.5.0"
]
```

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App z.lua -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main\bucket' -f
z.lua: 1.8.25 (scoop version is 1.8.25)
Forcing autoupdate!
Autoupdating z.lua
DEBUG[1774104409] [$updatedProperties] = [url extract_dir hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1774104409] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1774104409] $substitutions.$version                       1.8.25
DEBUG[1774104409] $substitutions.$minorVersion                  8
DEBUG[1774104409] $substitutions.$basenameNoExt                 v1.8.25
DEBUG[1774104409] $substitutions.$matchTail
DEBUG[1774104409] $substitutions.$majorVersion                  1
DEBUG[1774104409] $substitutions.$url                           https://github.com/skywind3000/z.lua/archive/refs/tags/v1.8.25.zip
DEBUG[1774104409] $substitutions.$matchHead                     1.8.25
DEBUG[1774104409] $substitutions.$cleanVersion                  1825
DEBUG[1774104409] $substitutions.$preReleaseVersion             1.8.25
DEBUG[1774104409] $substitutions.$underscoreVersion             1_8_25
DEBUG[1774104409] $substitutions.$dotVersion                    1.8.25
DEBUG[1774104409] $substitutions.$baseurl                       https://github.com/skywind3000/z.lua/archive/refs/tags
DEBUG[1774104409] $substitutions.$dashVersion                   1-8-25
DEBUG[1774104409] $substitutions.$patchVersion                  25
DEBUG[1774104409] $substitutions.$matchTag                      v1.8.25
DEBUG[1774104409] $substitutions.$urlNoExt                      https://github.com/skywind3000/z.lua/archive/refs/tags/v1.8.25
DEBUG[1774104409] $substitutions.$buildVersion
DEBUG[1774104409] $substitutions.$match1                        1.8.25
DEBUG[1774104409] $substitutions.$basename                      v1.8.25.zip
DEBUG[1774104409] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading v1.8.25.zip to compute hashes!
Loading v1.8.25.zip from cache
Computed hash: eb873632e37bbf96fb0255db9a9e27b14b3e06e0264b1e69bc30da13e912dbc8
Writing updated z.lua manifest

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)