### PR TITLE
moon: Update to version 2.4.3, fix autoupdate

### DIFF
--- a/bucket/moon.json
+++ b/bucket/moon.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.41.8",
+    "version": "2.4.3",
     "description": "A task runner and monorepo management tool for the web ecosystem, written in Rust.",
     "homepage": "https://moonrepo.dev/moon",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/moonrepo/moon/releases/download/v1.41.8/moon-x86_64-pc-windows-msvc.exe#/moon.exe",
-            "hash": "4592830af50746f8e54d2f38b9676a8819fe861e1934e8d5144a08856e5f8304"
+            "url": "https://github.com/moonrepo/moon/releases/download/v2.4.3/moon_cli-x86_64-pc-windows-msvc.zip",
+            "hash": "8ef934a30c3287f8f5ff77334a853cb6d47356e3ad3d90499c376ce79eaaff7d"
         }
     },
     "bin": "moon.exe",
@@ -16,8 +16,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/moonrepo/moon/releases/download/v$version/moon-x86_64-pc-windows-msvc.exe#/moon.exe"
+                "url": "https://github.com/moonrepo/moon/releases/download/v$version/moon_cli-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Upstream renamed the Windows asset from `moon-x86_64-pc-windows-msvc.exe` to `moon_cli-x86_64-pc-windows-msvc.zip` (zip contains `moon.exe`).
- Old autoupdate URL pattern 404s on current releases; update architecture URL/hash and autoupdate, with `$url.sha256` for hashes.

This is an asset rename / broken autoupdate fix, not a pure version bump.

## Checklist
- [x] New asset URL returns 200; old exe name 404 on latest
- [x] Hash from published `.sha256` file
