### PR TITLE
bun: Use persisted global bin path

### DIFF
--- a/bucket/bun.json
+++ b/bucket/bun.json
@@ -49,9 +49,7 @@
         "Remove-Item \"$dir\\bun-windows-*\" -Recurse"
     ],
     "installer": {
-        "script": [
-            "Add-Path -Path \"$persist_dir\\bin\" -Global:$global -Force"
-        ]
+        "script": "Add-Path -Path \"$persist_dir\\bin\" -Global:$global -Force"
     },
     "env_set": {
         "BUN_INSTALL": "$persist_dir",
@@ -71,9 +69,7 @@
         "install"
     ],
     "uninstaller": {
-        "script": [
-            "Remove-Path -Path \"$persist_dir\\bin\" -Global:$global"
-        ]
+        "script": "Remove-Path -Path \"$persist_dir\\bin\" -Global:$global"
     },
     "checkver": {
         "github": "https://github.com/oven-sh/bun",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

Relates to #7697

## Summary

Address the feedback in https://github.com/ScoopInstaller/Main/pull/7697#issuecomment-4079046852 by aligning Bun's global bin path with the real path Bun reports and checks.

Bun resolves Scoop's junctioned `current\bin` path to the persisted directory, so pointing `BUN_INSTALL` at `current` does not avoid the `not in $PATH` warning. This change instead configures Bun's global install paths explicitly under Scoop's persist directory and adds that real bin path to PATH.

## Changes

- set `BUN_INSTALL` to `$persist_dir`
- add `BUN_INSTALL_BIN` and `BUN_INSTALL_GLOBAL_DIR`
- replace `env_add_path` with explicit PATH management in `installer` / `uninstaller`
- remove stale `current\bin` / versioned `bin` PATH entries during install and uninstall
- keep existing `persist` entries and legacy `~/.bun` migration logic unchanged

## Testing

- `Test-Json -Path .\bucket\bun.json`
- `scoop uninstall bun`
- `scoop install .\bucket\bun.json`
- verified user PATH changed from `E:\Scoop\apps\bun\current\bin` to `E:\Scoop\persist\bun\bin`
- verified `bun pm bin -g` returns `E:\Scoop\persist\bun\bin` without the `not in $PATH` warning
- verified persisted global commands still resolve and run:
  - `figlet hello`

## Notes

This keeps Scoop persistence intact while matching Bun's actual path resolution behavior on Windows, where Bun resolves the junctioned `current\bin` path to the real persisted directory.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
