### PR TITLE
mimo-code@0.1.6: Add support for baseline version

### DIFF
--- a/bucket/mimo-code.json
+++ b/bucket/mimo-code.json
@@ -5,8 +5,24 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v0.1.6/mimocode-windows-x64.zip",
-            "hash": "1a2ef4bc07229b269f94197dcb7006c6f826086ac7b304762c24a1f041e5e214"
+            "url": [
+                "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v0.1.6/mimocode-windows-x64.zip",
+                "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v0.1.6/mimocode-windows-x64-baseline.zip#/baseline.zip_"
+            ],
+            "hash": [
+                "1a2ef4bc07229b269f94197dcb7006c6f826086ac7b304762c24a1f041e5e214",
+                "724b62c2e070d139ec7a4f6156f09d7391c7d11ea8ea3ab1264538812fc77f87"
+            ],
+            "pre_install": [
+                "$avx2 = Start-Job -ScriptBlock {",
+                "    Add-Type -MemberDefinition '[DllImport(\"kernel32.dll\")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);' -Name Kernel32 -Namespace Win32",
+                "    return [Win32.Kernel32]::IsProcessorFeaturePresent(40)",
+                "} | Receive-Job -Wait -AutoRemoveJob",
+                "if (-not $avx2) {",
+                "    Expand-7ZipArchive -Path \"$dir\\baseline.zip_\" -DestinationPath \"$dir\" -Overwrite All",
+                "}",
+                "Remove-Item -LiteralPath \"$dir\\baseline.zip_\" -Recurse -Force"
+            ]
         },
         "arm64": {
             "url": "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v0.1.6/mimocode-windows-arm64.zip",
@@ -20,7 +36,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v$version/mimocode-windows-x64.zip"
+                "url": [
+                    "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v$version/mimocode-windows-x64.zip",
+                    "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v$version/mimocode-windows-x64-baseline.zip#/baseline.zip_"
+                ]
             },
             "arm64": {
                 "url": "https://github.com/XiaomiMiMo/MiMo-Code/releases/download/v$version/mimocode-windows-arm64.zip"


### PR DESCRIPTION
Added support for the baseline build, which does not require AVX2.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->
Closes #8315
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
