### PR TITLE
podman@5.8.1: Add arm64 support

### DIFF
--- a/bucket/podman.json
+++ b/bucket/podman.json
@@ -5,11 +5,11 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/containers/podman/releases/download/v5.8.1/podman-installer-windows-amd64.exe#/podman-5.8.1-setup.exe",
+            "url": "https://github.com/containers/podman/releases/download/v5.8.1/podman-installer-windows-amd64.exe",
             "hash": "7b66b6caa88d070f5454d6effa7bbc7387b964f6d0d97df320f04ccca205ffe1"
         },
         "arm64": {
-            "url": "https://github.com/containers/podman/releases/download/v5.8.1/podman-installer-windows-arm64.exe#/podman-5.8.1-setup.exe",
+            "url": "https://github.com/containers/podman/releases/download/v5.8.1/podman-installer-windows-arm64.exe",
             "hash": "c8bb636ed7f180b700ad127aaec4a045c2e4dc6a8402e3275081b055d09dde9d"
         }
     },
@@ -33,7 +33,7 @@
     ],
     "installer": {
         "script": [
-            "Expand-DarkArchive \"$dir\\podman-$version-setup.exe\" \"$dir\\_tmp\" -Removal",
+            "Expand-DarkArchive \"$dir\\$fname\" \"$dir\\_tmp\" -Removal",
             "Expand-MsiArchive \"$dir\\_tmp\\AttachedContainer\\podman.msi\" \"$dir\" -ExtractDir 'PFiles64\\RedHat\\Podman'"
         ]
     },
@@ -80,10 +80,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/containers/podman/releases/download/v$version/podman-installer-windows-amd64.exe#/podman-$version-setup.exe"
+                "url": "https://github.com/containers/podman/releases/download/v$version/podman-installer-windows-amd64.exe"
             },
             "arm64": {
-                "url": "https://github.com/containers/podman/releases/download/v$version/podman-installer-windows-arm64.exe#/podman-$version-setup.exe"
+                "url": "https://github.com/containers/podman/releases/download/v$version/podman-installer-windows-arm64.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Podman provides both amd64 and arm64 builds for Windows. This pull request adds arm64 architecture to podman.json. There is no change to the installation script.

PS: podman-$version-setup.exe is the same file as podman-installer-windows-amd64.exe, as shown by the same checksum.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
