### PR TITLE
libjxl@0.12.0: Fix shims, migrate from ZIP to 7z release

### DIFF
--- a/bucket/libjxl.json
+++ b/bucket/libjxl.json
@@ -3,34 +3,32 @@
     "description": "JPEG XL image format (.jxl) encode/decode tools",
     "homepage": "https://jpeg.org/jpegxl",
     "license": "BSD-3-Clause",
-    "notes": "If the shim for brotli.exe was overwritten by this app's version and you'd like to point it back to brotli's version, run `scoop reset brotli`.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/libjxl/libjxl/releases/download/v0.12.0/jxl-x64-windows-static.zip",
-            "hash": "3025d7e308390796d20492322e606bc92decaee7b6bc99d3f7547870ae5db7de"
+            "url": "https://github.com/libjxl/libjxl/releases/download/v0.12.0/jxl-x64-windows-static.7z",
+            "hash": "ff147dc7ac4ce55392974ccc70f2a8a8ec0eff3ae28529b072258b66c8f01ab2",
+            "extract_dir": "x64-windows-static"
         },
         "32bit": {
-            "url": "https://github.com/libjxl/libjxl/releases/download/v0.12.0/jxl-x86-windows-static.zip",
-            "hash": "a675587f4fa4f907081ad2abb59d3e2890cac20c91350c27a9b4518f8952941c"
+            "url": "https://github.com/libjxl/libjxl/releases/download/v0.12.0/jxl-x86-windows-static.7z",
+            "hash": "c6f419659910a68782810a400aadaf5c1bfcbc67ea324223af09d7a7477c16cc",
+            "extract_dir": "x86-windows-static"
         }
     },
     "bin": [
         "bin\\benchmark_xl.exe",
-        "bin\\brotli.exe",
         "bin\\butteraugli_main.exe",
-        "bin\\cjpegli.exe",
         "bin\\cjxl.exe",
         "bin\\decode_and_encode.exe",
         "bin\\display_to_hlg.exe",
-        "bin\\djpegli.exe",
         "bin\\djxl_fuzzer_corpus.exe",
         "bin\\djxl.exe",
         "bin\\exr_to_pq.exe",
         "bin\\generate_lut_template.exe",
         "bin\\icc_simplify.exe",
-        "bin\\jpegli_dec_fuzzer_corpus.exe",
         "bin\\jxl_from_tree.exe",
         "bin\\jxlinfo.exe",
+        "bin\\jxltran.exe",
         "bin\\local_tone_map.exe",
         "bin\\pq_to_hlg.exe",
         "bin\\render_hlg.exe",
@@ -46,10 +44,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x64-windows-static.zip"
+                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x64-windows-static.7z",
             },
             "32bit": {
-                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x86-windows-static.zip"
+                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x86-windows-static.7z",
             }
         }
     }

--- a/bucket/libjxl.json
+++ b/bucket/libjxl.json
@@ -44,10 +44,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x64-windows-static.7z",
+                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x64-windows-static.7z"
             },
             "32bit": {
-                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x86-windows-static.7z",
+                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x86-windows-static.7z"
             }
         }
     }


### PR DESCRIPTION
Fix the libjxl manifest for the 0.12.0 [release](https://github.com/libjxl/libjxl/releases/tag/v0.12.0).
### Changes
- Removed `jpeggli` executables
- Removed `brotli` executable and note https://github.com/libjxl/libjxl/issues/4895#issuecomment-4867565971
- Added new `jxltran` executable
- Changed from .zip to .7z download (same contents, much smaller file size)
- Added `extract_dir`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
