### PR TITLE
cdrtools@3.02a09: Update homepage

### DIFF
--- a/bucket/cdrtools.json
+++ b/bucket/cdrtools.json
@@ -1,7 +1,7 @@
 {
     "version": "3.02a09",
     "description": "Burn and read CDs, DVDs, and Blu-ray discs",
-    "homepage": "https://sourceforge.net/projects/tumagcc/",
+    "homepage": "https://opensourcepack.blogspot.com/p/cdrtools.html",
     "license": {
         "identifier": "CDDL-1.0,GPL-2.0-only,LGPL-2.1-only",
         "url": "https://github.com/jobermayr/cdrtools/blob/master/COPYING"


### PR DESCRIPTION
#### Description
`cdrtools` homepage currently points at the SourceForge project page used only as a download mirror (`tumagcc`). The package project page is the Open Source Pack blog entry for cdrtools.

Closes #6873

#### Checklist
- [x] I have read the Contributing Guide.
- [x] I have associated the PR with the corresponding issue.
