### PR TITLE
libvips: Update to version 8.18.2, fix autoupdate

### DIFF
--- a/bucket/libvips.json
+++ b/bucket/libvips.json
@@ -1,16 +1,20 @@
 {
-    "version": "8.18.1",
+    "version": "8.18.2",
     "description": "A demand-driven, horizontally threaded image processing library",
     "homepage": "https://www.libvips.org/",
     "license": "LGPL-2.1-only",
     "architecture": {
         "64bit": {
-            "hash": "9f4ead82f5f1937584f55016309fdc7b0fa67e575ce94fa0e2efbcc8028716b0",
-            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.18.1/vips-dev-w64-all-8.18.1.zip"
+            "hash": "aec9b8d5e79c06aade9fd51224570c87687675896d4da335955047c211d40e01",
+            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.18.2/vips-dev-x64-all-8.18.2.zip"
         },
         "32bit": {
-            "hash": "752446892b0908188c0732fff5002437902466fe56a4bd12d9169bb3a03bc772",
-            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.18.1/vips-dev-w32-all-8.18.1.zip"
+            "hash": "0eb5b60295cc7d3a2797848c99554b19c0b8a99f1883c4feb9c8435398bb2183",
+            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.18.2/vips-dev-x86-all-8.18.2.zip"
+        },
+        "arm64": {
+            "hash": "349942b14cd401cc315b9a93bd2ab7f3c1b5f37ce30d8a90d4136875e4e63129",
+            "url": "https://github.com/libvips/build-win64-mxe/releases/download/v8.18.2/vips-dev-arm64-all-8.18.2.zip"
         }
     },
     "extract_dir": "vips-dev-8.18",
@@ -21,10 +25,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w64-all-$version.zip"
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-x64-all-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-w32-all-$version.zip"
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-x86-all-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/libvips/build-win64-mxe/releases/download/v$version/vips-dev-arm64-all-$version.zip"
             }
         },
         "extract_dir": "vips-dev-$majorVersion.$minorVersion"


### PR DESCRIPTION
Upstream [renamed](https://github.com/libvips/build-win64-mxe/releases/tag/v8.18.2) the release assets: `w64` → `x64`, `w32` → `x86`, and now also ships an `arm64` build. Updated the URLs/autoupdate accordingly and added an `arm64` architecture entry.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)