### PR TITLE
winpython@3.13.12.0: Fix extract_dir

### DIFF
--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -8,7 +8,7 @@
         "64bit": {
             "url": "https://sourceforge.net/projects/winpython/WinPython_3.13/3.13.12.0/WinPython64-3.13.12.0slim.7z",
             "hash": "00c5f73ec434bbc7c3450fc18cfd55fba050407153ee43637ac7a00f253b99d2",
-            "extract_dir": "WPy64-313120"
+            "extract_dir": "WPy64-3.13.12.0"
         }
     },
     "bin": [
@@ -95,7 +95,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://sourceforge.net/projects/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionslim.7z",
-                "extract_dir": "WPy64-$cleanVersion"
+                "extract_dir": "WPy64-$version"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

WinPython changes their zip file struct, this PR change the extract_dir from `WPy64-$cleanVersion` to `WPy64-$version`.

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
