### PR TITLE
noti: Migrate to Codeberg releases

### DIFF
--- a/bucket/noti.json
+++ b/bucket/noti.json
@@ -3,11 +3,6 @@
     "description": "Monitor a process and trigger a notification.",
     "homepage": "https://codeberg.org/roble/noti",
     "license": "MIT",
-    "checkver": {
-        "url": "https://codeberg.org/api/v1/repos/roble/noti/releases/latest",
-        "jsonpath": "$.tag_name",
-        "regex": "([\\d.]+)"
-    },
     "architecture": {
         "64bit": {
             "url": "https://codeberg.org/roble/noti/releases/download/3.8.0/noti3.8.0.windows-amd64.tar.gz",
@@ -15,6 +10,11 @@
         }
     },
     "bin": "noti.exe",
+    "checkver": {
+        "url": "https://codeberg.org/api/v1/repos/roble/noti/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "([\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

---

The noti project is moving to Codeberg. This change updates where Scoop fetches the source code from to point to the new home at Codeberg.

The notice on the old home is here: https://github.com/variadico/noti?tab=readme-ov-file#notice-noti-is-moving-to-codebergorgroblenoti-

The new home is here: https://codeberg.org/roble/noti