### PR TITLE
rclip: Fix extraction

### DIFF
--- a/bucket/rclip.json
+++ b/bucket/rclip.json
@@ -9,7 +9,6 @@
             "hash": "08026283ee0848b82ba6f8e828c4e7beedfb545f615001b1f7801fb626c64600"
         }
     },
-    "extract_dir": "APPDIR",
     "bin": "rclip.exe",
     "checkver": "github",
     "autoupdate": {

--- a/bucket/rclip.json
+++ b/bucket/rclip.json
@@ -5,16 +5,21 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/yurijmikhalevich/rclip/releases/download/v3.2.3/rclip-3.2.3.msi",
+            "url": "https://github.com/yurijmikhalevich/rclip/releases/download/v3.2.3/rclip-3.2.3.msi#/dl.msi_",
             "hash": "08026283ee0848b82ba6f8e828c4e7beedfb545f615001b1f7801fb626c64600"
         }
     },
+    "pre_install": [
+        "# Lessmsi behaves differently from Msiexec in this case.",
+        "$ExtractDir = if (get_config USE_LESSMSI $false) { 'APPDIR' } else { '' }",
+        "Expand-MsiArchive -Path \"$dir\\$fname\" -DestinationPath $dir -ExtractDir $ExtractDir -Removal"
+    ],
     "bin": "rclip.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/yurijmikhalevich/rclip/releases/download/v$version/rclip-$version.msi"
+                "url": "https://github.com/yurijmikhalevich/rclip/releases/download/v$version/rclip-$version.msi#/dl.msi_"
             }
         }
     }


### PR DESCRIPTION
~~It seems unnecessary to extract_dir.~~

Lessmsi exhibits different behavior compared to Msiexec when extracting rclip.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
