### PR TITLE
opencv: Update to version 5.0.0, fix checkver

### DIFF
--- a/bucket/opencv.json
+++ b/bucket/opencv.json
@@ -1,30 +1,26 @@
 {
-    "version": "4.12.0",
+    "version": "5.0.0",
     "description": "Open Source Computer Vision Library",
     "homepage": "https://opencv.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/opencv/opencv/releases/download/4.12.0/opencv-4.12.0-windows.exe#/dl.7z",
-            "hash": "b753b14d880b9bc8d89d6acd3b665c040baec0211078435432fcae117db707af"
+            "url": "https://github.com/opencv/opencv/releases/download/5.0.0/opencv-5.0.0-windows.exe#/dl.7z",
+            "hash": "9c6c1fcea58acdf06edba13148b2246e00c2658143fa51e61ecd370db8c39f63",
+            "env_add_path": "x64\\vc16\\bin",
+            "env_set": {
+                "OPENCV_DIR": "$dir\\x64\\vc16"
+            }
         }
     },
     "extract_dir": "opencv\\build",
-    "env_set": {
-        "OPENCV_DIR": "$dir\\x64\\vc16"
-    },
-    "env_add_path": "x64\\vc16\\bin",
     "checkver": {
         "github": "https://github.com/opencv/opencv"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/opencv/opencv/releases/download/$version/opencv-$version-windows.exe#/dl.7z",
-                "hash": {
-                    "url": "https://github.com/opencv/opencv/releases",
-                    "regex": "$sha256\\sopencv-$version-windows.exe"
-                }
+                "url": "https://github.com/opencv/opencv/releases/download/$version/opencv-$version-windows.exe#/dl.7z"
             }
         }
     }

--- a/bucket/opencv.json
+++ b/bucket/opencv.json
@@ -15,8 +15,7 @@
     },
     "env_add_path": "x64\\vc16\\bin",
     "checkver": {
-        "url": "https://opencv.org/releases/",
-        "regex": "\\*\\s</span>OpenCV – ([\\d.]+)"
+        "github": "https://github.com/opencv/opencv"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

The official OpenCV website's [release page](https://opencv.org/releases/) is currently not being actively updated. The current `opencv` manifest relies on the page for its `checkver` checks. As a result, the Scoop package is significantly outdated (currently stuck at `4.12.0`).

Meanwhile, official releases on their GitHub repository are fully up-to-date. They have already released `4.13.0` and the major milestone `5.0.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped OpenCV target to 5.0.0.
  * Updated 64-bit Windows download URL and checksum for the new release.
  * Switched version detection to use the official OpenCV GitHub releases for more reliable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->