### PR TITLE
cliproxyapi: Update to version 7.2.78

### DIFF
--- a/bucket/cliproxyapi.json
+++ b/bucket/cliproxyapi.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.2.77",
+    "version": "7.2.78",
     "description": "Wrap Gemini CLI, Antigravity, ChatGPT Codex, Claude Code, Grok Build as an OpenAI/Gemini/Claude/Codex compatible API service.",
     "homepage": "https://help.router-for.me",
     "license": "MIT",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.77/CLIProxyAPI_7.2.77_windows_amd64.zip",
-            "hash": "daa8277af35e2a5c7bbc9a71e768dceed5bdb31e66d48ac36be63b3d52338d1d"
+            "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.78/CLIProxyAPI_7.2.78_windows_amd64.zip",
+            "hash": "7f84171e8d38e514d3c236918b9b194f2346c2a46d35057db9c0cb9c87f57957"
         },
         "arm64": {
-            "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.77/CLIProxyAPI_7.2.77_windows_aarch64.zip",
-            "hash": "cbef6ab244741a41ad9d278716bf37cac7a233b80063d22254df04132e0c39cc"
+            "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.78/CLIProxyAPI_7.2.78_windows_aarch64.zip",
+            "hash": "2cbf567e5fc96497e12eeb67633fb023e579052aaa9d2b39e19d7c8fa401a265"
         }
     },
     "pre_install": [


### PR DESCRIPTION
## Summary
- Bump `cliproxyapi` from `7.2.77` to `7.2.78`.
- SHA256 from official Windows release assets.

## Checklist
- [x] Hash verified
- [x] URL pattern matches prior manifest
