### PR TITLE
(chore): Explicitly specify GitHub mode when using GitHub API

### DIFF
--- a/bucket/ammonite.json
+++ b/bucket/ammonite.json
@@ -10,7 +10,7 @@
     "hash": "80cc934033e61ec97a6f70810ac2076fff33d85c0bdfe4f1bb3d2c88582f4b0b",
     "bin": "amm.bat",
     "checkver": {
-        "url": "https://api.github.com/repos/lihaoyi/Ammonite/releases",
+        "github": "https://api.github.com/repos/lihaoyi/Ammonite/releases",
         "regex": "tag/([\\d\\w.-]+)"
     },
     "autoupdate": {

--- a/bucket/aptos-cli.json
+++ b/bucket/aptos-cli.json
@@ -11,7 +11,7 @@
     },
     "bin": "aptos.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/aptos-labs/aptos-core/releases",
+        "github": "https://api.github.com/repos/aptos-labs/aptos-core/releases",
         "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /aptos-cli/i)].browser_download_url",
         "regex": "(?i)download/aptos-cli-v([\\d.]+)/aptos-cli"
     },

--- a/bucket/arc.json
+++ b/bucket/arc.json
@@ -15,7 +15,7 @@
     },
     "bin": "arc.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/mholt/archiver/releases",
+        "github": "https://api.github.com/repos/mholt/archiver/releases",
         "regex": "arc_([\\d.]+)_windows_amd64\\.exe"
     },
     "autoupdate": {

--- a/bucket/audiowaveform.json
+++ b/bucket/audiowaveform.json
@@ -15,7 +15,7 @@
     },
     "bin": "audiowaveform.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/bbc/audiowaveform/releases",
+        "github": "https://api.github.com/repos/bbc/audiowaveform/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /audiowaveform-(?<version>[\\d.]+)-win64\\.zip/i)].browser_download_url",
         "regex": "audiowaveform-(?<version>[\\d.]+)-win64\\.zip"
     },

--- a/bucket/autocorrect.json
+++ b/bucket/autocorrect.json
@@ -11,7 +11,7 @@
     },
     "bin": "autocorrect.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/huacnlee/autocorrect/releases",
+        "github": "https://api.github.com/repos/huacnlee/autocorrect/releases",
         "regex": "tag/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/aws.json
+++ b/bucket/aws.json
@@ -15,7 +15,7 @@
         "aws_completer.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/aws/aws-cli/tags",
+        "github": "https://api.github.com/repos/aws/aws-cli/tags",
         "jsonpath": "$[0].name"
     },
     "autoupdate": {

--- a/bucket/azure-ps.json
+++ b/bucket/azure-ps.json
@@ -18,7 +18,7 @@
         "name": "AzureRM"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/Azure/azure-powershell/releases",
+        "github": "https://api.github.com/repos/Azure/azure-powershell/releases",
         "regex": "download/v(?<release>[^/]+)/Az-Cmdlets-([0-9.]+)-x64[.]msi"
     },
     "autoupdate": {

--- a/bucket/bbdown.json
+++ b/bucket/bbdown.json
@@ -36,7 +36,7 @@
         "BBDownTV.data"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/nilaoda/BBDown/releases",
+        "github": "https://api.github.com/repos/nilaoda/BBDown/releases",
         "jsonpath": "$[0].assets",
         "regex": "BBDown_(?<version>[\\d.]+)_(?<date>[\\d]+)_win-x64.zip"
     },

--- a/bucket/bflat.json
+++ b/bucket/bflat.json
@@ -15,7 +15,7 @@
     },
     "bin": "bflat.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/bflattened/bflat/releases/latest",
+        "github": "https://api.github.com/repos/bflattened/bflat/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "v([\\d.]+)"
     },

--- a/bucket/biome.json
+++ b/bucket/biome.json
@@ -15,7 +15,7 @@
     },
     "bin": "biome.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/biomejs/biome/releases",
+        "github": "https://api.github.com/repos/biomejs/biome/releases",
         "jsonpath": "$..tag_name",
         "regex": "@biomejs/biome@([\\d.]+)\""
     },

--- a/bucket/bitwarden-secrets-manager-cli.json
+++ b/bucket/bitwarden-secrets-manager-cli.json
@@ -18,7 +18,7 @@
     },
     "bin": "bws.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/bitwarden/sdk-sm/releases",
+        "github": "https://api.github.com/repos/bitwarden/sdk-sm/releases",
         "jsonpath": "$..assets[?(@.name =~ /bws-x86_64-pc-windows/i)].browser_download_url",
         "regex": "(?i)download/bws-v([\\d.]+)/bws-x86_64-pc-windows"
     },

--- a/bucket/camunda-operate.json
+++ b/bucket/camunda-operate.json
@@ -30,7 +30,7 @@
     ],
     "persist": "config",
     "checkver": {
-        "url": "https://api.github.com/repos/camunda/camunda-platform/releases",
+        "github": "https://api.github.com/repos/camunda/camunda-platform/releases",
         "regex": "download/(?<genVer>[\\d.]+%2Bgen[\\d.]+)/camunda-operate-([\\d.]+).zip"
     },
     "autoupdate": {

--- a/bucket/capnp.json
+++ b/bucket/capnp.json
@@ -11,7 +11,7 @@
         "capnproto-tools-win32-1.4.0/capnpc-capnp.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/capnproto/capnproto/tags",
+        "github": "https://api.github.com/repos/capnproto/capnproto/tags",
         "regex": "tags/v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/cc65.json
+++ b/bucket/cc65.json
@@ -33,7 +33,7 @@
         "LD65_CFG": "$dir\\cfg"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/cc65/cc65/actions/workflows/snapshot-on-push-master.yml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/cc65/cc65/actions/workflows/snapshot-on-push-master.yml/runs?branch=master&status=success",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {

--- a/bucket/codex.json
+++ b/bucket/codex.json
@@ -36,7 +36,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/openai/codex/releases",
+        "github": "https://api.github.com/repos/openai/codex/releases",
         "regex": "rust-v(\\d+\\.\\d+\\.\\d+)(?![^\\d]*alpha|[^\\d]*beta|[^\\d]*rc|[^\\d]*preview)"
     },
     "autoupdate": {

--- a/bucket/config-file-validator.json
+++ b/bucket/config-file-validator.json
@@ -15,7 +15,7 @@
     },
     "bin": "validator.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/Boeing/config-file-validator/releases",
+        "github": "https://api.github.com/repos/Boeing/config-file-validator/releases",
         "jsonpath": "$[?(@.prerelease == false)].tag_name",
         "regex": "(?:v|V)?([\\d.]+)"
     },

--- a/bucket/coq.json
+++ b/bucket/coq.json
@@ -31,7 +31,7 @@
         "COQBIN": "$dir\\bin"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/rocq-prover/platform/releases/latest",
+        "github": "https://api.github.com/repos/rocq-prover/platform/releases/latest",
         "regex": "Coq-Platform-release-([\\d.]+)-version.(?<coqver>[\\d.]+)-Windows-x86_64.exe",
         "reverse": true
     },

--- a/bucket/detekt.json
+++ b/bucket/detekt.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/detekt/detekt/releases",
+        "github": "https://api.github.com/repos/detekt/detekt/releases",
         "regex": "detekt-cli-(?<version>[\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/flux.json
+++ b/bucket/flux.json
@@ -19,7 +19,7 @@
     },
     "bin": "flux.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/fluxcd/flux2/releases",
+        "github": "https://api.github.com/repos/fluxcd/flux2/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "flux_([\\d.]+)_windows_amd64.zip"
     },

--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -86,7 +86,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "github": "https://api.github.com/repos/git-for-windows/git/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Portable/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?[\\d.]+windows[\\d.]+)/PortableGit-([\\d.]+)"
     },

--- a/bucket/git-xet.json
+++ b/bucket/git-xet.json
@@ -20,7 +20,7 @@
     },
     "bin": "git-xet.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/huggingface/xet-core/releases?per_page=45",
+        "github": "https://api.github.com/repos/huggingface/xet-core/releases?per_page=45",
         "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /git-xet/i)].browser_download_url",
         "regex": "(?i)download/git-xet-v([\\d.]+)/git-xet"
     },

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -94,7 +94,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "github": "https://api.github.com/repos/git-for-windows/git/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Portable/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?[\\d.]+windows[\\d.]+)/PortableGit-([\\d.]+)"
     },

--- a/bucket/grails.json
+++ b/bucket/grails.json
@@ -14,7 +14,7 @@
         "GRAILS_HOME": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/apache/grails-core/releases",
+        "github": "https://api.github.com/repos/apache/grails-core/releases",
         "regex": "/grails-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -15,7 +15,7 @@
     },
     "bin": "grpcurl.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/fullstorydev/grpcurl/releases",
+        "github": "https://api.github.com/repos/fullstorydev/grpcurl/releases",
         "regex": "grpcurl_([\\d.]+)_windows_x"
     },
     "autoupdate": {

--- a/bucket/hashlink.json
+++ b/bucket/hashlink.json
@@ -11,7 +11,7 @@
         "HASHLINKPATH": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/HaxeFoundation/hashlink/releases/latest",
+        "github": "https://api.github.com/repos/HaxeFoundation/hashlink/releases/latest",
         "regex": "([\\d.]+)-win"
     },
     "autoupdate": {

--- a/bucket/imagemagick-lean.json
+++ b/bucket/imagemagick-lean.json
@@ -23,7 +23,7 @@
     },
     "bin": "magick.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest",
+        "github": "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest",
         "jsonpath": "$.tag_name"
     },
     "autoupdate": {

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -32,7 +32,7 @@
         "MAGICK_CODER_MODULE_PATH": "$dir\\modules\\coders"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest",
+        "github": "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest",
         "jsonpath": "$.tag_name"
     },
     "autoupdate": {

--- a/bucket/ipinfo-cli.json
+++ b/bucket/ipinfo-cli.json
@@ -23,7 +23,7 @@
     ],
     "bin": "ipinfo.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/ipinfo/cli/releases/latest",
+        "github": "https://api.github.com/repos/ipinfo/cli/releases/latest",
         "jsonpath": "$.name",
         "regex": "ipinfo-(?<version>.*)$"
     },

--- a/bucket/kim.json
+++ b/bucket/kim.json
@@ -11,7 +11,7 @@
     },
     "bin": "kim.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/rancher/kim/releases",
+        "github": "https://api.github.com/repos/rancher/kim/releases",
         "regex": "download/v([\\w.-]+)/kim-windows-amd64.exe"
     },
     "autoupdate": {

--- a/bucket/kotlin-native.json
+++ b/bucket/kotlin-native.json
@@ -24,7 +24,7 @@
     ],
     "env_add_path": "bin",
     "checkver": {
-        "url": "https://api.github.com/repos/JetBrains/kotlin/releases/latest",
+        "github": "https://api.github.com/repos/JetBrains/kotlin/releases/latest",
         "regex": "windows-x86_64-([\\w.\\-]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/kustomize.json
+++ b/bucket/kustomize.json
@@ -15,7 +15,7 @@
     },
     "bin": "kustomize.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest",
+        "github": "https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest",
         "jsonpath": "$..name",
         "regex": "kustomize/v([\\d.]+)"
     },

--- a/bucket/lutgen.json
+++ b/bucket/lutgen.json
@@ -11,7 +11,7 @@
     },
     "bin": "lutgen.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/ozwaldorf/lutgen-rs/releases",
+        "github": "https://api.github.com/repos/ozwaldorf/lutgen-rs/releases",
         "jsonpath": "$..tag_name",
         "regex": "lutgen-v([\\d.]+)"
     },

--- a/bucket/mingit-busybox.json
+++ b/bucket/mingit-busybox.json
@@ -29,7 +29,7 @@
         "GIT_INSTALL_ROOT": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "github": "https://api.github.com/repos/git-for-windows/git/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+windows\\.\\d)/MinGit-([\\d.]+)-busybox-64"
     },

--- a/bucket/mingit.json
+++ b/bucket/mingit.json
@@ -33,7 +33,7 @@
         "GIT_INSTALL_ROOT": "$dir"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "github": "https://api.github.com/repos/git-for-windows/git/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /MinGit/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?[\\d.]+windows[\\d.]+)/MinGit-([\\d.]+)"
     },

--- a/bucket/mingw.json
+++ b/bucket/mingw.json
@@ -18,7 +18,7 @@
     "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
     "env_add_path": "bin",
     "checkver": {
-        "url": "https://api.github.com/repos/niXman/mingw-builds-binaries/releases",
+        "github": "https://api.github.com/repos/niXman/mingw-builds-binaries/releases",
         "jsonpath": "$..tag_name",
         "regex": "([\\d.]+)-(?<build>[a-z0-9_\\-]+)",
         "replace": "${1}-${build}"

--- a/bucket/nanarun.json
+++ b/bucket/nanarun.json
@@ -25,7 +25,7 @@
         "SynthRdp.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/M2Team/NanaRun/releases",
+        "github": "https://api.github.com/repos/M2Team/NanaRun/releases",
         "jsonpath": "$.[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -26,7 +26,7 @@
         "bin\\xxd.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/neovim/neovim/releases/latest",
+        "github": "https://api.github.com/repos/neovim/neovim/releases/latest",
         "jsonpath": "$.body",
         "regex": "NVIM v(?<majorVersion>[\\w.-]+)\\.(?<minorVersion>[\\w.-]+)\\.(?<patchVersion>[\\w.-]+)",
         "replace": "${majorVersion}.${minorVersion}.${patchVersion}"

--- a/bucket/openshift-okd-client.json
+++ b/bucket/openshift-okd-client.json
@@ -11,7 +11,7 @@
     },
     "bin": "oc.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/okd-project/okd/tags",
+        "github": "https://api.github.com/repos/okd-project/okd/tags",
         "jsonpath": "$[0].name"
     },
     "autoupdate": {

--- a/bucket/oxlint.json
+++ b/bucket/oxlint.json
@@ -16,7 +16,7 @@
     "pre_install": "Get-Item \"$dir\\oxlint-*.exe\" | Rename-Item -NewName \"$dir\\oxlint.exe\"",
     "bin": "oxlint.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/oxc-project/oxc/releases",
+        "github": "https://api.github.com/repos/oxc-project/oxc/releases",
         "regex": "tag/apps_v([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/pdf2djvu.json
+++ b/bucket/pdf2djvu.json
@@ -18,7 +18,7 @@
         "djvused.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/jwilk-archive/pdf2djvu/releases",
+        "github": "https://api.github.com/repos/jwilk-archive/pdf2djvu/releases",
         "regex": "pdf2djvu-win32-([\\d.]+)\\.zip"
     },
     "autoupdate": {

--- a/bucket/perl.json
+++ b/bucket/perl.json
@@ -33,7 +33,7 @@
         "perl\\bin"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/StrawberryPerl/Perl-Dist-Strawberry/releases/latest",
+        "github": "https://api.github.com/repos/StrawberryPerl/Perl-Dist-Strawberry/releases/latest",
         "regex": "releases/download/(?<tag>\\w+)/strawberry-perl-([\\d.]+)-64bit-portable\\.zip\""
     },
     "autoupdate": {

--- a/bucket/presentmon.json
+++ b/bucket/presentmon.json
@@ -11,7 +11,7 @@
     },
     "bin": "PresentMon.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/GameTechDev/PresentMon/releases/latest",
+        "github": "https://api.github.com/repos/GameTechDev/PresentMon/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "v([\\d.]+)"
     },

--- a/bucket/sapling.json
+++ b/bucket/sapling.json
@@ -24,7 +24,7 @@
     "extract_dir": "Sapling",
     "bin": "sl.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/facebook/sapling/releases/latest",
+        "github": "https://api.github.com/repos/facebook/sapling/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "(?<tag>(?<ver>[\\d.]+)\\.(?<date>[\\d]{8})-(?<time>[\\d]{6})\\+(?<hash>[\\da-f]{8}))",
         "replace": "${ver}.${date}.${time}.${hash}"

--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -15,7 +15,7 @@
     },
     "bin": "sed.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/mbuilov/sed-windows/releases/latest",
+        "github": "https://api.github.com/repos/mbuilov/sed-windows/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "sed-([\\d.]+)"
     },

--- a/bucket/simplex-chat.json
+++ b/bucket/simplex-chat.json
@@ -11,7 +11,7 @@
     },
     "bin": "simplex-chat.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/simplex-chat/simplex-chat/releases",
+        "github": "https://api.github.com/repos/simplex-chat/simplex-chat/releases",
         "jsonpath": "$[?(@.prerelease == false)]..browser_download_url",
         "regex": "download/v([\\d.]+)/simplex-chat-windows-x86-64"
     },

--- a/bucket/ssh3.json
+++ b/bucket/ssh3.json
@@ -19,7 +19,7 @@
     },
     "bin": "ssh3.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/francoismichel/ssh3/releases",
+        "github": "https://api.github.com/repos/francoismichel/ssh3/releases",
         "jsonpath": "$[0].tag_name",
         "regex": "v([\\d.]+(?:-[^-]+)?)"
     },

--- a/bucket/terraform-provider-ibm.json
+++ b/bucket/terraform-provider-ibm.json
@@ -17,7 +17,7 @@
         }
     },
     "checkver": {
-        "url": "https://api.github.com/repos/IBM-Cloud/terraform-provider-ibm/releases",
+        "github": "https://api.github.com/repos/IBM-Cloud/terraform-provider-ibm/releases",
         "regex": "releases/download/v([\\d.]+)/"
     },
     "autoupdate": {

--- a/bucket/ttyper.json
+++ b/bucket/ttyper.json
@@ -19,7 +19,7 @@
     },
     "bin": "ttyper.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/max-niederman/ttyper/releases",
+        "github": "https://api.github.com/repos/max-niederman/ttyper/releases",
         "jsonpath": "$.[0].tag_name",
         "regex": "v([\\w.-]+)"
     },

--- a/bucket/v.json
+++ b/bucket/v.json
@@ -13,7 +13,7 @@
     "extract_dir": "v",
     "bin": "v.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/vlang/v/releases?per_page=100",
+        "github": "https://api.github.com/repos/vlang/v/releases?per_page=100",
         "regex": "releases/tag/([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/vgmstream.json
+++ b/bucket/vgmstream.json
@@ -18,7 +18,7 @@
     },
     "bin": "vgmstream-cli.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/vgmstream/vgmstream/releases/latest",
+        "github": "https://api.github.com/repos/vgmstream/vgmstream/releases/latest",
         "jsonpath": "$..browser_download_url",
         "regex": "download/(r\\d+)/vgmstream-win"
     },

--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -101,7 +101,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/vim/vim-win32-installer/releases?per_page=45",
+        "github": "https://api.github.com/repos/vim/vim-win32-installer/releases?per_page=45",
         "jsonpath": "$[?(@.prerelease == false)].assets[?(@.name =~ /signed\\.zip/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>[^/]+)/gvim_([\\d.]+)_(?:x|arm)"
     },

--- a/bucket/wkhtmltopdf.json
+++ b/bucket/wkhtmltopdf.json
@@ -19,7 +19,7 @@
         "wkhtmltopdf.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/wkhtmltopdf/packaging/releases",
+        "github": "https://api.github.com/repos/wkhtmltopdf/packaging/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "/wkhtmltox-([\\d.-]+)\\.mxe-cross-"
     },

--- a/bucket/y-cruncher.json
+++ b/bucket/y-cruncher.json
@@ -11,7 +11,7 @@
     "extract_dir": "y-cruncher v0.8.7.9547b",
     "bin": "y-cruncher.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/Mysticial/y-cruncher/releases/latest",
+        "github": "https://api.github.com/repos/Mysticial/y-cruncher/releases/latest",
         "jsonpath": "$.tag_name",
         "regex": "\\Av(\\S+)\\Z"
     },

--- a/bucket/z.lua.json
+++ b/bucket/z.lua.json
@@ -12,7 +12,7 @@
     "hash": "eb873632e37bbf96fb0255db9a9e27b14b3e06e0264b1e69bc30da13e912dbc8",
     "extract_dir": "z.lua-1.8.25",
     "checkver": {
-        "url": "https://api.github.com/repos/skywind3000/z.lua/releases/latest",
+        "github": "https://api.github.com/repos/skywind3000/z.lua/releases/latest",
         "regex": "(?i)tag/(?<tag>v?([\\d.]+))(?=\")"
     },
     "autoupdate": {

--- a/bucket/zigup.json
+++ b/bucket/zigup.json
@@ -20,7 +20,7 @@
     ],
     "persist": "zig",
     "checkver": {
-        "url": "https://api.github.com/repos/marler8997/zigup/releases",
+        "github": "https://api.github.com/repos/marler8997/zigup/releases",
         "regex": "v([\\d_]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
Per ScoopInstaller/Scoop#6641, to make authenticated GitHub API requests with a token in checkver, GitHub mode must be explicitly specified. Additionally, `checkver.github` now allows configuring either a GitHub repo URL or a GitHub API URL.

Some `checkver` may still not work. However, since there is still another breaking change (ScoopInstaller/Scoop#6653) that hasn't been merged yet, we may wait until it is merged before fixing this issue to avoid duplicating work.

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
