### PR TITLE
rga@0.10.9: Fix incorrect shim name

### DIFF
--- a/bucket/rga.json
+++ b/bucket/rga.json
@@ -23,7 +23,7 @@
         "rga.exe",
         [
             "rga.exe",
-            "ripgrep-all.exe"
+            "ripgrep-all"
         ],
         "rga-fzf.exe",
         "rga-preproc.exe"


### PR DESCRIPTION
Relates to https://github.com/ScoopInstaller/Main/commit/1c7c2f21c967f96f89b5a143c1eb620606be7ee9.

Fixes an oversight where the shim gets named `ripgrep-all.exe.exe` instead of just `ripgrep-all.exe`.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
