### PR TITLE
innounp: Update to version 2.67.10, enable checkver

### DIFF
--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,11 +1,15 @@
 {
-    "version": "2.67.9",
+    "version": "2.67.10",
     "description": "Inno Setup Unpacker (Unicode)",
     "homepage": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/jrathlev/InnoUnpacker-Windows-GUI/releases/download/ui_2_2_9/innounp-2.zip",
-    "hash": "1439f8d9e24b19e7d0b31b9c427ba4533387522a370c39280f17d3371eb7febf",
+    "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-2.zip",
+    "hash": "5b96dbc57e7c87961366233d823fb471316b1eb6119e4914ced807d52c2b6f7d",
     "bin": "innounp.exe",
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/docs/innounp.htm",
+        "regex": "(?s)What's new/History.*?<b>(\\d+(?:\\.\\d+){2})</b>"
+    },
     "autoupdate": {
         "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-2.zip"
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

> A bug was introduced in innounp 2.67.10 that causes all extractions to fail. This PR rolls it back to version 2.67.9 ([0e86906](https://github.com/ScoopInstaller/Main/commit/0e86906e443f1953558f2032e5b50f4d786fdf7f)) and disables checkver.

v2.67.10 has been re-released with the bug fixed.

Relates to #8294

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
