### PR TITLE
oh-my-posh: Update to version 29.28.0

### DIFF
--- a/bucket/oh-my-posh.json
+++ b/bucket/oh-my-posh.json
@@ -1,5 +1,5 @@
 {
-    "version": "29.27.0",
+    "version": "29.28.0",
     "description": "A prompt theme engine for any shell",
     "homepage": "https://ohmyposh.dev",
     "license": "MIT",
@@ -7,22 +7,22 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.27.0/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.27.0/posh-windows-amd64.exe#/oh-my-posh.exe"
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.28.0/themes.zip",
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.28.0/posh-windows-amd64.exe#/oh-my-posh.exe"
             ],
             "hash": [
-                "711ee53a02a50d3f530c3bb67ba9a246b42bce9466af545f49ba0f0b9ccf6078",
-                "8b2023aa6250715fe908f7d675d18f7b368743d92c26528e088bed19459e5b64"
+                "d1a79400728eb84d22d75989d7bee59b91724a5a1bc413e61b37e52691404950",
+                "effa74ca461c6e467dd1c35801163697bf2055cf2fc9716550b0137cf89d9038"
             ]
         },
         "arm64": {
             "url": [
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.27.0/themes.zip",
-                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.27.0/posh-windows-arm64.exe#/oh-my-posh.exe"
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.28.0/themes.zip",
+                "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v29.28.0/posh-windows-arm64.exe#/oh-my-posh.exe"
             ],
             "hash": [
-                "711ee53a02a50d3f530c3bb67ba9a246b42bce9466af545f49ba0f0b9ccf6078",
-                "08ca9239cf8f62a4e186f8d2d56dc27db28d5c1d7102605bac5aa2afe8daf98a"
+                "d1a79400728eb84d22d75989d7bee59b91724a5a1bc413e61b37e52691404950",
+                "f8174f9551c9a378388a1f1c7f8d2adc8923bf609cedb14d3bcbb26232b04c40"
             ]
         }
     },


### PR DESCRIPTION
## Summary
- Bump `oh-my-posh` from 29.27.0 to 29.28.0
- Upstream: https://github.com/JanDeDobbeleer/oh-my-posh/releases/tag/v29.28.0
- Hashes verified locally for themes.zip + windows amd64/arm64 binaries

## Evidence
- Scoop was on 29.27.0; latest GitHub release is v29.28.0
- sha256 themes.zip: `d1a79400728eb84d22d75989d7bee59b91724a5a1bc413e61b37e52691404950`
- sha256 posh-windows-amd64.exe: `effa74ca461c6e467dd1c35801163697bf2055cf2fc9716550b0137cf89d9038`
- sha256 posh-windows-arm64.exe: `f8174f9551c9a378388a1f1c7f8d2adc8923bf609cedb14d3bcbb26232b04c40`

## Test plan
- [ ] CI hash validation
- [ ] `scoop install oh-my-posh` / update path