### PR TITLE
perry: Add version 0.5.386

### DIFF
--- a/bucket/perry.json
+++ b/bucket/perry.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.5.386",
+    "description": "Native TypeScript compiler — compiles .ts directly to native executables via LLVM.",
+    "homepage": "https://github.com/PerryTS/perry",
+    "license": "MIT",
+    "notes": [
+        "Perry shells out to clang for the IR -> object step. The 'main/llvm'",
+        "dependency installs the official MSVC-default LLVM, which Perry needs",
+        "for Windows-native object emission. If you have multiple clangs on PATH,",
+        "set PERRY_LLVM_CLANG to the full path of an MSVC-default clang.exe.",
+        "",
+        "Verify with: perry doctor",
+        "First compile: perry compile hello.ts -o hello.exe"
+    ],
+    "depends": "main/llvm",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/PerryTS/perry/releases/download/v0.5.386/perry-windows-x86_64.zip",
+            "hash": "8c833333ac5ee4279087b6fda1e1b3b01386da0cfe7d61467d3cb27147d284f4"
+        }
+    },
+    "bin": "perry.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/PerryTS/perry/releases/download/v$version/perry-windows-x86_64.zip",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/perry.json
+++ b/bucket/perry.json
@@ -1,7 +1,7 @@
 {
     "version": "0.5.386",
     "description": "Native TypeScript compiler — compiles .ts directly to native executables via LLVM.",
-    "homepage": "https://github.com/PerryTS/perry",
+    "homepage": "https://www.perryts.com",
     "license": "MIT",
     "notes": [
         "Perry shells out to clang for the IR -> object step. The 'main/llvm'",
@@ -20,7 +20,9 @@
         }
     },
     "bin": "perry.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/PerryTS/perry"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Relates to:
- https://github.com/ScoopInstaller/Extras/pull/17718

Adds a Scoop manifest for [Perry](https://github.com/PerryTS/perry) — native CLI TypeScript compiler that emits standalone native executables via LLVM. MIT, 1924 ★, 354+ patch releases since 2026-01-19.

### Redirected from Extras

Originally filed as ScoopInstaller/Main#7908 / ScoopInstaller/Extras#17718 — @z-Fng [reviewed it there](https://github.com/ScoopInstaller/Extras/pull/17718#issuecomment-4351718410) and noted that as a CLI tool it belongs in the Main bucket per the [main-bucket criteria](https://github.com/ScoopInstaller/Scoop/wiki/Criteria-for-including-apps-in-the-main-bucket). Manifest already passed the Extras `/verify` CI run (Lint / Description / License / Hashes / Checkver / Autoupdate / Autoupdate Hash Extraction — all ✓).

### Main bucket criteria

- [x] **Reasonably well-known and widely used developer tool** — 1924 ★, 46 forks (short of the 150-fork guideline but well above the 500-star threshold; @z-Fng's redirect from Extras → Main was the maintainer's call)
- [x] **Latest stable version** — v0.5.386 (auto-bumped from v0.5.345 by Scoop's checkver bot during the Extras PR review)
- [x] **Full version, not trial** — MIT, no paywall, no trial period
- [x] **Fairly standard install** — version-specific download URL, no pre/post install scripts
- [x] **Non-GUI tool** — pure CLI (`perry compile foo.ts -o foo.exe`)

### Manifest highlights

- `depends: "main/llvm"` — Perry shells out to clang for IR→object emission. The hard dependency on the official MSVC-default LLVM means the install works end-to-end out of the box; without it, users with MinGW-flavored clang on PATH hit a `LNK2019: __main` link error (a class of bug we just patched upstream in v0.5.353, but the dep makes it impossible to hit at all).
- `checkver: "github"` — standard shortcut.
- `autoupdate.architecture.64bit.hash.url: "$url.sha256"` — Perry's release workflow uploads `.sha256` sidecars next to every archive, so future bumps resolve hashes by URL automatically (verified — v0.5.386 already has the sidecar asset attached).

### Verified end-to-end

Tested locally on Windows 11 x64 against the prior v0.5.345 pin:

```
> scoop install <fork>/perry
... pulls 7zip + LLVM 22.1.4 + perry-windows-x86_64.zip (111 MB)
... hash check passes
> perry --version
perry 0.5.345
> perry doctor
[OK] perry version: 0.5.345
[OK] clang (LLVM codegen): clang version 22.1.3
[OK] runtime library: ~/scoop/apps/perry/current/perry_runtime.lib
> perry compile smoke.ts -o smoke.exe && ./smoke.exe
hello from scoop-installed perry
> scoop uninstall perry
... cleanly removes shim + install dir
```

The same manifest is also live in the project's own bucket at https://github.com/PerryTS/perry/tree/main/bucket as `perry-ts/perry`.

---

- [x] Use conventional PR title: `perry: Add version 0.5.386`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
