### PR TITLE
cocogitto: Add version 7.0.0

### DIFF
--- a/bucket/cocogitto.json
+++ b/bucket/cocogitto.json
@@ -1,0 +1,27 @@
+{
+    "version": "7.0.0",
+    "description": "A CLI and GitOps toolbox for the Conventional Commits and Semver specifications.",
+    "homepage": "https://docs.cocogitto.io",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cocogitto/cocogitto/releases/download/7.0.0/cocogitto-7.0.0-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "074f68f05d270da5c0d69d3e234ec362bec4c6e3189c21d1c948d038603655d7"
+        }
+    },
+    "extract_dir": "x86_64-pc-windows-msvc",
+    "bin": "cog.exe",
+    "checkver": {
+        "github": "https://github.com/cocogitto/cocogitto"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cocogitto/cocogitto/releases/download/$version/cocogitto-$version-x86_64-pc-windows-msvc.tar.gz"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #7991

Supersedes #6599 — the prior PR adds version 6.2.0, but the project has since had a major version bump to 7.0.0, so this PR replaces it with the current release.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)