### PR TITLE
bun: Update to version 1.3.12

### DIFF
--- a/bucket/bun.json
+++ b/bucket/bun.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.11",
+    "version": "1.3.12",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,17 +9,17 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/oven-sh/bun/releases/download/bun-v1.3.11/bun-windows-x64.zip",
-                "https://github.com/oven-sh/bun/releases/download/bun-v1.3.11/bun-windows-x64-baseline.zip"
+                "https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-x64.zip",
+                "https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-x64-baseline.zip"
             ],
             "hash": [
-                "066f8694f8b7d8df592452746d18f01710d4053e93030922dbc6e8c34a8c4b9f",
-                "9d0e0f923e9626f3bc6044fc32e0d3ab29039aea753f5678ef8801cf26f75288"
+                "841ff9c5dffcaa3a2620d1e3f87ee500f32a4ca830b001cade7a3479609d4a89",
+                "2d3d5f88a95943563f56f3643c8f4e2422261018f6d915329bb2fb33f7256ba2"
             ]
         },
         "arm64": {
-            "url": "https://github.com/oven-sh/bun/releases/download/bun-v1.3.11/bun-windows-aarch64.zip",
-            "hash": "c7f661d7529ec3f2fdfc1eac39a760c65f526955bce06b74859c532cb4bf00d7"
+            "url": "https://github.com/oven-sh/bun/releases/download/bun-v1.3.12/bun-windows-aarch64.zip",
+            "hash": "6cac24eab41e8d7e6b39b4dd3b4bca5ea0d11a1f43f94126bdff6e849f9f7f51"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Closes #7849

- update `bun` to `1.3.12`
- refresh Windows x64, x64-baseline, and arm64 hashes