### PR TITLE
erlang: Update to version 29.0.2, drop 32bit support

### DIFF
--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -1,5 +1,5 @@
 {
-    "version": "28.5",
+    "version": "29.0.2",
     "description": "A programming language used to build massively scalable soft real-time systems with requirements on high availability.",
     "homepage": "https://www.erlang.org",
     "license": "Apache-2.0",
@@ -8,12 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/erlang/otp/releases/download/OTP-28.5/otp_win64_28.5.exe#/dl.7z",
-            "hash": "46f56351e2e67865c6aaff83bcd0a7d97d73bea643a0531774dd9ba8fbee7dc0"
-        },
-        "32bit": {
-            "url": "https://github.com/erlang/otp/releases/download/OTP-28.5/otp_win32_28.5.exe#/dl.7z",
-            "hash": "1ff929353ba972fafbcba61dc8aa597874fef296f13d8e977984cef8b6fbf9e8"
+            "url": "https://github.com/erlang/otp/releases/download/OTP-29.0.2/otp_win64_29.0.2.exe#/dl.7z",
+            "hash": "19a7cf20d17716689996f7d47011fd62df6b4ebae9ba93becc0df90c9f93c111"
         }
     },
     "installer": {
@@ -44,9 +40,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/erlang/otp/releases/download/OTP-$version/otp_win64_$version.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/erlang/otp/releases/download/OTP-$version/otp_win32_$version.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Update Erlang version to 29.0.2

https://github.com/erlang/otp/releases/tag/OTP-29.0

> There is no longer a 32-bit Erlang/OTP build for Windows.
>
> Own Id: OTP-19960
> Application(s): otp

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Closes #8226 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
