### PR TITLE
qrcp: Update to version 0.11.6, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/qrcp.json
+++ b/bucket/qrcp.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/claudiodangelis/qrcp/releases/download/v0.11.6/qrcp_0.11.6_windows_386.tar.gz",
             "hash": "7c2928e8035d1a837abde077bb89f32929af89a68a05f88514c9595c705efadd"
+        },
+        "arm64": {
+            "url": "https://github.com/claudiodangelis/qrcp/releases/download/v0.11.6/qrcp_0.11.6_windows_arm64.tar.gz",
+            "hash": "829eeb8d772ee3fd8c9031f1144c0beb5c29d73c21e3f08c824396a009c92a1d"
         }
     },
     "bin": "qrcp.exe",
@@ -24,6 +28,9 @@
             },
             "32bit": {
                 "url": "https://github.com/claudiodangelis/qrcp/releases/download/v$version/qrcp_$version_windows_386.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/claudiodangelis/qrcp/releases/download/v$version/qrcp_$version_windows_arm64.tar.gz"
             }
         },
         "hash": {

--- a/bucket/qrcp.json
+++ b/bucket/qrcp.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.11.3",
+    "version": "0.11.6",
     "description": "Transfers files over wifi from computer to mobile device by scanning a QR code without leaving the terminal.",
     "homepage": "https://qrcp.sh/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/claudiodangelis/qrcp/releases/download/0.11.3/qrcp_0.11.3_windows_amd64.tar.gz",
-            "hash": "9eb907d1874966d475df66d5e2494b9280cced318a3260d9e8638c037d3981b7"
+            "url": "https://github.com/claudiodangelis/qrcp/releases/download/v0.11.6/qrcp_0.11.6_windows_amd64.tar.gz",
+            "hash": "4ca79eb69009ffabdca86a4212a079269755702b4a255ff2f33ed676d62c429d"
         },
         "32bit": {
-            "url": "https://github.com/claudiodangelis/qrcp/releases/download/0.11.3/qrcp_0.11.3_windows_386.tar.gz",
-            "hash": "9d902324724c00d5eb1d9d15f30d986458713e8429e312fa9c9738adffa2edc0"
+            "url": "https://github.com/claudiodangelis/qrcp/releases/download/v0.11.6/qrcp_0.11.6_windows_386.tar.gz",
+            "hash": "7c2928e8035d1a837abde077bb89f32929af89a68a05f88514c9595c705efadd"
         }
     },
     "bin": "qrcp.exe",
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/claudiodangelis/qrcp/releases/download/$version/qrcp_$version_windows_amd64.tar.gz"
+                "url": "https://github.com/claudiodangelis/qrcp/releases/download/v$version/qrcp_$version_windows_amd64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/claudiodangelis/qrcp/releases/download/$version/qrcp_$version_windows_386.tar.gz"
+                "url": "https://github.com/claudiodangelis/qrcp/releases/download/v$version/qrcp_$version_windows_386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
## Summary
- Bump `qrcp` from 0.11.3 to **0.11.6**
- [Edit] Add arm64 support
- Upstream: https://github.com/claudiodangelis/qrcp/releases/tag/v0.11.6
- Hashes taken from official `checksums.txt`
- Autoupdate URLs switched to `v$version` tag prefix (release tags are now `vX.Y.Z`)

## Evidence
- 64-bit: `4ca79eb69009ffabdca86a4212a079269755702b4a255ff2f33ed676d62c429d  qrcp_0.11.6_windows_amd64.tar.gz`
- 32-bit: `7c2928e8035d1a837abde077bb89f32929af89a68a05f88514c9595c705efadd  qrcp_0.11.6_windows_386.tar.gz`

## Checklist
- [x] Version/hash/url updated from upstream release
- [x] Autoupdate path adjusted for new tag style