### PR TITLE
granted: Update to version 0.39.0, switch to GitHub releases

### DIFF
--- a/bucket/granted.json
+++ b/bucket/granted.json
@@ -1,20 +1,20 @@
 {
     "version": "0.39.0",
     "description": "Granted is a command line interface (CLI) application which simplifies access to cloud roles and allows multiple cloud accounts to be opened in your web browser simultaneously.",
-    "homepage": "https://github.com/common-fate/granted",
+    "homepage": "https://github.com/fwdcloudsec/granted",
     "license": "MIT",
     "depends": "aws",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_i386.zip",
+            "url": "https://github.com/fwdcloudsec/granted/releases/download/v0.39.0/granted_0.39.0_windows_i386.zip",
             "hash": "3a4544e9de9eaeebd64fdf21d958b88b0f1110db2ad68ffa2a0ca964cba99a40"
         },
         "64bit": {
-            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_x86_64.zip",
+            "url": "https://github.com/fwdcloudsec/granted/releases/download/v0.39.0/granted_0.39.0_windows_x86_64.zip",
             "hash": "29227ca9041a743524306c87775a24d0784f900375f98571abc470b2d477cfc3"
         },
         "arm64": {
-            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_arm64.zip",
+            "url": "https://github.com/fwdcloudsec/granted/releases/download/v0.39.0/granted_0.39.0_windows_arm64.zip",
             "hash": "1038b8c242278018ca869071a047d489b75525a4217953dfbf547de03bb68df2"
         }
     },
@@ -26,13 +26,13 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/common-fate/granted/releases/download/v$version/granted_$version_windows_i386.zip"
+                "url": "https://github.com/fwdcloudsec/granted/releases/download/v$version/granted_$version_windows_i386.zip"
             },
             "64bit": {
-                "url": "https://github.com/common-fate/granted/releases/download/v$version/granted_$version_windows_x86_64.zip"
+                "url": "https://github.com/fwdcloudsec/granted/releases/download/v$version/granted_$version_windows_x86_64.zip"
             },
             "arm64": {
-                "url": "https://github.com/common-fate/granted/releases/download/v$version/granted_$version_windows_arm64.zip"
+                "url": "https://github.com/fwdcloudsec/granted/releases/download/v$version/granted_$version_windows_arm64.zip"
             }
         },
         "hash": {

--- a/bucket/granted.json
+++ b/bucket/granted.json
@@ -1,21 +1,21 @@
 {
-    "version": "0.38.0",
+    "version": "0.39.0",
     "description": "Granted is a command line interface (CLI) application which simplifies access to cloud roles and allows multiple cloud accounts to be opened in your web browser simultaneously.",
     "homepage": "https://github.com/common-fate/granted",
     "license": "MIT",
     "depends": "aws",
     "architecture": {
         "32bit": {
-            "url": "https://releases.commonfate.io/granted/v0.38.0/granted_0.38.0_windows_i386.zip",
-            "hash": "1385364028b7a5d2f2c096ea36ba3e673d7d3cf702c26cf7764ad5b0015693ce"
+            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_i386.zip",
+            "hash": "3a4544e9de9eaeebd64fdf21d958b88b0f1110db2ad68ffa2a0ca964cba99a40"
         },
         "64bit": {
-            "url": "https://releases.commonfate.io/granted/v0.38.0/granted_0.38.0_windows_x86_64.zip",
-            "hash": "0d8be12106ff1de11aa1740a795f060f172ccee04934b21ba44773f274905d2d"
+            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_x86_64.zip",
+            "hash": "29227ca9041a743524306c87775a24d0784f900375f98571abc470b2d477cfc3"
         },
         "arm64": {
-            "url": "https://releases.commonfate.io/granted/v0.38.0/granted_0.38.0_windows_arm64.zip",
-            "hash": "98d918574ebd31fc1de6ef6a0c59792efc8ec472cba6b1061cdcc0eeee8c7146"
+            "url": "https://github.com/common-fate/granted/releases/download/v0.39.0/granted_0.39.0_windows_arm64.zip",
+            "hash": "1038b8c242278018ca869071a047d489b75525a4217953dfbf547de03bb68df2"
         }
     },
     "bin": [
@@ -26,14 +26,17 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://releases.commonfate.io/granted/v$version/granted_$version_windows_i386.zip"
+                "url": "https://github.com/common-fate/granted/releases/download/v$version/granted_$version_windows_i386.zip"
             },
             "64bit": {
-                "url": "https://releases.commonfate.io/granted/v$version/granted_$version_windows_x86_64.zip"
+                "url": "https://github.com/common-fate/granted/releases/download/v$version/granted_$version_windows_x86_64.zip"
             },
             "arm64": {
-                "url": "https://releases.commonfate.io/granted/v$version/granted_$version_windows_arm64.zip"
+                "url": "https://github.com/common-fate/granted/releases/download/v$version/granted_$version_windows_arm64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/granted.json
+++ b/bucket/granted.json
@@ -1,7 +1,7 @@
 {
     "version": "0.39.0",
     "description": "Granted is a command line interface (CLI) application which simplifies access to cloud roles and allows multiple cloud accounts to be opened in your web browser simultaneously.",
-    "homepage": "https://github.com/fwdcloudsec/granted",
+    "homepage": "https://granted.dev",
     "license": "MIT",
     "depends": "aws",
     "architecture": {
@@ -22,7 +22,9 @@
         "assume.ps1",
         "granted.exe"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/fwdcloudsec/granted"
+    },
     "autoupdate": {
         "architecture": {
             "32bit": {


### PR DESCRIPTION
## Summary
- edited: https://github.com/fwdcloudsec/granted/releases/tag/v0.39.0
  - Granted v0.39.0 is the first release published under the [fwdcloudsec](https://github.com/fwdcloudsec) organization.
  - Binary downloads are now hosted at [releases.granted.dev](https://releases.granted.dev/)
  - Previous releases remain available at `releases.commonfate.io`.
- `releases.commonfate.io` returns 404 for granted 0.39 assets; downloads still work from GitHub (`common-fate/granted`, redirects to current org).
- Point architecture URLs and **autoupdate** at `https://github.com/common-fate/granted/releases/...` and use `checksums.txt` for hashes so future bumps do not keep the dead host template.

This is a host/autoupdate fix, not a pure version bump.

## Checklist
- [x] Hash verified from release checksums.txt
- [x] Autoupdate template no longer uses releases.commonfate.io
