### PR TITLE
chess-journal: Add version 0.1.33

### DIFF
--- a/bucket/chess-journal.json
+++ b/bucket/chess-journal.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.1.33",
+  "description": "Stockfish analysis, local AI commentary, 26K games & 5K puzzles — free desktop chess app.",
+  "homepage": "https://github.com/sazardev/chess-journal",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/sazardev/chess-journal/releases/download/v0.1.33/Chess.Journal_0.1.33_x64-setup.exe#/dl.7z",
+      "hash": "416e12000859c214ca5580ae456edaf0192047994baa5c384042fddc3513f76b"
+    }
+  },
+  "pre_install": [
+    "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse -Force"
+  ],
+  "shortcuts": [
+    [
+      "Chess Journal.exe",
+      "Chess Journal"
+    ]
+  ],
+  "checkver": "github",
+  "autoupdate": {
+    "url": "https://github.com/sazardev/chess-journal/releases/download/v$version/Chess.Journal_$version_x64-setup.exe#/dl.7z"
+  }
+}


### PR DESCRIPTION
Adds Chess Journal v0.1.33 to the Scoop bucket.

Chess Journal is a free, open-source chess app with Stockfish engine analysis, on-device AI commentary (no cloud, no API key), 26,000+ built-in games, 5,037 puzzles, smart natural-language search, Chess.com import, opening detection, and assistive coaching. All features work offline. MIT licensed.

- Auto-update via checkver (GitHub Releases)
- 64-bit only (Windows)