### PR TITLE
(chore): Add field IDs to package-request template to allow URL prefill

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-request.yml
@@ -27,30 +27,35 @@ body:
     - label: Fairly standard install (e.g. uses a version-specific download URL, no elaborate pre/post install scripts)
       required: true
 - type: input
+  id: name
   attributes:
     label: Name
     description: Name of the package
   validations:
     required: true
 - type: input
+  id: description
   attributes:
     label: Description
     description: Clear and concise details of what it is
   validations:
     required: true
 - type: input
+  id: homepage
   attributes:
     label: Homepage
     description: URI of the package's homepage
   validations:
     required: true
 - type: input
+  id: download-links
   attributes:
     label: Download Link(s)
     description: URI(s) of the package's download(s)
   validations:
     required: true
 - type: textarea
+  id: popularity
   attributes:
     label: Some Indication of Popularity/Repute
     description: GitHub stars/software reviews etc.

--- a/.github/ISSUE_TEMPLATE/package-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-request.yml
@@ -48,7 +48,7 @@ body:
   validations:
     required: true
 - type: input
-  id: download-links
+  id: download-link
   attributes:
     label: Download Link(s)
     description: URI(s) of the package's download(s)


### PR DESCRIPTION
Adds an `id` key to each input/textarea field in `.github/ISSUE_TEMPLATE/package-request.yml` so requesters (and tooling that opens the form on their behalf) can prefill body fields via URL query parameters, e.g.:

```
https://github.com/ScoopInstaller/Main/issues/new?template=package-request.yml&name=<app>&homepage=<url>&download-links=<url>&popularity=<note>
```

Per the [form schema docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema), URL prefill binds against a field's `id`. Without explicit IDs, only the top-level `title` and `body` params take effect, which isn't enough here because the form-level required validations on Name/Description/Homepage/Download Link(s)/Popularity block submission with everything else empty.

Checkboxes are left unchanged as GitHub [doesn't yet support](https://github.com/orgs/community/discussions/32200) URL prefill for `type: checkboxes`. Sibling templates are also left unchanged.

### Motivation

I maintain tooling that helps me file package requests here, and I want it to route through this template so requests arrive correctly labelled, in line with @z-Fng's nudge in https://github.com/ScoopInstaller/Main/issues/7998#issuecomment-4436906425 ("Please use the issue template. The issues you raised don't have any labels.").