### PR TITLE
meta-package-manager: Update to version 7.2.0, fix autoupdate

### DIFF
--- a/bucket/meta-package-manager.json
+++ b/bucket/meta-package-manager.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.6.0",
+    "version": "7.2.0",
     "description": "Wraps all package managers with a unifying CLI",
     "homepage": "https://kdeldycke.github.io/meta-package-manager/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v6.6.0/mpm-6.6.0-windows-x64.exe#/mpm.exe",
-            "hash": "f1d3cc20def764956556a5bdd51b6f4303655f0321b460fece714214565954e2"
+            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v7.2.0/meta-package-manager-7.2.0-windows-x64.exe#/mpm.exe",
+            "hash": "04510eb885f9e41ca820d9d55e09ffcca882694630ba9a1d0dd07a5976b88dbd"
         },
         "arm64": {
-            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v6.6.0/mpm-6.6.0-windows-arm64.exe#/mpm.exe",
-            "hash": "4d38ad3cfc100d9e5e0153459c86bc227b186c1282781362e33e4bdda40d6051"
+            "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v7.2.0/meta-package-manager-7.2.0-windows-arm64.exe#/mpm.exe",
+            "hash": "36ea1e2e35fd854fa800f6a0daa135ec905f1f3959053d169bdc399c8120fcf9"
         }
     },
     "bin": "mpm.exe",

--- a/bucket/meta-package-manager.json
+++ b/bucket/meta-package-manager.json
@@ -20,10 +20,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/mpm-$version-windows-x64.exe#/mpm.exe"
+                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/meta-package-manager-$version-windows-x64.exe#/mpm.exe"
             },
             "arm64": {
-                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/mpm-$version-windows-arm64.exe#/mpm.exe"
+                "url": "https://github.com/kdeldycke/meta-package-manager/releases/download/v$version/meta-package-manager-$version-windows-arm64.exe#/mpm.exe"
             }
         }
     }


### PR DESCRIPTION
## Summary
- Bump `meta-package-manager` from `6.6.0` to `7.2.0`.
- SHA256 from official Windows x64/arm64 exe assets.

## Checklist
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)