### PR TITLE
gum: Update to version 0.14.0, fix autoupdate

### DIFF
--- a/bucket/gum.json
+++ b/bucket/gum.json
@@ -1,31 +1,38 @@
 {
-    "version": "0.13.0",
+    "version": "0.14.0",
     "description": "Gradle/Maven wrapper",
     "homepage": "https://github.com/kordamp/gm",
-    "license": "Apache-2.0",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://github.com/kordamp/gm/blob/HEAD/LICENSE"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kordamp/gm/releases/download/v0.13.0/gm_Windows_x86_64.zip",
-            "hash": "sha512:3b41a9547d07a0485f9b5b01e05e278fc75e6d440ff384484557bd5793e4541ce5935b8852807dfb93774899bd87f9d8cc776fd3754ec3eb1d0ff628c1d0f2e6"
+            "url": "https://github.com/kordamp/gm/releases/download/v0.14.0/gm-0.14.0-windows-amd64.zip",
+            "hash": "sha512:4a49a4e6626390f7440b19dec01c4d880576ff0c2947e15c5c9eae81d7be5e79c4ffe9f84f3aedbbf05487ef94ab65ae0a568fcea51e6abe4e47161551023c76",
+            "extract_dir": "gm-0.14.0-windows-amd64"
         },
-        "32bit": {
-            "url": "https://github.com/kordamp/gm/releases/download/v0.13.0/gm_Windows_i386.zip",
-            "hash": "sha512:76ba73fe90c34b06e8c94c0e095904371a44d9c2410b75345a8a69c837d42733b90f3879774ef0d99ddda67f9b12375bd4ebe2cb5df7aab0708225394b4530cb"
+        "arm64": {
+            "url": "https://github.com/kordamp/gm/releases/download/v0.14.0/gm-0.14.0-windows-arm64.zip",
+            "hash": "sha512:9e2ef825395ce0dc64411def6bc274e83f2aec444c10ab54dc5e45bd47353f1be00bccc597ae7083af9023b588cece0fef5c64229bc42774fd394af69f0645fa",
+            "extract_dir": "gm-0.14.0-windows-arm64"
         }
     },
-    "bin": "gm.exe",
+    "bin": "bin\\gm.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kordamp/gm/releases/download/v$version/gm_Windows_x86_64.zip"
+                "url": "https://github.com/kordamp/gm/releases/download/v$version/gm-$version-windows-amd64.zip",
+                "extract_dir": "gm-$version-windows-amd64"
             },
-            "32bit": {
-                "url": "https://github.com/kordamp/gm/releases/download/v$version/gm_Windows_i386.zip"
+            "arm64": {
+                "url": "https://github.com/kordamp/gm/releases/download/v$version/gm-$version-windows-arm64.zip",
+                "extract_dir": "gm-$version-windows-arm64"
             }
         },
         "hash": {
-            "url": "$baseurl/checksums.txt"
+            "url": "$baseurl/checksums_sha512.txt"
         }
     }
 }


### PR DESCRIPTION
### Summary

Updates `gum` (Gradle/Maven wrapper) to version **0.14.0** and adjusts the manifest to match the new upstream release structure.

### Related issues or pull requests

- Relates to #7394 

### Changes

- Update version to **0.14.0**
- Modernize `license` field with a structured object including SPDX identifier and URL
- **Architecture adjustment**: Remove `32bit` support and add `arm64` support to align with upstream releases
- **Directory structure update**: 
  - Add `extract_dir` as the new release archives now contain a nested root folder
  - Update `bin` path from `gm.exe` to `bin\gm.exe` to reflect the internal folder layout
- Update `autoupdate` logic to track the new naming convention and use `checksums_sha512.txt` for hash verification

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App gum -Dir '' -f
gum: 0.14.0 (scoop version is 0.14.0)
Forcing autoupdate!
Autoupdating gum
DEBUG[1775301974] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1775301974] $substitutions.$cleanVersion                  0140
DEBUG[1775301974] $substitutions.$buildVersion
DEBUG[1775301974] $substitutions.$basename                      gm-0.14.0-windows-arm64.zip
DEBUG[1775301974] $substitutions.$minorVersion                  14
DEBUG[1775301974] $substitutions.$patchVersion                  0
DEBUG[1775301974] $substitutions.$dashVersion                   0-14-0
DEBUG[1775301974] $substitutions.$version                       0.14.0
DEBUG[1775301974] $substitutions.$dotVersion                    0.14.0
DEBUG[1775301974] $substitutions.$underscoreVersion             0_14_0
DEBUG[1775301974] $substitutions.$majorVersion                  0
DEBUG[1775301974] $substitutions.$preReleaseVersion             0.14.0
DEBUG[1775301974] $substitutions.$matchTail
DEBUG[1775301974] $substitutions.$url                           https://github.com/kordamp/gm/releases/download/v0.14.0/gm-0.14.0-windows-arm64.zip
DEBUG[1775301974] $substitutions.$match1                        0.14.0
DEBUG[1775301974] $substitutions.$urlNoExt                      https://github.com/kordamp/gm/releases/download/v0.14.0/gm-0.14.0-windows-arm64
DEBUG[1775301974] $substitutions.$baseurl                       https://github.com/kordamp/gm/releases/download/v0.14.0
DEBUG[1775301974] $substitutions.$basenameNoExt                 gm-0.14.0-windows-arm64
DEBUG[1775301974] $substitutions.$matchHead                     0.14.0
DEBUG[1775301974] $hashfile_url = https://github.com/kordamp/gm/releases/download/v0.14.0/checksums_sha512.txt -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for gm-0.14.0-windows-arm64.zip in https://github.com/kordamp/gm/releases/download/v0.14.0/checksums_sha512.txt
DEBUG[1775301975] $filenameRegex = ([a-fA-F0-9]{32,128})[\x20\t]+.*gm-0\.14\.0-windows-arm64\.zip(?:\s|$)|gm-0\.14\.0-windows-arm64\.zip[\x20\t]+.*?([a-fA-F0-9]{32,128}) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:101:13
Found: sha512:9e2ef825395ce0dc64411def6bc274e83f2aec444c10ab54dc5e45bd47353f1be00bccc597ae7083af9023b588cece0fef5c64229bc42774fd394af69f0645fa using Extract Mode
Writing updated gum manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/gum --arch arm64
Installing 'gum' (0.14.0) [arm64] from 'Unofficial' bucket
Loading gm-0.14.0-windows-arm64.zip from cache.
Checking hash of gm-0.14.0-windows-arm64.zip... OK.
Extracting gm-0.14.0-windows-arm64.zip... Done.
Linking D:\Software\Scoop\Local\apps\gum\current => D:\Software\Scoop\Local\apps\gum\0.14.0
Creating shim for 'gm'.
'gum' (0.14.0) was installed successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)