### PR TITLE
trid: Simplify checkver regex

### DIFF
--- a/bucket/trid.json
+++ b/bucket/trid.json
@@ -15,11 +15,13 @@
             ]
         }
     },
-    "pre_install": "Expand-InnoArchive -Path \"$dir\\TrID_setup.exe\" -DestinationPath $dir -Removal",
+    "installer": {
+        "script": "Expand-InnoArchive -Path \"$dir\\TrID_setup.exe\" -Removal"
+    },
     "bin": "trid.exe",
     "checkver": {
-        "regex": "(?smi)Win32.*?TrID v([\\d\\.]*).*?(\\d{2})\\/(\\d{2})\\/(\\d{2})",
-        "replace": "${1}-${4}.${3}.${2}"
+        "regex": "(?si)Win/x86-64.+?TrID v?([\\d.]+).+?(?<day>\\d{2})/(?<month>\\d{2})/(?<year>\\d+)",
+        "replace": "${1}-${year}.${month}.${day}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
### Summary

Refactors the `trid` manifest to use the standard `installer` block and improves the `checkver` regex for more robust version parsing.

### Changes

- Migrate extraction logic from `pre_install` to `installer.script` for better manifest structure
- Update `checkver` regex to support 64-bit strings and implement named capture groups (`day`, `month`, `year`)
- Refine regex flags to `(?si)` and ensure the versioning scheme matches the expected format

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Main][ trid ≢  ~1]
└─> .\bin\checkver.ps1 -App '.\bucket\trid.json' -f
trid: 2.47-26.04.30 (scoop version is 2.47-26.04.30)
Forcing autoupdate!
Autoupdating trid
DEBUG[1777622849] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1777622849] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1777622849] $substitutions.$matchHead                     2.47
DEBUG[1777622849] $substitutions.$matchTail                     -26.04.30
DEBUG[1777622849] $substitutions.$minorVersion                  47
DEBUG[1777622849] $substitutions.$baseurl                       https://www.mark0.net/download
DEBUG[1777622849] $substitutions.$majorVersion                  2
DEBUG[1777622849] $substitutions.$buildVersion                  
DEBUG[1777622849] $substitutions.$dashVersion                   2-47-26-04-30
DEBUG[1777622849] $substitutions.$underscoreVersion             2_47_26_04_30
DEBUG[1777622849] $substitutions.$version                       2.47-26.04.30
DEBUG[1777622849] $substitutions.$preReleaseVersion             26.04.30
DEBUG[1777622849] $substitutions.$dotVersion                    2.47.26.04.30
DEBUG[1777622849] $substitutions.$urlNoExt                      https://www.mark0.net/download/triddefs
DEBUG[1777622849] $substitutions.$matchDay                      30
DEBUG[1777622849] $substitutions.$cleanVersion                  247260430
DEBUG[1777622849] $substitutions.$basenameNoExt                 triddefs
DEBUG[1777622849] $substitutions.$basename                      triddefs.zip
DEBUG[1777622849] $substitutions.$match1                        2.47
DEBUG[1777622849] $substitutions.$patchVersion                  
DEBUG[1777622849] $substitutions.$url                           https://www.mark0.net/download/triddefs.zip
DEBUG[1777622849] $substitutions.$matchYear                     26
DEBUG[1777622849] $substitutions.$matchMonth                    04
DEBUG[1777622849] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading triddefs.zip to compute hashes!
Loading triddefs.zip from cache
Computed hash: bd38d1f77c8fe416f8addd5e2359c70247f2fa45c6178160e80fd5d772a98d73
DEBUG[1777622849] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1777622849] $substitutions.$matchHead                     2.47
DEBUG[1777622849] $substitutions.$matchTail                     -26.04.30
DEBUG[1777622849] $substitutions.$minorVersion                  47
DEBUG[1777622849] $substitutions.$baseurl                       https://www.mark0.net/download
DEBUG[1777622849] $substitutions.$majorVersion                  2
DEBUG[1777622849] $substitutions.$buildVersion                  
DEBUG[1777622849] $substitutions.$dashVersion                   2-47-26-04-30
DEBUG[1777622849] $substitutions.$underscoreVersion             2_47_26_04_30
DEBUG[1777622849] $substitutions.$version                       2.47-26.04.30
DEBUG[1777622849] $substitutions.$preReleaseVersion             26.04.30
DEBUG[1777622849] $substitutions.$dotVersion                    2.47.26.04.30
DEBUG[1777622849] $substitutions.$urlNoExt                      https://www.mark0.net/download/trid_win64
DEBUG[1777622849] $substitutions.$matchDay                      30
DEBUG[1777622849] $substitutions.$cleanVersion                  247260430
DEBUG[1777622849] $substitutions.$basenameNoExt                 trid_win64
DEBUG[1777622849] $substitutions.$basename                      trid_win64.zip
DEBUG[1777622849] $substitutions.$match1                        2.47
DEBUG[1777622849] $substitutions.$patchVersion                  
DEBUG[1777622849] $substitutions.$url                           https://www.mark0.net/download/trid_win64.zip
DEBUG[1777622849] $substitutions.$matchYear                     26
DEBUG[1777622849] $substitutions.$matchMonth                    04
DEBUG[1777622849] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading trid_win64.zip to compute hashes!
Loading trid_win64.zip from cache
Computed hash: 5683d49089d6f08312ad0736f47f212fbedd4a92af700eab34ee4b242e6060c3
Writing updated trid manifest
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)