### PR TITLE
deepseek-tui: Update to version 0.8.18

### DIFF
--- a/bucket/deepseek-tui.json
+++ b/bucket/deepseek-tui.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.17",
+    "version": "0.8.18",
     "description": "Coding agent for DeepSeek models that runs in your terminal.",
     "homepage": "https://github.com/Hmbown/DeepSeek-TUI",
     "license": "MIT",
@@ -9,12 +9,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.17/deepseek-tui-windows-x64.exe#/deepseek-tui.exe",
-                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.17/deepseek-windows-x64.exe#/deepseek.exe"
+                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.18/deepseek-tui-windows-x64.exe#/deepseek-tui.exe",
+                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.18/deepseek-windows-x64.exe#/deepseek.exe"
             ],
             "hash": [
-                "f9bb87ed221002ab9ac01db6dd4f5d901234cb807620c2710e6bb8c8f6d79218",
-                "245f54d8cf22284cfa6614a47c9fd3a404affbda53d2472e73ba65c9fbd528a6"
+                "2bf6c996089025180fb4e67c7498103f011f0105db8d42523678e599e14aa971",
+                "8f7d2bbbb5af99bc9b2c8fdf7b6a87218f3a8a6bd70663c5c3141d35889ed3fd"
             ]
         }
     },


### PR DESCRIPTION
Updates deepseek-tui to 0.8.18.\n\nRelease: https://github.com/Hmbown/DeepSeek-TUI/releases/tag/v0.8.18\nChecksum manifest: https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.18/deepseek-artifacts-sha256.txt