### PR TITLE
doggo: Update to version 1.2.0, fix autoupdate

### DIFF
--- a/bucket/doggo.json
+++ b/bucket/doggo.json
@@ -1,18 +1,16 @@
 {
-    "version": "1.1.7",
+    "version": "1.2.0",
     "description": "Command-line DNS Client for Humans",
     "homepage": "https://doggo.mrkaran.dev/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mr-karan/doggo/releases/download/v1.1.7/doggo_1.1.7_Windows_x86_64.zip",
-            "hash": "f26b855ad241db1c3c1f86bb80206aefe433ace71fa391b87ed75e293dbe03f8",
-            "extract_dir": "doggo_1.1.7_Windows_x86_64"
+            "url": "https://github.com/mr-karan/doggo/releases/download/v1.2.0/doggo-windows-x86_64.zip",
+            "hash": "a84f677f7596c320f419cdc035adb64e89def37fb1ee6c57500a39742024e664"
         },
         "32bit": {
-            "url": "https://github.com/mr-karan/doggo/releases/download/v1.1.7/doggo_1.1.7_Windows_i386.zip",
-            "hash": "24eaa46c9e34e4c64eb70fcb573fb9676c0e93657be6ce775e3cd5edbb028481",
-            "extract_dir": "doggo_1.1.7_Windows_i386"
+            "url": "https://github.com/mr-karan/doggo/releases/download/v1.2.0/doggo-windows-i386.zip",
+            "hash": "35388ff89c90e0f22beecc70a9fad38daa88c30768655fa3cea07462abc80969"
         }
     },
     "bin": "doggo.exe",
@@ -22,12 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_x86_64.zip",
-                "extract_dir": "doggo_$version_Windows_x86_64"
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo-windows-x86_64.zip"
             },
             "32bit": {
-                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo_$version_Windows_i386.zip",
-                "extract_dir": "doggo_$version_Windows_i386"
+                "url": "https://github.com/mr-karan/doggo/releases/download/v$version/doggo-windows-i386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
- Fix autoupdate, remove `extract_dir`.
- Update to the latest version.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
