### PR TITLE
kiro-cli: Add version 2.2.0

### DIFF
--- a/bucket/kiro-cli.json
+++ b/bucket/kiro-cli.json
@@ -1,5 +1,4 @@
 {
-    "##": "Original source script provided by Amazon => https://cli.kiro.dev/install.ps1",
     "version": "2.2.0",
     "description": "A CLI utility developed by Amazon that allows you to interact with Kiro's AI agents directly from your terminal.",
     "homepage": "https://kiro.dev/cli/",
@@ -13,6 +12,7 @@
             "hash": "bd95c91d9e8b4bf7b796142b0edb517169ebcc18b1f578b056736660e09bea3d"
         }
     },
+    "extract_dir": "LocalApp\\Kiro-Cli",
     "bin": "kiro-cli.exe",
     "checkver": {
         "url": "https://prod.download.cli.kiro.dev/stable/latest/manifest.json",
@@ -21,9 +21,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://prod.download.cli.kiro.dev/stable/$version/kiro-cli-x86_64-pc-windows-msvc.msi"
+                "url": "https://prod.download.cli.kiro.dev/stable/$version/kiro-cli-x86_64-pc-windows-msvc.msi",
+                "hash": {
+                    "url": "https://prod.download.cli.kiro.dev/stable/latest/manifest.json",
+                    "jsonpath": "$.packages[?(@.targetTriple == 'x86_64-pc-windows-msvc')].sha256"
+                }
             }
         }
-    },
-    "extract_dir": "LocalApp/Kiro-Cli"
+    }
 }

--- a/bucket/kiro-cli.json
+++ b/bucket/kiro-cli.json
@@ -1,0 +1,29 @@
+{
+    "##": "Original source script provided by Amazon => https://cli.kiro.dev/install.ps1",
+    "version": "2.2.0",
+    "description": "A CLI utility developed by Amazon that allows you to interact with Kiro's AI agents directly from your terminal.",
+    "homepage": "https://kiro.dev/cli/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://kiro.dev/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://prod.download.cli.kiro.dev/stable/2.2.0/kiro-cli-x86_64-pc-windows-msvc.msi",
+            "hash": "bd95c91d9e8b4bf7b796142b0edb517169ebcc18b1f578b056736660e09bea3d"
+        }
+    },
+    "bin": "kiro-cli.exe",
+    "checkver": {
+        "url": "https://prod.download.cli.kiro.dev/stable/latest/manifest.json",
+        "jsonpath": "$.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://prod.download.cli.kiro.dev/stable/$version/kiro-cli-x86_64-pc-windows-msvc.msi"
+            }
+        }
+    },
+    "extract_dir": "LocalApp/Kiro-Cli"
+}


### PR DESCRIPTION
Copied from a [misattributed PR on the Extras bucket](https://github.com/ScoopInstaller/Extras/pull/17720). My bad.

## To The Maintainers

I want to open with an apology for jumping the gun on the submission. I know the contribution guide says to wait for an issue approval by one of the maintainers, but I wanted to use it at work, so I went ahead and created the manifest.

## Summary of Work

Recently, Amazon has released their Kiro CLI for Windows. The standard command they provide is a typical PowerShell one-liner not unlike Scoop itself:

```powershell
# From => https://kiro.dev/cli/
irm 'https://cli.kiro.dev/install.ps1' | iex
```

Upon inspecting the script, it provides a typical JSON manifest that can be used to determine the metadata for integrating with Scoop, including a SHA-256 file hash for validation. I just mapped these elements onto a Scoop manifest, verified it worked on my local machine, as well as a small tweak using `extract_dir` to reduce nesting of the binary, and it's effectively done.

I'm open to suggestions for improvements.

Closes #7909 

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
