### PR TITLE
go-swagger: Update to version 0.35.0, drop arm64 support

### DIFF
--- a/bucket/go-swagger.json
+++ b/bucket/go-swagger.json
@@ -1,16 +1,12 @@
 {
-    "version": "0.33.1",
+    "version": "0.35.0",
     "description": "Golang implementation of Swagger 2.0 (OpenAPI 2.0)",
     "homepage": "https://goswagger.io",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/go-swagger/go-swagger/releases/download/v0.33.1/swagger_windows_amd64.exe#/swagger.exe",
-            "hash": "0fe476d2f689f229496eef1c22aa8751a511532ad17f5671aadfe6aa4c2c5bf0"
-        },
-        "arm64": {
-            "url": "https://github.com/go-swagger/go-swagger/releases/download/v0.33.1/swagger_windows_arm64.exe#/swagger.exe",
-            "hash": "3e6531a6f2f20a6d21270d520ee63beccab8a8913e0ed4e363aad39eb8c38bb1"
+            "url": "https://github.com/go-swagger/go-swagger/releases/download/v0.35.0/swagger_0.35.0_Windows_x86_64.zip",
+            "hash": "082d5a277352a8b023b10d6b7a7977d55cbc39031fde7c21aa312685004c5e35"
         }
     },
     "bin": "swagger.exe",
@@ -20,14 +16,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/go-swagger/go-swagger/releases/download/v$version/swagger_windows_amd64.exe#/swagger.exe"
-            },
-            "arm64": {
-                "url": "https://github.com/go-swagger/go-swagger/releases/download/v$version/swagger_windows_arm64.exe#/swagger.exe"
+                "url": "https://github.com/go-swagger/go-swagger/releases/download/v$version/swagger_$version_Windows_x86_64.zip"
             }
-        },
-        "hash": {
-            "url": "$baseurl/sha256sum.txt"
         }
     }
 }


### PR DESCRIPTION
## Summary
- v0.35.0 no longer publishes `swagger_windows_amd64.exe` / Windows arm64 binaries (and the bare amd64 asset is double-ext `swagger_windows_amd64.exe.exe`).
- Switch 64bit to `swagger_$version_Windows_x86_64.zip` (contains `swagger.exe`), drop obsolete arm64, and update autoupdate accordingly.

This is an asset layout / rename fix, not a pure version bump.

## Checklist
- [x] Zip contents verified (`swagger.exe`)
- [x] Hash verified from downloaded zip
