### PR TITLE
ripgrep: Update to version 15.2.0

### DIFF
--- a/bucket/ripgrep.json
+++ b/bucket/ripgrep.json
@@ -1,5 +1,5 @@
 {
-    "version": "15.1.0",
+    "version": "15.2.0",
     "description": "Recursively searches directories for a regex pattern.",
     "homepage": "https://github.com/BurntSushi/ripgrep",
     "license": "MIT",
@@ -8,19 +8,19 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-pc-windows-msvc.zip",
-            "hash": "124510b94b6baa3380d051fdf4650eaa80a302c876d611e9dba0b2e18d87493a",
-            "extract_dir": "ripgrep-15.1.0-x86_64-pc-windows-msvc"
+            "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-x86_64-pc-windows-msvc.zip",
+            "hash": "71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5",
+            "extract_dir": "ripgrep-15.2.0-x86_64-pc-windows-msvc"
         },
         "32bit": {
-            "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-i686-pc-windows-msvc.zip",
-            "hash": "725be85a1e8f92878a548f40ee4f6df64bc93b809586462b3c6d884e1de1e83a",
-            "extract_dir": "ripgrep-15.1.0-i686-pc-windows-msvc"
+            "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-i686-pc-windows-msvc.zip",
+            "hash": "9bf73bdb3fda9ad4b0235e1295b02c717031c986afa4d7c05dd0af8b74010a95",
+            "extract_dir": "ripgrep-15.2.0-i686-pc-windows-msvc"
         },
         "arm64": {
-            "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-pc-windows-msvc.zip",
-            "hash": "00d931fb5237c9696ca49308818edb76d8eb6fc132761cb2a1bd616b2df02f8e",
-            "extract_dir": "ripgrep-15.1.0-aarch64-pc-windows-msvc"
+            "url": "https://github.com/BurntSushi/ripgrep/releases/download/15.2.0/ripgrep-15.2.0-aarch64-pc-windows-msvc.zip",
+            "hash": "e4abca10c3a64ebea742667dd7009449d49403db5460dd6873e389fa2945360f",
+            "extract_dir": "ripgrep-15.2.0-aarch64-pc-windows-msvc"
         }
     },
     "bin": "rg.exe",


### PR DESCRIPTION
## Summary
- Bump `ripgrep` 15.2.0 → 15.2.0
- Hashes from upstream `*.zip.sha256` for msvc windows assets

## Checklist
- [x] Real hashes from official release assets
- [x] All arches in manifest updated
