### PR TITLE
officecli: Add version 1.0.133

### DIFF
--- a/bucket/officecli.json
+++ b/bucket/officecli.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.0.129",
+    "version": "1.0.132",
     "description": "Read, edit, and automate Office documents (.docx, .xlsx, .pptx)",
     "homepage": "https://officecli.ai",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.129/officecli-win-x64.exe#/officecli.exe",
-            "hash": "e4c84a4a32f4d22f3880575d16b1499856d1c48e86d293274919906f95d81057"
+            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.132/officecli-win-x64.exe#/officecli.exe",
+            "hash": "303ff8bfbf05f5535ed423b59d8d664bb4c95c1e646a0cce2a619996fbe0f6de"
         },
         "arm64": {
-            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.129/officecli-win-arm64.exe#/officecli.exe",
-            "hash": "77fb8f7802593d40d751e59281ca7a454d6f339061c0b4bc97dc0bb37c12a798"
+            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.132/officecli-win-arm64.exe#/officecli.exe",
+            "hash": "f5cd21e28158c88175d1cc5dccd863e1a8d618625c4223f658c3f9ea5987092e"
         }
     },
     "bin": "officecli.exe",
@@ -20,19 +20,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-x64.exe#/officecli.exe",
-                "hash": {
-                    "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/SHA256SUMS",
-                    "regex": "([a-fA-F\\d]{64})\\s+officecli-win-x64\\.exe"
-                }
+                "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-x64.exe#/officecli.exe"
             },
             "arm64": {
-                "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-arm64.exe#/officecli.exe",
-                "hash": {
-                    "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/SHA256SUMS",
-                    "regex": "([a-fA-F\\d]{64})\\s+officecli-win-arm64\\.exe"
-                }
+                "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-arm64.exe#/officecli.exe"
             }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
         }
     }
 }

--- a/bucket/officecli.json
+++ b/bucket/officecli.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.0.129",
+    "description": "Read, edit, and automate Office documents (.docx, .xlsx, .pptx)",
+    "homepage": "https://officecli.ai",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.129/officecli-win-x64.exe#/officecli.exe",
+            "hash": "e4c84a4a32f4d22f3880575d16b1499856d1c48e86d293274919906f95d81057"
+        },
+        "arm64": {
+            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.129/officecli-win-arm64.exe#/officecli.exe",
+            "hash": "77fb8f7802593d40d751e59281ca7a454d6f339061c0b4bc97dc0bb37c12a798"
+        }
+    },
+    "bin": "officecli.exe",
+    "checkver": {
+        "github": "https://github.com/iOfficeAI/OfficeCLI"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-x64.exe#/officecli.exe",
+                "hash": {
+                    "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/SHA256SUMS",
+                    "regex": "([a-fA-F\\d]{64})\\s+officecli-win-x64\\.exe"
+                }
+            },
+            "arm64": {
+                "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-arm64.exe#/officecli.exe",
+                "hash": {
+                    "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/SHA256SUMS",
+                    "regex": "([a-fA-F\\d]{64})\\s+officecli-win-arm64\\.exe"
+                }
+            }
+        }
+    }
+}

--- a/bucket/officecli.json
+++ b/bucket/officecli.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.133",
-    "description": "Read, edit, and automate Office documents (.docx, .xlsx, .pptx)",
+    "description": "The world's first and the best Office suite designed for AI agents",
     "homepage": "https://officecli.ai",
     "license": "Apache-2.0",
     "architecture": {
@@ -25,9 +25,6 @@
             "arm64": {
                 "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v$version/officecli-win-arm64.exe#/officecli.exe"
             }
-        },
-        "hash": {
-            "url": "$baseurl/SHA256SUMS"
         }
     }
 }

--- a/bucket/officecli.json
+++ b/bucket/officecli.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.0.132",
+    "version": "1.0.133",
     "description": "Read, edit, and automate Office documents (.docx, .xlsx, .pptx)",
     "homepage": "https://officecli.ai",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.132/officecli-win-x64.exe#/officecli.exe",
-            "hash": "303ff8bfbf05f5535ed423b59d8d664bb4c95c1e646a0cce2a619996fbe0f6de"
+            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.133/officecli-win-x64.exe#/officecli.exe",
+            "hash": "899bfe2989f51b0322c8d47b302dc2cd0d64c751c16411792f4bf00a8300d1f8"
         },
         "arm64": {
-            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.132/officecli-win-arm64.exe#/officecli.exe",
-            "hash": "f5cd21e28158c88175d1cc5dccd863e1a8d618625c4223f658c3f9ea5987092e"
+            "url": "https://github.com/iOfficeAI/OfficeCLI/releases/download/v1.0.133/officecli-win-arm64.exe#/officecli.exe",
+            "hash": "a8eb62283c8fd987a8ba29da479c255585c81e2c62dd9edf0bee20c2ad244ae2"
         }
     },
     "bin": "officecli.exe",


### PR DESCRIPTION
Closes ScoopInstaller/Main#8278

Moved from ScoopInstaller/Extras#18249 at @niheaven's suggestion (pure CLI tool, fits Main). The manifest is identical to the one that passed all checks there (Lint / Description / License / Hashes / Checkver / Autoupdate / Autoupdate Hash Extraction).

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

[officecli](https://github.com/iOfficeAI/OfficeCLI) — read, edit, and automate Office documents (.docx, .xlsx, .pptx) from the command line. Single self-contained binary, Apache-2.0, ~9k stars. Already in Homebrew core and on npm.

- 64bit + arm64, hashes verified against the release's `SHA256SUMS`
- Explicit `checkver.github` + autoupdate with per-arch hash extraction from `SHA256SUMS`