### PR TITLE
zor-code: Add version 0.1.0

### DIFF
--- a/bucket/zor-code.json
+++ b/bucket/zor-code.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.1.0",
+  "description": "Open-source AI coding agent for the terminal",
+  "homepage": "https://github.com/Zor-AI/zor",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/Zor-AI/zor/releases/download/v0.1.0/zor-code-windows-x86_64.exe",
+      "hash": "825af236d9f01dfb92489b5d9005f132655dc4dd75829f57956921358f75e01e",
+      "bin": "zor-code-windows-x86_64.exe"
+    }
+  },
+  "checkver": {
+    "github": "https://github.com/Zor-AI/zor"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/Zor-AI/zor/releases/download/v$version/zor-code-windows-x86_64.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add zor-code manifest for the open-source AI coding agent for the terminal.

- 27 LLM providers
- Local model support via Ollama
- MCP support
- Versioned URL with SHA256 hash