### PR TITLE
xdelta@3.1.0: Use aliases instead of renaming binaries

### DIFF
--- a/bucket/xdelta.json
+++ b/bucket/xdelta.json
@@ -6,13 +6,64 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v3.1.0/xdelta3-3.1.0-x86_64.exe.zip",
-            "hash": "b10e0d1df3e212e5a2d37d5c088d2f72ecec760bc3c26caeca51499c3118b93a"
+            "hash": "b10e0d1df3e212e5a2d37d5c088d2f72ecec760bc3c26caeca51499c3118b93a",
+            "bin": [
+                [
+                    "xdelta3-3.1.0-x86_64.exe",
+                    "xdelta3"
+                ],
+                [
+                    "xdelta3-3.1.0-x86_64.exe",
+                    "xdelta"
+                ]
+            ]
         },
         "32bit": {
             "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v3.1.0/xdelta3-3.1.0-i686.exe.zip",
-            "hash": "1e72f920dbae1b4edc7be0feba841d78fb06ad38b67630e99d5ff655d8c5d62f"
+            "hash": "1e72f920dbae1b4edc7be0feba841d78fb06ad38b67630e99d5ff655d8c5d62f",
+            "bin": [
+                [
+                    "xdelta3-3.1.0-i686.exe",
+                    "xdelta3"
+                ],
+                [
+                    "xdelta3-3.1.0-i686.exe",
+                    "xdelta"
+                ]
+            ]
         }
     },
-    "pre_install": "Get-ChildItem \"$dir\\xdelta3-*.exe\" | Rename-Item -NewName 'xdelta.exe'",
-    "bin": "xdelta.exe"
+    "checkver": {
+        "github": "https://github.com/jmacd/xdelta-gpl"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v$version/xdelta3-$version-x86_64.exe.zip",
+                "bin": [
+                    [
+                        "xdelta3-$version-x86_64.exe",
+                        "xdelta3"
+                    ],
+                    [
+                        "xdelta3-$version-x86_64.exe",
+                        "xdelta"
+                    ]
+                ]
+            },
+            "32bit": {
+                "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v$version/xdelta3-$version-i686.exe.zip",
+                "bin": [
+                    [
+                        "xdelta3-$version-i686.exe",
+                        "xdelta3"
+                    ],
+                    [
+                        "xdelta3-$version-i686.exe",
+                        "xdelta"
+                    ]
+                ]
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- Fixed Aliases
	- Removed executable rename 
- Added the checkver (useless given that there haven't been any releases in years, but since I was at it, I went ahead and did it)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Closes #7851

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
