### PR TITLE
megatools@1.11.5.20250706: Fix URLs

### DIFF
--- a/bucket/megatools.json
+++ b/bucket/megatools.json
@@ -1,16 +1,16 @@
 {
     "version": "1.11.5.20250706",
     "description": "Collection of programs for accessing Mega.nz service from a command line.",
-    "homepage": "https://megatools.megous.com/",
+    "homepage": "https://xff.cz/megatools",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://megatools.megous.com/builds/builds/megatools-1.11.5.20250706-win64.zip",
+            "url": "https://xff.cz/megatools/builds/builds/megatools-1.11.5.20250706-win64.zip",
             "hash": "bd1269e50d9c45e369c14e287c1754c9506e1b11efcc0cd4bb95d460c9d782b5",
             "extract_dir": "megatools-1.11.5.20250706-win64"
         },
         "32bit": {
-            "url": "https://megatools.megous.com/builds/builds/megatools-1.11.5.20250706-win32.zip",
+            "url": "https://xff.cz/megatools/builds/builds/megatools-1.11.5.20250706-win32.zip",
             "hash": "b226ad80f52b786abeeaea70bb2ce87bd445d3750c1dea0906d0de939428e09f",
             "extract_dir": "megatools-1.11.5.20250706-win32"
         }
@@ -18,17 +18,17 @@
     "bin": "megatools.exe",
     "persist": "mega.ini",
     "checkver": {
-        "url": "https://megatools.megous.com/builds/LATEST",
+        "url": "https://xff.cz/megatools/builds/LATEST",
         "regex": "megatools-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://megatools.megous.com/builds/builds/megatools-$version-win64.zip",
+                "url": "https://xff.cz/megatools/builds/builds/megatools-$version-win64.zip",
                 "extract_dir": "megatools-$version-win64"
             },
             "32bit": {
-                "url": "https://megatools.megous.com/builds/builds/megatools-$version-win32.zip",
+                "url": "https://xff.cz/megatools/builds/builds/megatools-$version-win32.zip",
                 "extract_dir": "megatools-$version-win32"
             }
         }


### PR DESCRIPTION
The dev's migration to https://xff.cz/megatools was gradual but now everything related to megatools is found solely on there. https://megatools.megous.com no longer works.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)