### PR TITLE
probe-rs: Add shim for `cargo-embed` & `cargo-flash`

### DIFF
--- a/bucket/probe-rs.json
+++ b/bucket/probe-rs.json
@@ -19,6 +19,8 @@
     },
     "bin": [
         "probe-rs.exe",
+        "cargo-embed.exe",
+        "cargo-flash.exe",
         "rtthost.exe",
         "target-gen.exe"
     ],


### PR DESCRIPTION
cargo-flash and cargo-embed can no longer be installed with `cargo install ...` and are now provided with the probe-rs package directly. Both needs to be added in the bin array.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
