### PR TITLE
deepseek-tui: Update to version 0.8.20

### DIFF
--- a/bucket/deepseek-tui.json
+++ b/bucket/deepseek-tui.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.19",
+    "version": "0.8.20",
     "description": "Coding agent for DeepSeek models that runs in your terminal.",
     "homepage": "https://github.com/Hmbown/DeepSeek-TUI",
     "license": "MIT",
@@ -9,12 +9,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.19/deepseek-tui-windows-x64.exe#/deepseek-tui.exe",
-                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.19/deepseek-windows-x64.exe#/deepseek.exe"
+                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.20/deepseek-tui-windows-x64.exe#/deepseek-tui.exe",
+                "https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.20/deepseek-windows-x64.exe#/deepseek.exe"
             ],
             "hash": [
-                "37c936579fd65fb80a676d7a3ab0f4dd7c5cccde0e83b06a1ce0e49bf51b8993",
-                "edebc7e2db3080bb5a975121641fc6b05834dbcbca098ca2f70ee5d24435bc51"
+                "0e9204bf876996510b04c7e54acc62e54164a452172fdec0980e66dc5fff6640",
+                "fb54dac247ded39564d0dd49c4050d479baf6836f9ef6f1c6833b9c64ec59405"
             ]
         }
     },


### PR DESCRIPTION
Updates deepseek-tui to 0.8.20.

Release: https://github.com/Hmbown/DeepSeek-TUI/releases/tag/v0.8.20
Checksum manifest: https://github.com/Hmbown/DeepSeek-TUI/releases/download/v0.8.20/deepseek-artifacts-sha256.txt

Local verification:
- jq parsed bucket/deepseek-tui.json
- Downloaded both Windows assets and verified SHA256 hashes match the manifest