### PR TITLE
xdelta: Update to version 3.2.0, switch to active jmacd/xdelta repo

### DIFF
--- a/bucket/xdelta.json
+++ b/bucket/xdelta.json
@@ -1,69 +1,35 @@
 {
-    "version": "3.1.0",
-    "description": "Open-source binary diff, delta/differential compression tools, VCDIFF/RFC 3284 delta compression.",
-    "homepage": "http://xdelta.org/",
-    "license": "GPL-2.0-only",
+    "version": "3.2.0",
+    "description": "Xdelta version 3 is a C library and command-line tool for delta compression using VCDIFF/RFC 3284 streams.",
+    "homepage": "https://xdelta.org",
+    "license": "Apache-2.0",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v3.1.0/xdelta3-3.1.0-x86_64.exe.zip",
-            "hash": "b10e0d1df3e212e5a2d37d5c088d2f72ecec760bc3c26caeca51499c3118b93a",
-            "bin": [
-                [
-                    "xdelta3-3.1.0-x86_64.exe",
-                    "xdelta3"
-                ],
-                [
-                    "xdelta3-3.1.0-x86_64.exe",
-                    "xdelta"
-                ]
-            ]
-        },
-        "32bit": {
-            "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v3.1.0/xdelta3-3.1.0-i686.exe.zip",
-            "hash": "1e72f920dbae1b4edc7be0feba841d78fb06ad38b67630e99d5ff655d8c5d62f",
-            "bin": [
-                [
-                    "xdelta3-3.1.0-i686.exe",
-                    "xdelta3"
-                ],
-                [
-                    "xdelta3-3.1.0-i686.exe",
-                    "xdelta"
-                ]
-            ]
+            "url": "https://github.com/jmacd/xdelta/releases/download/v3.2.0/xdelta3-3.2.0-windows-x86_64.zip",
+            "hash": "af8ef036cb077a48df080c9a8ac1be4a6e7511c32d11f8bec89b6803a9e52576"
         }
     },
+    "extract_dir": "xdelta3-3.2.0-windows-x86_64",
+    "bin": [
+        "xdelta3.exe",
+        [
+            "xdelta3.exe",
+            "xdelta"
+        ],
+        "xdelta3decode.exe"
+    ],
     "checkver": {
-        "github": "https://github.com/jmacd/xdelta-gpl"
+        "github": "https://github.com/jmacd/xdelta"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v$version/xdelta3-$version-x86_64.exe.zip",
-                "bin": [
-                    [
-                        "xdelta3-$version-x86_64.exe",
-                        "xdelta3"
-                    ],
-                    [
-                        "xdelta3-$version-x86_64.exe",
-                        "xdelta"
-                    ]
-                ]
-            },
-            "32bit": {
-                "url": "https://github.com/jmacd/xdelta-gpl/releases/download/v$version/xdelta3-$version-i686.exe.zip",
-                "bin": [
-                    [
-                        "xdelta3-$version-i686.exe",
-                        "xdelta3"
-                    ],
-                    [
-                        "xdelta3-$version-i686.exe",
-                        "xdelta"
-                    ]
-                ]
+                "url": "https://github.com/jmacd/xdelta/releases/download/v$version/xdelta3-$version-windows-x86_64.zip"
             }
-        }
+        },
+        "extract_dir": "xdelta3-$version-windows-x86_64"
     }
 }

--- a/bucket/xdelta.json
+++ b/bucket/xdelta.json
@@ -1,7 +1,7 @@
 {
     "version": "3.2.0",
     "description": "Xdelta version 3 is a C library and command-line tool for delta compression using VCDIFF/RFC 3284 streams.",
-    "homepage": "https://xdelta.org",
+    "homepage": "https://github.com/jmacd/xdelta",
     "license": "Apache-2.0",
     "suggest": {
         "vcredist": "extras/vcredist2022"
@@ -9,10 +9,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jmacd/xdelta/releases/download/v3.2.0/xdelta3-3.2.0-windows-x86_64.zip",
-            "hash": "af8ef036cb077a48df080c9a8ac1be4a6e7511c32d11f8bec89b6803a9e52576"
+            "hash": "af8ef036cb077a48df080c9a8ac1be4a6e7511c32d11f8bec89b6803a9e52576",
+            "extract_dir": "xdelta3-3.2.0-windows-x86_64"
         }
     },
-    "extract_dir": "xdelta3-3.2.0-windows-x86_64",
     "bin": [
         "xdelta3.exe",
         [
@@ -21,15 +21,13 @@
         ],
         "xdelta3decode.exe"
     ],
-    "checkver": {
-        "github": "https://github.com/jmacd/xdelta"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jmacd/xdelta/releases/download/v$version/xdelta3-$version-windows-x86_64.zip"
+                "url": "https://github.com/jmacd/xdelta/releases/download/v$version/xdelta3-$version-windows-x86_64.zip",
+                "extract_dir": "xdelta3-$version-windows-x86_64"
             }
-        },
-        "extract_dir": "xdelta3-$version-windows-x86_64"
+        }
     }
 }


### PR DESCRIPTION
> The `xdelta` manifest tracks [`jmacd/xdelta-gpl`](https://github.com/jmacd/xdelta-gpl), which is abandoned: its last release is `v3.1.0` (Jan 2016) and the repo has had no pushes since 2018. As a result the manifest is frozen at 3.1.0 and `checkver` can never advance it.
> 
> The author has since moved active development to the canonical repo [`jmacd/xdelta`](https://github.com/jmacd/xdelta), re-licensed under Apache-2.0. That repo released `v3.2.0` on 2026-06-21 with a self-contained prebuilt Windows binary. The manifest should track this active repo so it stays current.

Closes #8202

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)