### PR TITLE
elan: Add version 4.2.1

### DIFF
--- a/bucket/elan.json
+++ b/bucket/elan.json
@@ -1,0 +1,33 @@
+{
+    "version": "4.2.1",
+    "description": "A small tool for managing your installations of the Lean theorem prover.",
+    "homepage": "https://github.com/leanprover/elan",
+    "license": "MIT|Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/leanprover/elan/releases/download/v4.2.1/elan-x86_64-pc-windows-msvc.zip",
+            "hash": "ad4befa57060933d65464bca4eca34c334f714000b5969c49309755682541dc1"
+        }
+    },
+    "installer": {
+        "script": [
+            "[Environment]::SetEnvironmentVariable('ELAN_HOME', \"$persist_dir\\.elan\", 'Process')",
+            "Invoke-ExternalCommand -Path \"$dir\\elan-init.exe\" -Args @('-y', '--no-modify-path') | Out-Null"
+        ]
+    },
+    "env_add_path": ".elan\\bin",
+    "env_set": {
+        "ELAN_HOME": "$persist_dir\\.elan"
+    },
+    "persist": ".elan",
+    "checkver": {
+        "github": "https://github.com/leanprover/elan"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/leanprover/elan/releases/download/v$version/elan-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}

--- a/bucket/elan.json
+++ b/bucket/elan.json
@@ -1,6 +1,6 @@
 {
     "version": "4.2.1",
-    "description": "A small tool for managing your installations of the Lean theorem prover.",
+    "description": "A CLI tool for managing your installations of the Lean theorem prover.",
     "homepage": "https://github.com/leanprover/elan",
     "license": "MIT|Apache-2.0",
     "architecture": {
@@ -20,9 +20,7 @@
         "ELAN_HOME": "$persist_dir\\.elan"
     },
     "persist": ".elan",
-    "checkver": {
-        "github": "https://github.com/leanprover/elan"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Closes #6725

Picks up from the stalled #6736 — the original author confirmed they no longer use Windows and asked someone else to take it over. Manifest follows the same rustup-derived pattern, bumped to v4.2.1, with the `checkver` object form.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)