### PR TITLE
tabby-agent: Add version 0.32.0

### DIFF
--- a/bucket/tabby-agent.json
+++ b/bucket/tabby-agent.json
@@ -1,7 +1,7 @@
 {
     "version": "0.32.0",
     "description": "Self-hosted AI coding assistant.",
-    "homepage": "https://tabbyml.com/",
+    "homepage": "https://tabbyml.com",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -11,10 +11,9 @@
         }
     },
     "env_set": {
-        "TABBY_ROOT": "$persist_dir\\.tabby"
+        "TABBY_ROOT": "$persist_dir"
     },
     "bin": "tabby.exe",
-    "persist": ".tabby",
     "checkver": {
         "github": "https://github.com/TabbyML/tabby"
     },

--- a/bucket/tabby-agent.json
+++ b/bucket/tabby-agent.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/TabbyML/tabby/releases/download/v0.32.0/tabby_x86_64-windows-msvc-cpu.zip",
-            "hash": "d492b1e49433fcdbe5be954ae54adf56a3f3cc20f8a824fa957b992b5ed3ac78"
+            "hash": "d492b1e49433fcdbe5be954ae54adf56a3f3cc20f8a824fa957b992b5ed3ac78",
+            "extract_dir": "tabby_x86_64-windows-msvc-cpu"
         }
     },
-    "extract_dir": "tabby_x86_64-windows-msvc-cpu",
     "bin": [
         "llama-server.exe",
         "tabby.exe"

--- a/bucket/tabby-agent.json
+++ b/bucket/tabby-agent.json
@@ -13,9 +13,7 @@
     "env_set": {
         "TABBY_ROOT": "$persist_dir\\.tabby"
     },
-    "bin": [
-        "tabby.exe"
-    ],
+    "bin": "tabby.exe",
     "persist": ".tabby",
     "checkver": {
         "github": "https://github.com/TabbyML/tabby"

--- a/bucket/tabby-agent.json
+++ b/bucket/tabby-agent.json
@@ -10,10 +10,13 @@
             "extract_dir": "tabby_x86_64-windows-msvc-cpu"
         }
     },
+    "env_set": {
+        "TABBY_ROOT": "$persist_dir\\.tabby"
+    },
     "bin": [
-        "llama-server.exe",
         "tabby.exe"
     ],
+    "persist": ".tabby",
     "checkver": {
         "github": "https://github.com/TabbyML/tabby"
     },

--- a/bucket/tabby-agent.json
+++ b/bucket/tabby-agent.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.32.0",
+    "description": "Self-hosted AI coding assistant.",
+    "homepage": "https://tabbyml.com/",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TabbyML/tabby/releases/download/v0.32.0/tabby_x86_64-windows-msvc-cpu.zip",
+            "hash": "d492b1e49433fcdbe5be954ae54adf56a3f3cc20f8a824fa957b992b5ed3ac78"
+        }
+    },
+    "extract_dir": "tabby_x86_64-windows-msvc-cpu",
+    "bin": [
+        "llama-server.exe",
+        "tabby.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/TabbyML/tabby"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TabbyML/tabby/releases/download/v$version/tabby_x86_64-windows-msvc-cpu.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://repology.org/project/tabby-ai-assistant/versions

Closes #5716 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Tabby self-hosted agent version 0.32.0 on Windows x86_64 with automatic update checking enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->