### PR TITLE
amber: Add version 0.6.1 (migrate from Extras bucket)

### DIFF
--- a/bucket/amber.json
+++ b/bucket/amber.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.6.1",
+    "description": "Recursively searches/replaces directories for a regex pattern.",
+    "homepage": "https://github.com/dalance/amber",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dalance/amber/releases/download/v0.6.1/amber-v0.6.1-x86_64-win.zip",
+            "hash": "ad3aa89d7751a1e8cbced749aa47d891aceffc55528eee852e631be392341abb"
+        }
+    },
+    "extract_dir": "target/x86_64-pc-windows-msvc/release",
+    "bin": [
+        "ambs.exe",
+        "ambr.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dalance/amber/releases/download/v$version/amber-v$version-x86_64-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moved from the [Extras bucket](https://github.com/ScoopInstaller/Extras/blob/master/bucket/amber.json) — amber is a CLI tool that meets Main's criteria (951 stars, MIT, latest stable release, version-specific download URL). Companion PR removing it from Extras: https://github.com/ScoopInstaller/Extras/pull/18341

Two deliberate changes from the Extras manifest:
- `checkver` reduced to the `"github"` shortcut, since `homepage` is the repo URL and no jsonpath/regex is needed
- Added `suggest.vcredist` — both `ambs.exe` and `ambr.exe` link `VCRUNTIME140.dll`

PR checklist:
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)