### PR TITLE
cloudflared: Update to version 2026.7.2

### DIFF
--- a/bucket/cloudflared.json
+++ b/bucket/cloudflared.json
@@ -1,16 +1,16 @@
 {
-    "version": "2026.7.1",
+    "version": "2026.7.2",
     "description": "Command-line client to interact with Cloudflare Tunnel, Cloudflare Access, start up a DNS over HTTPS resolver and more.",
     "homepage": "https://github.com/cloudflare/cloudflared",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/cloudflare/cloudflared/releases/download/2026.7.1/cloudflared-windows-amd64.exe#/cloudflared.exe",
-            "hash": "ccb0756de288d3c2c076d19764ca53e0849a10f2dd9c23f8656ac42bdeb45001"
+            "url": "https://github.com/cloudflare/cloudflared/releases/download/2026.7.2/cloudflared-windows-amd64.exe#/cloudflared.exe",
+            "hash": "cdb5d4432f6ae1595654a692a51308b69d2bf7af961f5578d9391837cf072df9"
         },
         "32bit": {
-            "url": "https://github.com/cloudflare/cloudflared/releases/download/2026.7.1/cloudflared-windows-386.exe#/cloudflared.exe",
-            "hash": "627fe6e42c5e92e42de962afec19bcbf14a60d43c352dbe4b605f1e3246462ed"
+            "url": "https://github.com/cloudflare/cloudflared/releases/download/2026.7.2/cloudflared-windows-386.exe#/cloudflared.exe",
+            "hash": "32decf512bb37dfcf8f915e923b8132803cb0f7262995d0b168495694b1ee2d7"
         }
     },
     "bin": "cloudflared.exe",


### PR DESCRIPTION
## Summary
- Bump `cloudflared` from `2026.7.1` to `2026.7.2`.
- SHA256 from official Windows amd64/386 exe assets.

## Checklist
- [x] Hash verified
- [x] URL pattern matches autoupdate
