### PR TITLE
langsmith-cli: Add version 0.2.37

### DIFF
--- a/bucket/langsmith-cli.json
+++ b/bucket/langsmith-cli.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.37",
+    "description": "A coding agent-first CLI for interacting with LangSmith.",
+    "homepage": "https://github.com/langchain-ai/langsmith-cli",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/langchain-ai/langsmith-cli/releases/download/v0.2.37/langsmith_windows_amd64.zip",
+            "hash": "add669fbe38e46ce35e4a80296b553492bc528abd82150d92cac2c1b5c521656"
+        },
+        "arm64": {
+            "url": "https://github.com/langchain-ai/langsmith-cli/releases/download/v0.2.37/langsmith_windows_arm64.zip",
+            "hash": "6a05409b6955d1b85931afaa8b60e3ae1829675d347e2b804557f8d911d4b837"
+        }
+    },
+    "bin": "langsmith.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/langchain-ai/langsmith-cli/releases/download/v$version/langsmith_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/langchain-ai/langsmith-cli/releases/download/v$version/langsmith_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
Closes #8185

- Add `langsmith-cli` manifest for the official LangSmith CLI release binary
- Support Windows amd64 and arm64 release ZIPs
- Add GitHub `checkver` and checksum-backed `autoupdate`

`langsmith-cli` installs the upstream binary unchanged. The upstream CLI includes `langsmith self-update`, but Scoop-managed installs should be updated with `scoop update langsmith-cli`; manually running `self-update` can replace the binary outside Scoop's manifest version tracking.

Validation:

- `pwsh -NoProfile -File .\bin\checkver.ps1 langsmith-cli`
- `pwsh -NoProfile -File .\bin\checkhashes.ps1 langsmith-cli`
- `pwsh -NoProfile -File .\bin\checkurls.ps1 langsmith-cli`
- `scoop install .\bucket\langsmith-cli.json`
- `langsmith --version`


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)