### PR TITLE
bazel: set BAZEL_SH only when msys2 bash exists

### DIFF
--- a/bucket/bazel.json
+++ b/bucket/bazel.json
@@ -3,6 +3,10 @@
     "description": "A fast, scalable, multi-language and extensible build system",
     "homepage": "https://bazel.build",
     "license": "Apache-2.0",
+    "notes": [
+        "BAZEL_SH is set only when main/msys2 is installed (path must exist).",
+        "If you use another bash (e.g. git), set BAZEL_SH yourself — scoop no longer points at a missing msys2 path (#7402)."
+    ],
     "suggest": {
         "MSYS2": "msys2",
         "Python27": "versions/python27",
@@ -15,8 +19,21 @@
         }
     },
     "bin": "bazel.exe",
-    "env_set": {
-        "BAZEL_SH": "$(appdir msys2 $global)\\current\\usr\\bin\\bash.exe"
+    "installer": {
+        "script": [
+            "$bash = \"$(appdir msys2 $global)\\current\\usr\\bin\\bash.exe\"",
+            "if (Test-Path $bash) {",
+            "    Set-EnvVar -Name BAZEL_SH -Value $bash -Global:$global",
+            "} else {",
+            "    Write-Host \"msys2 not installed; BAZEL_SH not set. Install 'msys2' or set BAZEL_SH to your bash.exe (see #7402).\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$global = installed $app $true",
+            "Remove-EnvVar -Name BAZEL_SH -Global:$global"
+        ]
     },
     "checkver": {
         "github": "https://github.com/bazelbuild/bazel"


### PR DESCRIPTION
### Prerequisites

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

`bazel` used `env_set` to always write `BAZEL_SH` to `$(appdir msys2)/current/usr/bin/bash.exe`. If `msys2` was only suggested (not installed), users got a **non-existent** path (#7402).

This PR:
- removes unconditional `env_set`
- sets `BAZEL_SH` in `installer` only when that bash path exists
- removes `BAZEL_SH` on uninstall
- documents manual override when using another bash (e.g. git)

Closes #7402

## Test plan
- [x] `bazel.json` parses as JSON
- [ ] Windows: install without msys2 → no broken BAZEL_SH
- [ ] Windows: install with msys2 → BAZEL_SH points at msys2 bash
