### PR TITLE
postgresql: Update to version 18.4-2, fix checkver & autoupdate

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://get.enterprisedb.com/postgresql/postgresql-18.4-1-windows-x64-binaries.zip",
-            "hash": "7effe34c0bf89027b3f171447d351cbc460f4566c8d0f643daec67f140787858"
+            "url": "https://get.enterprisedb.com/postgresql/postgresql-18.4-2-windows-x64-binaries.zip",
+            "hash": "02e239529ed7833d169f98d915d3feffe0813264b08b3ae353e78e8b9c97e1a6"
         }
     },
     "extract_dir": "pgsql",
@@ -34,13 +34,13 @@
     },
     "persist": "data",
     "checkver": {
-        "url": "https://www.enterprisedb.com/downloads/postgres-postgresql-downloads",
+        "url": "https://www.enterprisedb.com/download-postgresql-binaries",
         "regex": ">(?<version>\\d+\\.[\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-1-windows-x64-binaries.zip"
+                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-2-windows-x64-binaries.zip"
             }
         }
     }

--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -1,5 +1,5 @@
 {
-    "version": "18.4",
+    "version": "18.4-2",
     "description": "Object-relational database management system based on POSTGRES.",
     "homepage": "https://www.postgresql.org",
     "license": "PostgreSQL",
@@ -34,13 +34,19 @@
     },
     "persist": "data",
     "checkver": {
-        "url": "https://www.enterprisedb.com/download-postgresql-binaries",
-        "regex": ">(?<version>\\d+\\.[\\d.]+)<"
+        "url": "https://www.enterprisedb.com/downloads/postgres-postgresql-downloads",
+        "script": [
+            "$url = ([xml]$page).SelectSingleNode('//table/tbody/tr[1]/td[5]/a').href",
+            "$request = [System.Net.HttpWebRequest]::Create($url)",
+            "$response = $request.GetResponse()",
+            "Write-Output $response.ResponseUri.AbsoluteUri"
+        ],
+        "regex": "postgresql-(?<version>\\d+\\.\\d+-\\d+)-windows"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-2-windows-x64-binaries.zip"
+                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-windows-x64-binaries.zip"
             }
         }
     }


### PR DESCRIPTION
EDB restructured their downloads page (enterprisedb.com/download-postgresql-binaries); it no longer exposes direct filenames, only opaque sbp.enterprisedb.com/getfile.jsp redirects. Resolving that redirect shows PostgreSQL 18.4 Windows binaries are now packaged as build "-2" (the "-1" build is no longer served). Updated url, hash, and autoupdate template accordingly.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
