### PR TITLE
psmux: Add version 3.3.1

### DIFF
--- a/bucket/psmux.json
+++ b/bucket/psmux.json
@@ -1,7 +1,7 @@
 {
     "version": "3.3.1",
     "description": "Terminal multiplexer for Windows - tmux alternative for PowerShell and Windows Terminal",
-    "homepage": "https://github.com/psmux/psmux",
+    "homepage": "https://psmux.pages.dev",
     "license": "MIT",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
Adds psmux terminal multiplexer to the bucket. Copied straight from their own scoop bucket at https://github.com/psmux/scoop-psmux

Closes #7811

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 
