### PR TITLE
go-jsonnet: Update to version 0.22.0, fix autoupdate

### DIFF
--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -1,20 +1,20 @@
 {
-    "version": "0.21.0",
+    "version": "0.22.0",
     "description": "A data templating language for app and tool developers",
     "homepage": "https://jsonnet.org/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_x86_64.tar.gz",
-            "hash": "81d71a287ee5dfd0860831eeac281a7327ce8876d5fe9a8b7e19726dbbc0ce4f"
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.22.0/go-jsonnet_0.22.0_windows_amd64.tar.gz",
+            "hash": "277b83ddbe836a627dcde0655720aa42b02277fdf3a9cdaebeef2a53e98599b1"
         },
         "arm64": {
-            "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_arm64.tar.gz",
-            "hash": "5244713590b976d8cb675aba57434b2fa667663c299fe777a478c01c86e46341"
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.22.0/go-jsonnet_0.22.0_windows_arm64.tar.gz",
+            "hash": "663d4b9258e201ce9471a02e329167027e68bf4063192a937d83d8b6bac8b044"
         },
         "32bit": {
-            "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_i386.tar.gz",
-            "hash": "93921aa0bd999ed45348e862ffbb1649c8939020468f52f80176a86b71e9978e"
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.22.0/go-jsonnet_0.22.0_windows_386.tar.gz",
+            "hash": "a94fcbe373a2a50323e872297c9d492e5d216ec527c6a83a303a7a2796aaa181"
         }
     },
     "bin": [
@@ -27,13 +27,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_Windows_x86_64.tar.gz"
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_windows_amd64.tar.gz"
             },
             "arm64": {
-                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_Windows_arm64.tar.gz"
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_windows_arm64.tar.gz"
             },
             "32bit": {
-                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_Windows_i386.tar.gz"
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_windows_386.tar.gz"
             }
         },
         "hash": {


### PR DESCRIPTION
## Summary
- Bump `go-jsonnet` from 0.21.0 to **0.22.0**
- Upstream: https://github.com/google/go-jsonnet/releases/tag/v0.22.0
- Asset naming changed: `go-jsonnet_$version_windows_{amd64,arm64,386}.tar.gz`
- Hashes from official `checksums.txt`; autoupdate URLs updated to match

## Evidence
- amd64: `277b83ddbe836a627dcde0655720aa42b02277fdf3a9cdaebeef2a53e98599b1`
- arm64: `663d4b9258e201ce9471a02e329167027e68bf4063192a937d83d8b6bac8b044`
- 386: `a94fcbe373a2a50323e872297c9d492e5d216ec527c6a83a303a7a2796aaa181`

## Checklist
- [x] Version/hash/url updated from upstream release
- [x] Autoupdate path adjusted for new asset names