### PR TITLE
megacmd@2.5.2: Add shim for `mega-proxy`

### DIFF
--- a/bucket/megacmd.json
+++ b/bucket/megacmd.json
@@ -82,6 +82,7 @@
         "mega-mv.bat",
         "mega-passwd.bat",
         "mega-preview.bat",
+        "mega-proxy.bat",
         "mega-put.bat",
         "mega-pwd.bat",
         "mega-quit.bat",


### PR DESCRIPTION
This adds a shim that was missing, which invokes the mega-proxy.bat file included with MEGAcmd.

The command's documentation is located here: https://github.com/meganz/MEGAcmd/blob/master/contrib/docs/commands/proxy.md

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)