### PR TITLE
ant: Update to version 1.10.16, fix checkver

### DIFF
--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -35,8 +35,8 @@
         ]
     },
     "checkver": {
-        "url": "https://dlcdn.apache.org//ant/README.html",
-        "regex": "Release Notes of Apache Ant ([\\d.]+)"
+        "url": "https://ant.apache.org/bindownload.cgi",
+        "regex": "apache-ant-(?<version>[\\d.]+)-bin\\.zip"
     },
     "autoupdate": {
         "url": "https://dlcdn.apache.org//ant/binaries/apache-ant-$version-bin.zip",


### PR DESCRIPTION
The 1.10.15 binaries have been removed from the server so the current manifest is broken.  If there's a scheduled auto-update then it's not picking up the new version.  Raising this PR to get the new version live.  Feel free to reject if someone can manually trigger the auto-update.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
