### PR TITLE
traefik: Update to version 3.7.8

### DIFF
--- a/bucket/traefik.json
+++ b/bucket/traefik.json
@@ -1,21 +1,21 @@
 {
-    "version": "3.7.7",
+    "version": "3.7.8",
     "description": "HTTP reverse proxy and load balancer",
     "homepage": "https://traefik.io/",
     "license": "MIT",
     "notes": "Run with a configuration file 'traefik -c <yourconfig.toml>' or 'traefik --help' for all options.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/traefik/traefik/releases/download/v3.7.7/traefik_v3.7.7_windows_amd64.zip",
-            "hash": "583210132cee24b8547b55fb6b7bd8a49ab2651a96f14d5954bceb41a5358575"
+            "url": "https://github.com/traefik/traefik/releases/download/v3.7.8/traefik_v3.7.8_windows_amd64.zip",
+            "hash": "33077a137f21213ec381a3833981115cfce8c05c5b8256750e2dbc1a7b235a14"
         },
         "32bit": {
-            "url": "https://github.com/traefik/traefik/releases/download/v3.7.7/traefik_v3.7.7_windows_386.zip",
-            "hash": "7d4f4ec65236a36f5660bdd95f537c20c0c8b3744177b038549dfde82a2db5d4"
+            "url": "https://github.com/traefik/traefik/releases/download/v3.7.8/traefik_v3.7.8_windows_386.zip",
+            "hash": "195a7e08c6c0e042cee026026f01150a70635ecbdfff937e30337e99e1535a64"
         },
         "arm64": {
-            "url": "https://github.com/traefik/traefik/releases/download/v3.7.7/traefik_v3.7.7_windows_arm64.zip",
-            "hash": "80f255c4a95d7e9620bc6df2fd5b3d9599318e16bf26b4f7d64dc7a17e256a78"
+            "url": "https://github.com/traefik/traefik/releases/download/v3.7.8/traefik_v3.7.8_windows_arm64.zip",
+            "hash": "d6d6591df10e1570f89855457c36ed089bbe8184c63781ac8cd605848151157f"
         }
     },
     "bin": "traefik.exe",


### PR DESCRIPTION
## Summary
- Bump `traefik` 3.7.7 → 3.7.8
- Hashes computed from official Windows zip assets

## Checklist
- [x] Real hashes
- [x] 64bit/32bit/arm64 updated
