### PR TITLE
meta-package-manager: Update to version 6.2.1, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/meta-package-manager.json
+++ b/bucket/meta-package-manager.json
@@ -1,12 +1,16 @@
 {
-    "version": "6.1.1",
+    "version": "6.2.1",
     "description": "Wraps all package managers with a unifying CLI",
     "homepage": "https://kdeldycke.github.io/meta-package-manager/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v6.1.1/mpm-windows-x64.exe#/mpm.exe",
-            "hash": "0a6de87e7c3b2771a9e4d1d59a3904c850c89ffedd1955632689bdb5e559dd9d"
+            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v6.2.1/mpm-6.2.1-windows-x64.exe#/mpm.exe",
+            "hash": "3edbaf472a6a154db6c2f9f33f935737eeead50a8a7159612ebe0ba930d3a47f"
+        },
+        "arm64": {
+            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v6.2.1/mpm-6.2.1-windows-arm64.exe#/mpm.exe",
+            "hash": "136d9410d3887b1023e30f9e31f6e3d054d117ebd08cf50d7d8f83f87a3c6b39"
         }
     },
     "bin": "mpm.exe",
@@ -16,7 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/mpm-windows-x64.exe#/mpm.exe"
+                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/mpm-$version-windows-x64.exe#/mpm.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/mpm-$version-windows-arm64.exe#/mpm.exe"
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Main/issues/7810

I am the author of Meta Package Manager and just noticed the update was not performed. Here is a fix with additional `arm64` support

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`                                                                                                        
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
