### PR TITLE
rasm: Add version 0.2.1

### DIFF
--- a/bucket/rasm.json
+++ b/bucket/rasm.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.2.1",
+    "description": "x86_64 assembler with Intel syntax.",
+    "homepage": "https://github.com/dev-er1/rasm",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dev-er1/rasm/releases/download/v0.2.1/rasm-windows-amd64.zip",
+            "hash": "ccfd694705b953a4c443b99442fdc1daffac7aa8956523381113daa9e1f3c09d"
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dev-er1/rasm/releases/download/v$version/rasm-windows-amd64.zip"
+            }
+        }
+    },
+    "bin": "rasm.exe"
+}


### PR DESCRIPTION
Adds RASM, an x86_64 assembler with Intel syntax.

Homepage: https://github.com/dev-er1/rasm
License: Apache-2.0

* [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
* [x] I have read the Contributing Guide