### PR TITLE
tesseract-languages@4.1.0: Fix extraction

### DIFF
--- a/bucket/tesseract-languages.json
+++ b/bucket/tesseract-languages.json
@@ -12,22 +12,22 @@
     ],
     "depends": "tesseract",
     "url": [
-        "https://github.com/tesseract-ocr/tessdata_fast/archive/4.1.0.zip",
-        "https://raw.githubusercontent.com/tesseract-ocr/tessdata/d87b3cbc75555bd3282e0cadab5e159e2d468396/equ.traineddata",
+        "https://github.com/tesseract-ocr/tessdata_fast/archive/4.1.0.zip#/dl.7z_",
         "https://raw.githubusercontent.com/USCDataScience/counterfeit-electronics-tesseract/319a6eeacff181dad5c02f3e7a3aff804eaadeca/Training%20Tesseract/snum.traineddata"
     ],
     "hash": [
         "46ae18d17bd9583392ae7c047b751846233d4e030264a551e71ff4f25e035548",
-        "8f660323d8a7b7a0e8d2fae1a3439e6e470222bfbb990b2ab7fe9e1fb4791c0b",
         "36f772980ff17c66a767f584a0d80bf2302a1afa585c01a226c1863afcea1392"
     ],
-    "extract_dir": "tessdata_fast-4.1.0",
+    "pre_install": [
+        "# Use the -snl- switch to ignore symbolic link errors during decompression.",
+        "Expand-7zipArchive -Path \"$dir\\dl.7z_\" -ExtractDir \"tessdata_fast-$version\" -Switches '-snl-' -Removal"
+    ],
     "env_set": {
         "TESSDATA_PREFIX": "$dir"
     },
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/tesseract-ocr/tessdata_fast/archive/$version.zip",
-        "extract_dir": "tessdata_fast-$version"
+        "url": "https://github.com/tesseract-ocr/tessdata_fast/archive/$version.zip#/dl.7z_"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->
- Removed `equ.traineddata` as it already exists in [4.1.0](https://github.com/tesseract-ocr/tessdata_fast/commit/65727574dfcd264acbb0c3e07860e4e9e9b22185).
- Symlinks pointing to Git submodules cannot be resolved when downloaded from GitHub, which causes robocopy to fail. Unresolved symlinks are now ignored.

Closes #7401
Closes #8176
Relates to #4874
Relates to https://github.com/ScoopInstaller/Scoop/issues/6611
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
