### PR TITLE
kubeshark@53.3.0: Fix homepage & hash autoupdate

### DIFF
--- a/bucket/kubeshark.json
+++ b/bucket/kubeshark.json
@@ -1,7 +1,7 @@
 {
     "version": "53.3.0",
     "description": "The API Traffic Viewer for Kubernetes",
-    "homepage": "https://kubeshark.co",
+    "homepage": "https://kubeshark.com",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -18,8 +18,7 @@
             "64bit": {
                 "url": "https://github.com/kubeshark/kubeshark/releases/download/v$version/kubeshark.exe",
                 "hash": {
-                    "url": "$baseurl/kubeshark_windows_amd64.sha256",
-                    "regex": "$sha256"
+                    "url": "$url.sha256"
                 }
             }
         }


### PR DESCRIPTION
- Set actual homepage.
- Fix hash autoupdate.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
