### PR TITLE
gosuki@1.4.1: Switch from `.tar.gz` to `.zip` releases

### DIFF
--- a/bucket/gosuki.json
+++ b/bucket/gosuki.json
@@ -5,16 +5,16 @@
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/blob42/gosuki/releases/download/v1.4.1/gosuki-v1.4.1-windows-amd64.tar.gz",
-            "hash": "53c1fd2ab12e4796284a95732bea8b7fc68f17c14542ca83d82c01619b49c537",
+            "url": "https://github.com/blob42/gosuki/releases/download/v1.4.1/gosuki-v1.4.1-windows-amd64.zip",
+            "hash": "af2f45c5980b2997fbd7792457f2dc6fd6a6a1e87b2366020bdaeccec1f0528f",
             "bin": [
                 "gosuki.exe",
                 "suki.exe"
             ]
         },
         "32bit": {
-            "url": "https://github.com/blob42/gosuki/releases/download/v1.4.1/gosuki-v1.4.1-windows-386.tar.gz",
-            "hash": "087e3777657dc5ed0badea9cdcb1904f5023df3efc3ce406d23cef7f8bfe4f4d",
+            "url": "https://github.com/blob42/gosuki/releases/download/v1.4.1/gosuki-v1.4.1-windows-386.zip",
+            "hash": "f211ef704acfcc55624902de1e179e4298a011161f4e1e80e402e02a10b59ad9",
             "bin": [
                 [
                     "gosuki-386.exe",
@@ -34,10 +34,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/blob42/gosuki/releases/download/v$version/gosuki-v$version-windows-amd64.tar.gz"
+                "url": "https://github.com/blob42/gosuki/releases/download/v$version/gosuki-v$version-windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/blob42/gosuki/releases/download/v$version/gosuki-v$version-windows-386.tar.gz"
+                "url": "https://github.com/blob42/gosuki/releases/download/v$version/gosuki-v$version-windows-386.zip"
             }
         },
         "extract_dir": "gosuki-v$version"


### PR DESCRIPTION
It changed the releases name, https://github.com/blob42/gosuki/releases/tag/v1.4.1

> Windows binaries packaged in zip instead of tar.gz

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
