### PR TITLE
catime: Add version 1.5.0

### DIFF
--- a/bucket/catime.json
+++ b/bucket/catime.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.5.0",
+    "description": "An ultra-lightweight Windows countdown and Pomodoro timer",
+    "homepage": "https://github.com/vladelaina/Catime",
+    "license": "Apache-2.0",
+    "url": "https://github.com/vladelaina/Catime/releases/download/v1.5.0/catime_1.5.0.exe#/catime.exe",
+    "hash": "f89c30c2d076d22870eceee79672d9ed0f5742f994c624a9bb1a7dd61bea1e8d",
+    "bin": "catime.exe",
+    "shortcuts": [
+        [
+            "catime.exe",
+            "Catime"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/vladelaina/Catime"
+    },
+    "autoupdate": {
+        "url": "https://github.com/vladelaina/Catime/releases/download/v$version/catime_$version.exe#/catime.exe"
+    }
+}


### PR DESCRIPTION
Closes ScoopInstaller/Extras#18284

## Summary

Add Catime 1.5.0 to the Main bucket.

Catime is an ultra-lightweight, portable Windows countdown and Pomodoro timer. It supports both command-line and system tray operation.

## Features

- Start a timer from the command line, for example: `catime 25m`
- Left-click the tray icon to quickly select and start a timer
- Right-click the tray icon to access countdown, Pomodoro, appearance, notification, plugin, and other settings
- Support for custom fonts, tray animations, notification sounds, and plugins
- Distributed as a lightweight standalone Win32 executable
- Does not require administrator privileges

## Popularity and reputation

- 4.4k+ GitHub stars
- 177+ GitHub forks
- Featured as a "Repository of the Day"
- Actively maintained with versioned GitHub Releases
- Open-source under the Apache-2.0 license

## Manifest details

The manifest includes:

- A verified SHA256 hash for the GitHub Release executable
- A `catime.exe` command-line shim
- A Start Menu shortcut
- GitHub-based version checking
- Automatic update URL generation

User configuration, fonts, plugins, notification sounds, and tray animations are stored under `%LOCALAPPDATA%\Catime`, so they are preserved across Scoop upgrades.

## Links

- Homepage: https://github.com/vladelaina/Catime
- Release: https://github.com/vladelaina/Catime/releases/tag/v1.5.0
- License: https://github.com/vladelaina/Catime/blob/main/LICENSE

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)