### PR TITLE
gitleaks@8.30.1: Add arm64 version, update GitHub link

### DIFF
--- a/bucket/gitleaks.json
+++ b/bucket/gitleaks.json
@@ -5,29 +5,36 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zricethezav/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x64.zip",
+            "url": "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x64.zip",
             "hash": "d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e"
         },
         "32bit": {
-            "url": "https://github.com/zricethezav/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x32.zip",
+            "url": "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x32.zip",
             "hash": "190ad53db301eec3e90afe3a1a75270768b8ebf89e731345e19421c32c1ae1a1"
+        },
+        "arm64": {
+            "url": "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_arm64.zip",
+            "hash": "b95f5e4f5c425cedca7ee203d9afd29597e692c4924a12ed42f970537c72cc0f"
         }
     },
     "bin": "gitleaks.exe",
     "checkver": {
-        "github": "https://github.com/zricethezav/gitleaks"
+        "github": "https://github.com/gitleaks/gitleaks"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zricethezav/gitleaks/releases/download/v$version/gitleaks_$version_windows_x64.zip"
+                "url": "https://github.com/gitleaks/gitleaks/releases/download/v$version/gitleaks_$version_windows_x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/zricethezav/gitleaks/releases/download/v$version/gitleaks_$version_windows_x32.zip"
+                "url": "https://github.com/gitleaks/gitleaks/releases/download/v$version/gitleaks_$version_windows_x32.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/gitleaks/gitleaks/releases/download/v$version/gitleaks_$version_windows_arm64.zip"
             }
         },
         "hash": {
-            "url": "https://github.com/zricethezav/gitleaks/releases/download/v$version/gitleaks_$version_checksums.txt"
+            "url": "$baseurl/gitleaks_$version_checksums.txt"
         }
     }
 }


### PR DESCRIPTION
- Add arm64 version;
- update GitHub link.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)