### PR TITLE
mingw-mstorsjo-llvm-msvcrt: Add version 22.1.3-20260407

### DIFF
--- a/bucket/mingw-mstorsjo-llvm-msvcrt.json
+++ b/bucket/mingw-mstorsjo-llvm-msvcrt.json
@@ -1,0 +1,37 @@
+{
+    "version": "22.1.3-20260407",
+    "description": "LLVM toolchain based on mingw-w64. (MSVCRT, mstorsjo build)",
+    "homepage": "https://github.com/mstorsjo/llvm-mingw/",
+    "license": "GPL-3.0-or-later,ZPL-2.1,Apache-2.0 WITH LLVM-exception,ISC",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/20260407/llvm-mingw-20260407-msvcrt-x86_64.zip",
+            "hash": "4bd6d5ebe087e911a9a570a204f5fb7711ca6c5572c086adaee08e0f189941af",
+            "extract_dir": "llvm-mingw-20260407-msvcrt-x86_64"
+        },
+        "32bit": {
+            "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/20260407/llvm-mingw-20260407-msvcrt-i686.zip",
+            "hash": "133770d89c1a8879de8b168fb1c662d2090122360e8e7a210645b608a378d71d",
+            "extract_dir": "llvm-mingw-20260407-msvcrt-i686"
+        }
+    },
+    "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
+    "env_add_path": "bin",
+    "checkver": {
+        "github": "https://github.com/mstorsjo/llvm-mingw/",
+        "regex": "llvm-mingw\\s+(?<time>\\d+)\\swith\\s+LLVM\\s+(?<llvm>[\\d.]+)",
+        "replace": "${llvm}-${time}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/$matchTime/llvm-mingw-$matchTime-msvcrt-x86_64.zip",
+                "extract_dir": "llvm-mingw-$matchTime-msvcrt-x86_64"
+            },
+            "32bit": {
+                "url": "https://github.com/mstorsjo/llvm-mingw/releases/download/$matchTime/llvm-mingw-$matchTime-msvcrt-i686.zip",
+                "extract_dir": "llvm-mingw-$matchTime-msvcrt-i686"
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description
Add `mingw-mstorsjo-llvm-msvcrt` manifest, providing an MSVCRT-based LLVM-MinGW toolchain.

#### Motivation and Context
The existing `llvm-mingw-ucrt` manifest uses the newer UCRT runtime. For development scenarios that require compatibility with older Windows systems (e.g., Windows 7), the MSVCRT version is necessary. This PR fills that gap and provides users with an additional option.

#### How Has This Been Tested?
- [x] Tested locally on Windows 10 x64 via `scoop install ./mingw-mstorsjo-llvm-msvcrt.json`
- [x] Verified `clang --version` works correctly
- [x] Confirmed URL and SHA256 hashes match official release

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured the manifest follows the required field order.
- [x] I have tested the manifest locally.
- [x] I have confirmed `autoupdate` works correctly.