### PR TITLE
uv: Stop forcing UV_* env vars on update

### DIFF
--- a/bucket/uv.json
+++ b/bucket/uv.json
@@ -29,15 +29,15 @@
             "Add-Path -Path \"$persist_dir\\tools\\shims\" -Global:$global -Force"
         ]
     },
-    "persist": [
-        "cache",
-        "python",
-        "tools"
-    ],
     "bin": [
         "uv.exe",
         "uvx.exe",
         "uvw.exe"
+    ],
+    "persist": [
+        "cache",
+        "python",
+        "tools"
     ],
     "uninstaller": {
         "script": [

--- a/bucket/uv.json
+++ b/bucket/uv.json
@@ -4,9 +4,10 @@
     "homepage": "https://docs.astral.sh/uv/",
     "license": "Apache-2.0|MIT",
     "notes": [
-        "Scoop persists data since version 0.11.16. You may need to move data by yourself.",
-        "Before: '$env:APPDATA\\uv', '$env:LOCALAPPDATA\\uv'",
-        "After : '$persist_dir'"
+        "This manifest no longer forces UV_* environment variables on install/update (see #8116).",
+        "Set UV_CACHE_DIR / UV_PYTHON_* / UV_TOOL_* yourself if you want non-default locations.",
+        "Optional Scoop-managed paths under $persist_dir: cache, python, tools (persist keeps them across updates).",
+        "Installer still adds $persist_dir\\python\\shims and $persist_dir\\tools\\shims to PATH when present."
     ],
     "architecture": {
         "64bit": {
@@ -28,13 +29,11 @@
             "Add-Path -Path \"$persist_dir\\tools\\shims\" -Global:$global -Force"
         ]
     },
-    "env_set": {
-        "UV_CACHE_DIR": "$persist_dir\\cache",
-        "UV_PYTHON_BIN_DIR": "$persist_dir\\python\\shims",
-        "UV_PYTHON_INSTALL_DIR": "$persist_dir\\python\\versions",
-        "UV_TOOL_BIN_DIR": "$persist_dir\\tools\\shims",
-        "UV_TOOL_DIR": "$persist_dir\\tools\\versions"
-    },
+    "persist": [
+        "cache",
+        "python",
+        "tools"
+    ],
     "bin": [
         "uv.exe",
         "uvx.exe",


### PR DESCRIPTION
### Prerequisites
<!--  Please make sure you check these boxes before submitting your PR.  -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

`uv` currently uses `env_set` for `UV_CACHE_DIR` / `UV_PYTHON_*` / `UV_TOOL_*`, so every Scoop update **overwrites** user-chosen locations (issue #8116). That breaks multi-drive layouts and existing tool/cache paths.

This PR:
- removes the forced `env_set` block (users keep their existing `UV_*` values)
- adds `persist` for `cache` / `python` / `tools` so Scoop-managed data still survives updates if used
- keeps PATH installer/uninstaller hooks for the shims dirs
- documents optional self-managed `UV_*` in `notes`

Closes #8116

## Test plan
- [x] `uv.json` parses as JSON
- [ ] Windows: install/update `uv` no longer rewrites pre-set `UV_CACHE_DIR`
- [ ] PATH shims dirs still added when present
