### PR TITLE
git-tfs-lfs: Add version 0.35.0

### DIFF
--- a/bucket/git-tfs-lfs.json
+++ b/bucket/git-tfs-lfs.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.35.0",
+  "description": "A Git/TFS bridge with full Git LFS support, similar to git-svn.",
+  "homepage": "https://github.com/lucianm/git-tfs",
+  "license": "Apache-2.0",
+  "depends": "git",
+  "url": "https://github.com/lucianm/git-tfs/releases/download/v0.35.0/GitTfs-0.35.0.zip",
+  "hash": "aa83486521655a3e90264500323aa6b517e0e6a4e59980d3257ac19bdcce3786",
+  "bin": "git-tfs.exe",
+  "checkver": {
+    "github": "https://github.com/lucianm/git-tfs"
+  },
+  "autoupdate": {
+    "url": "https://github.com/lucianm/git-tfs/releases/download/v$version/GitTfs-$version.zip"
+  }
+}


### PR DESCRIPTION
- added full LFS support and various maintenance updates over upstream git-tfs-0.34.0
- drop-in replacement, would replace git-tfs
- @coderabbitai review

Closes #7939
