### PR TITLE
doscript: Add version 0.6.13

### DIFF
--- a/bucket/bucket/doscript.json
+++ b/bucket/bucket/doscript.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.6.13",
+  "description": "DoScript — Automation for Humans",
+  "homepage": "https://github.com/TheServer-lab/DoScript",
+  "license": {
+    "identifier": "SOCL",
+    "url": "https://github.com/TheServer-lab/DoScript/blob/main/LICENSE"
+  },
+  "url": "https://github.com/TheServer-lab/DoScript/releases/download/v0.6.13/doscript-portable.zip",
+  "hash": "E49703D56CDFC4A91935F381FF0DE3829DBB47A51C4EB0C61D5A507DA2E76325",
+  "bin": "do.exe",
+  "checkver": {
+    "github": "TheServer-lab/DoScript"
+  },
+  "autoupdate": {
+    "url": "https://github.com/TheServer-lab/DoScript/releases/download/v$version/doscript-portable.zip"
+  }
+}


### PR DESCRIPTION
DoScript — Automation for Humans

GitHub: https://github.com/TheServer-lab/DoScript

A portable CLI scripting tool for system automation.
Closes #7889

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
