### PR TITLE
innounp: Update to version 2.70.1, fix autoupdate URL

### DIFF
--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.67.11",
+    "version": "2.70.1",
     "description": "Inno Setup Unpacker (Unicode)",
     "homepage": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
     "license": "GPL-3.0-only",
-    "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-2.zip",
-    "hash": "851772538a041229102ad9964542d49dc00c74002e3091a70469c079ae368f52",
+    "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-270.zip",
+    "hash": "c4b499a027fcaaf5682f02919862a47cd2ab9ac25472e254485a03c5704a36f6",
     "bin": "innounp.exe",
     "checkver": {
         "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/docs/innounp.htm",
         "regex": "(?s)What's new/History.*?<b>(\\d+(?:\\.\\d+){2})</b>"
     },
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-2.zip"
+        "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-$majorVersion$minorVersion.zip"
     }
 }


### PR DESCRIPTION
## Summary
- `innounp`'s download URL 404s: upstream (jrathlev/InnoUnpacker-Windows-GUI) renamed release assets from a static `innounp-2.zip` to versioned filenames (`innounp-267.zip`, `innounp-270.zip`, ...), breaking both the manifest's `url` and `autoupdate.url`.
- Bumps to the latest upstream release, `2.70.1`, and points `url`/`hash` at the current asset (`innounp-270.zip`).
- Fixes `autoupdate.url` to use `$majorVersion$minorVersion` so future version bumps track the new naming convention automatically — verified against both currently published assets: `2.67.11` → `innounp-267.zip`, `2.70.1` → `innounp-270.zip`.

## Test plan
- [x] Downloaded `innounp-270.zip` directly and verified the sha256 hash matches the manifest.
- [x] `bin/checkver.ps1 -App innounp` resolves cleanly to `2.70.1` against the updated manifest.
- [x] `bin/formatjson.ps1 -App innounp` produces no diff (formatting unchanged).
- [x] Installed locally via `scoop install` from this manifest and confirmed `innounp.exe` runs (`innounp - the Inno Setup Unpacker, version 2.70.1 (2026-07-21)`).