### PR TITLE
everything-cli: Update to version 1.1.0.37, fix checkver & autoupdate

### DIFF
--- a/bucket/everything-cli.json
+++ b/bucket/everything-cli.json
@@ -1,6 +1,6 @@
 {
     "version": "1.1.0.37",
-    "description": "Command line interface to Everything. (es.exe)",
+    "description": "Command line interface to Everything (also known as ES).",
     "homepage": "https://www.voidtools.com/support/everything/command_line_interface/",
     "license": "MIT",
     "suggest": {

--- a/bucket/everything-cli.json
+++ b/bucket/everything-cli.json
@@ -1,21 +1,23 @@
 {
-    "version": "1.1.0.30",
-    "description": "Command line interface to Everything.",
+    "version": "1.1.0.37",
+    "description": "Command line interface to Everything. (es.exe)",
     "homepage": "https://www.voidtools.com/support/everything/command_line_interface/",
     "license": "MIT",
-    "depends": "extras/everything",
+    "suggest": {
+        "Everything": "extras/everything"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://www.voidtools.com/ES-1.1.0.30.x64.zip",
-            "hash": "30147feadae528d4bbfb3bcb4597a4c7d9f52a0f9f708ea6577b6028bd8dd268"
+            "url": "https://github.com/voidtools/ES/releases/download/1.1.0.37/ES-1.1.0.37.x64.zip",
+            "hash": "7a57670d9152068d05876c58858c82fe6d3915a9df2c819f4de8801e2929d3a7"
         },
         "32bit": {
-            "url": "https://www.voidtools.com/ES-1.1.0.30.x86.zip",
-            "hash": "7e9f04cb92e9eb0440655a395537b204e98e3accd5335e610649d323b15f5117"
+            "url": "https://github.com/voidtools/ES/releases/download/1.1.0.37/ES-1.1.0.37.x86.zip",
+            "hash": "35f8fe8c92b44d834cf51239ee345927e44d33c6c86d64b756990b066fa0da47"
         },
         "arm64": {
-            "url": "https://www.voidtools.com/ES-1.1.0.30.ARM64.zip",
-            "hash": "af5f02b29d6e91b7e70d3b6809bbfe931af671d981e060ecb4f015c30f9697b9"
+            "url": "https://github.com/voidtools/ES/releases/download/1.1.0.37/ES-1.1.0.37.ARM64.zip",
+            "hash": "774dba860c3cecab95de43c95266754adfc8e92c7c59d6564a3b5dbaeb20dca8"
         }
     },
     "pre_install": [
@@ -26,19 +28,18 @@
     "bin": "es.exe",
     "persist": "es.ini",
     "checkver": {
-        "url": "https://www.voidtools.com/downloads/",
-        "regex": "ES-([\\d.]+)\\.x64\\.zip"
+        "github": "https://github.com/voidtools/ES"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.voidtools.com/ES-$version.x64.zip"
+                "url": "https://github.com/voidtools/ES/releases/download/$version/ES-$version.x64.zip"
             },
             "32bit": {
-                "url": "https://www.voidtools.com/ES-$version.x86.zip"
+                "url": "https://github.com/voidtools/ES/releases/download/$version/ES-$version.x86.zip"
             },
             "arm64": {
-                "url": "https://www.voidtools.com/ES-$version.ARM64.zip"
+                "url": "https://github.com/voidtools/ES/releases/download/$version/ES-$version.ARM64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
* Recent versions of everything-cli are now published from the author's [GitHub page](https://github.com/voidtools/ES/releases) and have not been added to the Voidtools homepage; switches checkver to point at the GitHub releases page and updates to most recent version, 1.1.0.37
* everything-cli is now compatible both with Everything 1.4 packaged at extras/everything and also Everything 1.5 alpha/beta packaged at versions/everything-alpha & -beta respectively. As a result, changed former "depends" field to "suggest" field.
* I've been maintaining my own manifest for this program for years because I couldn't find it through scoop.sh search. Added "es.exe" to the description to make it more discoverable :P

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
