### PR TITLE
nim: Add bin to PATH for runtime DLLs

### DIFF
--- a/bucket/nim.json
+++ b/bucket/nim.json
@@ -56,5 +56,6 @@
     },
     "uninstaller": {
         "script": "Remove-Path -Path \"$env:USERPROFILE\\.nimble\\bin\" -Global:$global"
-    }
+    },
+    "env_add_path": "bin"
 }


### PR DESCRIPTION
#### Description
Nim places runtime DLLs (for example `pcre64.dll`) in the package `bin` directory. The manifest currently exposes tools via `bin` shims but does not add `bin` to PATH, so some stdlib-dependent tools fail with `could not load: pcre64.dll`.

Add `env_add_path: bin` so those DLLs resolve at runtime.

Closes #5992

#### Checklist
- [x] I have read the Contributing Guide.
- [x] I have associated the PR with the corresponding issue.
