### PR TITLE
grok-cli: Add version 0.2.67

### DIFF
--- a/bucket/grok-cli.json
+++ b/bucket/grok-cli.json
@@ -3,7 +3,8 @@
     "description": "An extensible coding agent that can be used interactively, in scripts, or through the Agent Client Protocol",
     "homepage": "https://x.ai/cli",
     "license": {
-        "identifier": "Proprietary"
+        "identifier": "Proprietary",
+        "url": "https://x.ai/legal/terms-of-service"
     },
     "architecture": {
         "64bit": {

--- a/bucket/grok-cli.json
+++ b/bucket/grok-cli.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.67",
+    "description": "An extensible coding agent that can be used interactively, in scripts, or through the Agent Client Protocol",
+    "homepage": "https://x.ai/cli",
+    "license": {
+        "identifier": "Proprietary"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://x.ai/cli/grok-0.2.67-windows-x86_64.exe#/grok.exe",
+            "hash": "5727644f66599522c95b2a0e3591393554447bf1799106b1be3358d7d3e72234"
+        },
+        "arm64": {
+            "url": "https://x.ai/cli/grok-0.2.67-windows-aarch64.exe#/grok.exe",
+            "hash": "699b58a9fbcbca4377869ffc601ce3e95c5135ab6821147fd3d75b9614dc5849"
+        }
+    },
+    "bin": "grok.exe",
+    "checkver": {
+        "url": "https://x.ai/cli/stable",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://x.ai/cli/grok-$version-windows-x86_64.exe#/grok.exe"
+            },
+            "arm64": {
+                "url": "https://x.ai/cli/grok-$version-windows-aarch64.exe#/grok.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Per @z-Fng's suggestion in https://github.com/ScoopInstaller/Main/issues/8216#issuecomment-4797117832, Grok CLI meets the main-bucket criteria, so opening it against Main instead of Extras (replaces ScoopInstaller/Extras#18133).

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)