### PR TITLE
openconnect@9.21: Fix `pre_install` script

### DIFF
--- a/bucket/openconnect.json
+++ b/bucket/openconnect.json
@@ -13,7 +13,7 @@
             "hash": "cd0c3ef3bf0270f9450bfe7e8958944920dea5e8ba58ba1cc21e0742eefa8cc3"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*.exe\" -Recurse",
     "bin": "openconnect.exe",
     "checkver": {
         "url": "https://www.infradead.org/openconnect/download.html",

--- a/bucket/openconnect.json
+++ b/bucket/openconnect.json
@@ -13,7 +13,7 @@
             "hash": "cd0c3ef3bf0270f9450bfe7e8958944920dea5e8ba58ba1cc21e0742eefa8cc3"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall OpenConnect.exe\" -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
     "bin": "openconnect.exe",
     "checkver": {
         "url": "https://www.infradead.org/openconnect/download.html",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

~`Uninstall OpenConnect.exe` is no longer bundled with the installer~ https://github.com/ScoopInstaller/Extras/issues/15709#issuecomment-4726716146

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
