### PR TITLE
granted: Update to version 0.39.0

### DIFF
--- a/bucket/granted.json
+++ b/bucket/granted.json
@@ -1,21 +1,21 @@
 {
-    "version": "0.38.0",
+    "version": "0.39.0",
     "description": "Granted is a command line interface (CLI) application which simplifies access to cloud roles and allows multiple cloud accounts to be opened in your web browser simultaneously.",
     "homepage": "https://github.com/common-fate/granted",
     "license": "MIT",
     "depends": "aws",
     "architecture": {
         "32bit": {
-            "url": "https://releases.commonfate.io/granted/v0.38.0/granted_0.38.0_windows_i386.zip",
-            "hash": "1385364028b7a5d2f2c096ea36ba3e673d7d3cf702c26cf7764ad5b0015693ce"
+            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_i386.zip",
+            "hash": "3a4544e9de9eaeebd64fdf21d958b88b0f1110db2ad68ffa2a0ca964cba99a40"
         },
         "64bit": {
-            "url": "https://releases.commonfate.io/granted/v0.38.0/granted_0.38.0_windows_x86_64.zip",
-            "hash": "0d8be12106ff1de11aa1740a795f060f172ccee04934b21ba44773f274905d2d"
+            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_x86_64.zip",
+            "hash": "29227ca9041a743524306c87775a24d0784f900375f98571abc470b2d477cfc3"
         },
         "arm64": {
-            "url": "https://releases.commonfate.io/granted/v0.38.0/granted_0.38.0_windows_arm64.zip",
-            "hash": "98d918574ebd31fc1de6ef6a0c59792efc8ec472cba6b1061cdcc0eeee8c7146"
+            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_arm64.zip",
+            "hash": "1038b8c242278018ca869071a047d489b75525a4217953dfbf547de03bb68df2"
         }
     },
     "bin": [


### PR DESCRIPTION
## Summary
- Bump `granted` from `0.38.0` to `0.39.0`.
- SHA256 from official Windows release assets.

## Checklist
- [x] Hash verified
- [x] URL pattern matches prior manifest
