### PR TITLE
pnpm@11.3.0: Add persist for v11

### DIFF
--- a/bucket/pnpm.json
+++ b/bucket/pnpm.json
@@ -17,9 +17,34 @@
         "pnpm.exe",
         [
             "pnpm.exe",
+            "pn"
+        ],
+        [
+            "pnpm.exe",
             "pnpx",
             "dlx"
+        ],
+        [
+            "pnpm.exe",
+            "pnx",
+            "dlx"
         ]
+    ],
+    "post_install": [
+        "pnpm config set storeDir \"$dir\\store\"",
+        "pnpm config set cacheDir \"$dir\\cache\"",
+        "pnpm config set stateDir \"$dir\\state\""
+    ],
+    "env_add_path": "bin",
+    "env_set": {
+        "PNPM_HOME": "$dir"
+    },
+    "persist": [
+        "bin",
+        "global",
+        "store",
+        "cache",
+        "state"
     ],
     "checkver": {
         "script": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

- Relates to #6762

Users must migrate manually, but newly installed global apps work fine out of the box.

Configuration could be set via environment variables (e.g., `PNPM_CONFIG_CACHE_DIR`) or `pnpm config set cacheDir`. I prefer the same approach as Yarn, so users' environments aren't polluted by Scoop.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
