### PR TITLE
glazepkg: Fix license

### DIFF
--- a/bucket/glazepkg.json
+++ b/bucket/glazepkg.json
@@ -2,7 +2,7 @@
     "version": "0.5.4",
     "description": "See all your installed packages in one place.",
     "homepage": "https://github.com/neur0map/glazepkg",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/neur0map/glazepkg/releases/download/v0.5.4/gpk-windows-amd64.exe#/gpk.exe",


### PR DESCRIPTION
I mistakenly thought that as long as “Later” was mentioned in the LICENSE, it meant a “-or-later” agreement.
But it seems that the phrase (at your option) any later version isn’t present anywhere in the entire repository, and the LICENSE file also doesn’t explicitly mention “Later” in its header.

https://github.com/search?q=repo%3Aneur0map%2Fglazepkg+any+later+version&type=code

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
