### PR TITLE
no-mistakes: Add version 1.30.1

### DIFF
--- a/bucket/no-mistakes.json
+++ b/bucket/no-mistakes.json
@@ -14,7 +14,6 @@
         }
     },
     "env_set": {
-        "NO_MISTAKES_TELEMETRY": "0",
         "NO_MISTAKES_NO_UPDATE_CHECK": "1"
     },
     "bin": "no-mistakes.exe",

--- a/bucket/no-mistakes.json
+++ b/bucket/no-mistakes.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.30.1",
+    "description": "A local Git proxy that AI-validates your code before push, forwarding only clean commits upstream.",
+    "homepage": "https://kunchenguid.github.io/no-mistakes",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kunchenguid/no-mistakes/releases/download/v1.30.1/no-mistakes-v1.30.1-windows-amd64.zip",
+            "hash": "6d324e16b1ef51c0ba8ca0073bf839e91d790566d36d40011c49199da1201694"
+        },
+        "arm64": {
+            "url": "https://github.com/kunchenguid/no-mistakes/releases/download/v1.30.1/no-mistakes-v1.30.1-windows-arm64.zip",
+            "hash": "11ec1108dc22b4a19c01db72ef368ac56dfa16488bf0079ace3d1c0cca530579"
+        }
+    },
+    "env_set": {
+        "NO_MISTAKES_TELEMETRY": "0",
+        "NO_MISTAKES_NO_UPDATE_CHECK": "1"
+    },
+    "bin": "no-mistakes.exe",
+    "checkver": {
+        "github": "https://github.com/kunchenguid/no-mistakes"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kunchenguid/no-mistakes/releases/download/v$version/no-mistakes-v$version-windows-amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/kunchenguid/no-mistakes/releases/download/v$version/no-mistakes-v$version-windows-arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "$sha256\\s+$basename"
+        }
+    }
+}


### PR DESCRIPTION
I think should set:

```
    "env_set": {
        "NO_MISTAKES_TELEMETRY": "0",
        "NO_MISTAKES_NO_UPDATE_CHECK": "1"
    },
```

Refer to https://kunchenguid.github.io/no-mistakes/start-here/installation/#update

Closes #8223 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
