### PR TITLE
crystal: Update to version 1.20.0-1, fix checkver & autoupdate

### DIFF
--- a/bucket/crystal.json
+++ b/bucket/crystal.json
@@ -26,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/crystal-lang/crystal/releases/download/$version/crystal-$version-windows-x86_64-msvc-unsupported.zip"
+                "url": "https://github.com/crystal-lang/crystal/releases/download/$version/crystal-$version-1-windows-x86_64-msvc-unsupported.zip"
             }
         }
     }

--- a/bucket/crystal.json
+++ b/bucket/crystal.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.19.1",
+    "version": "1.20.0-1",
     "description": "The Crystal Programming Language",
     "homepage": "https://www.crystal-lang.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-windows-x86_64-msvc-unsupported.zip",
-            "hash": "c01932aab890c442d7d66de67c7a51d9c815b3b8529fc4adbb1907205fea138a"
+            "url": "https://github.com/crystal-lang/crystal/releases/download/1.20.0/crystal-1.20.0-1-windows-x86_64-msvc-unsupported.zip",
+            "hash": "aaedf29c2baa57435aa65e95549b134b4a86e19b2654a1d0c1b794b66fb54a02"
         }
     },
     "bin": [
@@ -21,12 +21,13 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/crystal-lang/crystal"
+        "github": "https://github.com/crystal-lang/crystal",
+        "regex": "crystal-(?<version>[\\d.-]+)-windows-x86_64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/crystal-lang/crystal/releases/download/$version/crystal-$version-1-windows-x86_64-msvc-unsupported.zip"
+                "url": "https://github.com/crystal-lang/crystal/releases/download/$matchHead/crystal-$version-windows-x86_64-msvc-unsupported.zip"
             }
         }
     }


### PR DESCRIPTION
Crystal language version 1.20.0 was released yesterday, however the release file name format has changed since 1.19.1 which breaks autoupdate with a 404 Not Found error, see excerpt from excavator job: https://github.com/ScoopInstaller/Main/actions/runs/24597420567/job/71930055815#step:3:587

```
crystal: 1.20.0 (scoop version is 1.19.1) autoupdate available
Autoupdating crystal
Could not find hash in https://api.github.com/repos/crystal-lang/crystal/releases
Downloading crystal-1.20.0-windows-x86_64-msvc-unsupported.zip to compute hashes!
VERBOSE: Requested HTTP/1.1 GET with 0-byte payload
VERBOSE: Received HTTP/1.1 response of content type application/json of unknown size
VERBOSE: Content encoding: utf-8
The remote server returned an error: (404) Not Found.
URL https://github.com/crystal-lang/crystal/releases/download/1.20.0/crystal-1.20.0-windows-x86_64-msvc-unsupported.zip is not valid
ERROR Could not update crystal, hash for crystal-1.20.0-windows-x86_64-msvc-unsupported.zip failed!
```

Updates the autoupdate URL to match the new 1.20.0 release download file name format.

Fixes #7874.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
