### PR TITLE
dos2unix@7.5.5: Update URLs

### DIFF
--- a/bucket/dos2unix.json
+++ b/bucket/dos2unix.json
@@ -1,16 +1,19 @@
 {
     "version": "7.5.5",
-    "description": "Convert text files with DOS or Mac line endings to Unix line endings and vice versa",
-    "homepage": "https://waterlan.home.xs4all.nl/dos2unix.html",
-    "license": "BSD-2-Clause",
+    "description": "Convert text files with DOS or Mac line breaks to Unix line breaks and vice versa.",
+    "homepage": "https://waterlander.net/dos2unix/",
+    "license": {
+        "identifier": "BSD-2-Clause",
+        "url": "https://waterlander.net/dos2unix/doc/COPYING.txt"
+    },
     "architecture": {
-        "64bit": {
-            "url": "https://waterlan.home.xs4all.nl/dos2unix/dos2unix-7.5.5-win64.zip",
-            "hash": "3583866c837f1b621fd9cab2928ad59c36bc5d3cc0effd34882a45ff976bfd54"
-        },
         "32bit": {
-            "url": "https://waterlan.home.xs4all.nl/dos2unix/dos2unix-7.5.5-win32.zip",
+            "url": "https://waterlander.net/dos2unix/files/dos2unix-7.5.5-win32.zip",
             "hash": "0b604d9527edfd819f64e5a4395a4132c763a08669630a155095c021c3da160e"
+        },
+        "64bit": {
+            "url": "https://waterlander.net/dos2unix/files/dos2unix-7.5.5-win64.zip",
+            "hash": "3583866c837f1b621fd9cab2928ad59c36bc5d3cc0effd34882a45ff976bfd54"
         }
     },
     "bin": [
@@ -22,11 +25,11 @@
     "checkver": "Stable version:\\s+([\\d.]+)",
     "autoupdate": {
         "architecture": {
-            "64bit": {
-                "url": "https://waterlan.home.xs4all.nl/dos2unix/dos2unix-$version-win64.zip"
-            },
             "32bit": {
-                "url": "https://waterlan.home.xs4all.nl/dos2unix/dos2unix-$version-win32.zip"
+                "url": "https://waterlander.net/dos2unix/files/dos2unix-$version-win32.zip"
+            },
+            "64bit": {
+                "url": "https://waterlander.net/dos2unix/files/dos2unix-$version-win64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
> This page will go offline on 1 July 2026. Go to the new page at <https://waterlander.net/>
- [Erwin Waterlander, WCD Wherever Change Directory](https://waterlan.home.xs4all.nl/) - [Archived](https://web.archive.org/web/20260511230947/https://waterlan.home.xs4all.nl/) 11 May 2026 at the [Wayback Machine](https://en.wikipedia.org/wiki/Wayback_Machine)
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution URLs and repository metadata to reflect the new upstream provider location.
  * Enhanced license field structure with additional reference information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Main/pull/8012)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->