### PR TITLE
docker-compose@5.1.1: Add arm64 support

### DIFF
--- a/bucket/docker-compose.json
+++ b/bucket/docker-compose.json
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/docker/compose/releases/download/v5.1.1/docker-compose-windows-x86_64.exe#/docker-compose.exe",
             "hash": "f7ad2f6965c88153e4902019ec86e95414f0025cba0b6440f328f935a1f8b12b"
+        },
+        "arm64": {
+            "url": "https://github.com/docker/compose/releases/download/v5.1.1/docker-compose-windows-aarch64.exe#/docker-compose.exe",
+            "hash": "2c42d7600886bb56d9bb009f348b4f7f8c603c954c7b07be3d53b3218877ce4a"
         }
     },
     "bin": "docker-compose.exe",
@@ -21,6 +25,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/docker/compose/releases/download/v$version/docker-compose-windows-x86_64.exe#/docker-compose.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/docker/compose/releases/download/v$version/docker-compose-windows-aarch64.exe#/docker-compose.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
docker-compose provides both x86_64 and arm64 builds for Windows. This pull request adds arm64 architecture to docker-compose.json. There is no change to the installation script.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
