### PR TITLE
cuda@13.2.0: Add `bin/x64` to PATH

### DIFF
--- a/bucket/cuda.json
+++ b/bucket/cuda.json
@@ -9,7 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "http://developer.download.nvidia.com/compute/cuda/13.2.0/local_installers/cuda_13.2.0_windows.exe#/dl.7z",
-            "hash": "md5:58b553e346d97155d5f7476be08bed41"
+            "hash": "md5:58b553e346d97155d5f7476be08bed41",
+            "env_add_path": [
+                "bin",
+                "bin\\x64"
+            ]
         }
     },
     "installer": {
@@ -22,10 +26,6 @@
             "Get-ChildItem \"$dir\" -Exclude $names | Remove-Item -Recurse -Force"
         ]
     },
-    "env_add_path": [
-        "bin",
-        "bin\\x64"
-    ],
     "env_set": {
         "CUDA_PATH": "$dir"
     },


### PR DESCRIPTION
  CUDA 13.2.0 installs required runtime DLLs such as `cublas64_13.dll`, `cublasLt64_13.dll`, and `cudart64_13.dll` under `bin\x64`, but the current manifest only adds `bin` to `PATH`.

  This causes CUDA consumers such as `llama.cpp-cu131` to fail to load the CUDA backend unless `bin\x64` is added manually.

  This change adds `bin\x64` to `env_add_path` so the CUDA runtime DLLs are discoverable by default after `scoop install cuda`.