### PR TITLE
kimi-cli@1.28.0: Switch to onedir build

### DIFF
--- a/bucket/kimi-cli.json
+++ b/bucket/kimi-cli.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/MoonshotAI/kimi-cli/releases/download/1.28.0/kimi-1.28.0-x86_64-pc-windows-msvc-onedir.zip",
-            "hash": "3a8e089f068e3569e7a0f6400d29d62280e57376cdd11aa324e9b632d1e42e2d",
-            "extract_dir": "kimi"
+            "hash": "3a8e089f068e3569e7a0f6400d29d62280e57376cdd11aa324e9b632d1e42e2d"
         }
     },
+    "extract_dir": "kimi",
     "bin": "kimi.exe",
     "checkver": {
         "github": "https://github.com/MoonshotAI/kimi-cli"
@@ -17,8 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/MoonshotAI/kimi-cli/releases/download/$version/kimi-$version-x86_64-pc-windows-msvc-onedir.zip",
-                "extract_dir": "kimi"
+                "url": "https://github.com/MoonshotAI/kimi-cli/releases/download/$version/kimi-$version-x86_64-pc-windows-msvc-onedir.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

> Onedir stands for "one directory" because the goal is to provide a single directory containing all the executables that program needs. It includes the version of Python needed by program and its required dependencies.

Closes #7805

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)