### PR TITLE
bbdown: Move `depends` to `suggest`, persist more files

### DIFF
--- a/bucket/bbdown.json
+++ b/bucket/bbdown.json
@@ -1,6 +1,6 @@
 {
     "version": "1.6.3",
-    "description": "一款命令行式哔哩哔哩下载器. Bilibili Downloader.",
+    "description": "A CLI-based Bilibili downloader.",
     "homepage": "https://github.com/nilaoda/BBDown",
     "license": "MIT",
     "suggest": {


### PR DESCRIPTION
Relates to https://github.com/ScoopInstaller/Main/discussions/7453
Closes https://github.com/ScoopInstaller/Main/issues/6877

### Changes
- Move `FFmpeg` from `depends` to `suggest`
- More files in `persist` and `pre_install`

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Changed FFmpeg from a required dependency to an optional suggestion, providing multiple implementation options for users to choose from.
  * Enhanced data persistence to handle additional application directories, ensuring more comprehensive data backup and recovery across multiple BBDown-related folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->