### PR TITLE
osf-cli-go: Add version 0.3.2

### DIFF
--- a/bucket/osf-cli-go.json
+++ b/bucket/osf-cli-go.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.3.2",
+  "description": "Command-line client for the Open Science Framework",
+  "homepage": "https://github.com/edithatogo/osf-cli-go",
+  "license": "Apache-2.0",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/edithatogo/osf-cli-go/releases/download/v0.3.2/osf-windows-amd64.exe",
+      "hash": "ff1b7f07439af40e8f566231b1d9451de99c25a08b773ce48d12142c950164bc"
+    },
+    "arm64": {
+      "url": "https://github.com/edithatogo/osf-cli-go/releases/download/v0.3.2/osf-windows-arm64.exe",
+      "hash": "34d026382ffd17a9c01ee0dee3b094d14053420a5432ddcfdd6b78fcaf299c80"
+    }
+  },
+  "bin": "osf.exe",
+  "post_install": [
+    "$binary = \"osf-windows-$architecture.exe\"",
+    "Rename-Item -LiteralPath (Join-Path $dir.currentVersion $binary) -NewName osf.exe"
+  ],
+  "checkver": {
+    "github": "https://github.com/edithatogo/osf-cli-go"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/edithatogo/osf-cli-go/releases/download/v$version/osf-windows-amd64.exe"
+      },
+      "arm64": {
+        "url": "https://github.com/edithatogo/osf-cli-go/releases/download/v$version/osf-windows-arm64.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds OSF CLI Go, a command-line client for the Open Science Framework.

## Validation
- Release asset URLs and SHA-256 hashes verified against v0.3.2.
- Manifest includes checkver and autoupdate metadata.
- Portable command is `osf`.

Source repository: https://github.com/edithatogo/osf-cli-go