### PR TITLE
supabase: Align manifest with official scoop-bucket

### DIFF
--- a/bucket/supabase.json
+++ b/bucket/supabase.json
@@ -1,31 +1,33 @@
 {
     "version": "2.105.0",
     "description": "Supabase CLI",
-    "homepage": "https://supabase.com",
+    "homepage": "https://supabase.com/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_2.105.0_windows_amd64.zip",
-            "hash": "c453ba5573fb1dffdd13e609af436e69be12435040adf30b0a2195f51a1dd046",
-            "bin": ["supabase.exe"]
+            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_windows_amd64.tar.gz",
+            "hash": "f4c11bb8b3c34fcf5ab6dd41cb1e9403416c7c319d668f24b3769f004bd24824"
         },
         "arm64": {
-            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_2.105.0_windows_arm64.zip",
-            "hash": "d2c277a65d8b68d5bf2bc0233ec0bd3e5beab6d3a4798ed7fa119113bc02412e",
-            "bin": ["supabase.exe"]
+            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_windows_arm64.tar.gz",
+            "hash": "676118fb1d5b48cc9b88f06fac87bbc261bc910ce91f7e235c12854644857929"
         }
     },
+    "bin": "supabase.exe",
     "checkver": {
         "github": "https://github.com/supabase/cli"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_$version_windows_amd64.zip"
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_amd64.tar.gz"
             },
             "arm64": {
-                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_$version_windows_arm64.zip"
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_arm64.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/supabase_$version_checksums.txt"
         }
     }
 }

--- a/bucket/supabase.json
+++ b/bucket/supabase.json
@@ -1,33 +1,31 @@
 {
     "version": "2.105.0",
-    "description": "An open-source Firebase alternative.",
-    "homepage": "https://supabase.com/",
+    "description": "Supabase CLI",
+    "homepage": "https://supabase.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_windows_amd64.tar.gz",
-            "hash": "f4c11bb8b3c34fcf5ab6dd41cb1e9403416c7c319d668f24b3769f004bd24824"
+            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_2.105.0_windows_amd64.zip",
+            "hash": "c453ba5573fb1dffdd13e609af436e69be12435040adf30b0a2195f51a1dd046",
+            "bin": ["supabase.exe"]
         },
         "arm64": {
-            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_windows_arm64.tar.gz",
-            "hash": "676118fb1d5b48cc9b88f06fac87bbc261bc910ce91f7e235c12854644857929"
+            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_2.105.0_windows_arm64.zip",
+            "hash": "d2c277a65d8b68d5bf2bc0233ec0bd3e5beab6d3a4798ed7fa119113bc02412e",
+            "bin": ["supabase.exe"]
         }
     },
-    "bin": "supabase.exe",
     "checkver": {
         "github": "https://github.com/supabase/cli"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_amd64.tar.gz"
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_$version_windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_arm64.tar.gz"
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_$version_windows_arm64.zip"
             }
-        },
-        "hash": {
-            "url": "$baseurl/supabase_$version_checksums.txt"
         }
     }
 }

--- a/bucket/supabase.json
+++ b/bucket/supabase.json
@@ -27,7 +27,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/supabase_$version_checksums.txt"
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/supabase.json
+++ b/bucket/supabase.json
@@ -1,7 +1,7 @@
 {
     "version": "2.105.0",
-    "description": "Supabase CLI",
-    "homepage": "https://supabase.com/",
+    "description": "Supabase CLI.",
+    "homepage": "https://supabase.com",
     "license": "MIT",
     "architecture": {
         "64bit": {

--- a/bucket/supabase.json
+++ b/bucket/supabase.json
@@ -5,12 +5,12 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_windows_amd64.tar.gz",
-            "hash": "f4c11bb8b3c34fcf5ab6dd41cb1e9403416c7c319d668f24b3769f004bd24824"
+            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_2.105.0_windows_amd64.zip",
+            "hash": "c453ba5573fb1dffdd13e609af436e69be12435040adf30b0a2195f51a1dd046"
         },
         "arm64": {
-            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_windows_arm64.tar.gz",
-            "hash": "676118fb1d5b48cc9b88f06fac87bbc261bc910ce91f7e235c12854644857929"
+            "url": "https://github.com/supabase/cli/releases/download/v2.105.0/supabase_2.105.0_windows_arm64.zip",
+            "hash": "d2c277a65d8b68d5bf2bc0233ec0bd3e5beab6d3a4798ed7fa119113bc02412e"
         }
     },
     "bin": "supabase.exe",
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_amd64.tar.gz"
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_$version_windows_amd64.zip"
             },
             "arm64": {
-                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_windows_arm64.tar.gz"
+                "url": "https://github.com/supabase/cli/releases/download/v$version/supabase_$version_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Updates description/homepage metadata to match the official bucket.
- Align description with supabase owned bucket description: https://github.com/supabase/scoop-bucket/blob/main/supabase.json#L4
  Supabase doesn't use the "firebase open-source alternative" as a description for their cli tool anymore.
- Switches download artifacts from .tar.gz to .zip with versioned filenames.
- Fix autoupdate hash extraction.