### PR TITLE
deno: Update to version 2.9.3

### DIFF
--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/denoland/deno/releases/download/v2.9.3/deno-x86_64-pc-windows-msvc.zip",
-            "hash": "Algorithm"
+            "hash": "60343461ac5fe3a31f4ef12667f2946bb852e20655c8610aeb7e751e87f7df3a"
         }
     },
     "bin": "deno.exe",

--- a/bucket/deno.json
+++ b/bucket/deno.json
@@ -1,12 +1,12 @@
 {
-    "version": "2.9.2",
+    "version": "2.9.3",
     "description": "A secure runtime for JavaScript and TypeScript",
     "homepage": "https://deno.com",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/denoland/deno/releases/download/v2.9.2/deno-x86_64-pc-windows-msvc.zip",
-            "hash": "5fe194d26ac5ef77fcc5288c2c438c7a0465f3b6180440ebf04092714bf2dcdf"
+            "url": "https://github.com/denoland/deno/releases/download/v2.9.3/deno-x86_64-pc-windows-msvc.zip",
+            "hash": "Algorithm"
         }
     },
     "bin": "deno.exe",


### PR DESCRIPTION
## Summary
- Bump `deno` 2.9.2 → 2.9.3
- Hash from official `deno-x86_64-pc-windows-msvc.zip.sha256sum`

## Checklist
- [x] Official release asset
- [x] SHA256 from upstream sha256sum
- [x] One package only
