### PR TITLE
chsrc@0.2.6: Add arm64 build

### DIFF
--- a/bucket/chsrc.json
+++ b/bucket/chsrc.json
@@ -22,6 +22,9 @@
             },
             "32bit": {
                 "url": "https://github.com/RubyMetric/chsrc/releases/download/v$version/chsrc-x86-windows.exe#/chsrc.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/RubyMetric/chsrc/releases/download/v$version/chsrc-arm64-windows.exe#/chsrc.exe"
             }
         }
     }

--- a/bucket/chsrc.json
+++ b/bucket/chsrc.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/RubyMetric/chsrc/releases/download/v0.2.6/chsrc-x86-windows.exe#/chsrc.exe",
             "hash": "7cf7f3ce3616552ad803087ebb26b2f4af3b12eef5daeedd2601b128f8667043"
+        },
+        "arm64": {
+            "url": "https://github.com/RubyMetric/chsrc/releases/download/v0.2.6/chsrc-arm64-windows.exe#/chsrc.exe",
+            "hash": "2e336f111ad8f5062dfd85cbea4e57962f3b1e262c64d6e716b58098982dfe5c"
         }
     },
     "bin": "chsrc.exe",


### PR DESCRIPTION
## ℹ️ What's changed?

Windows on ARM support was added after [`v0.2.5`](https://github.com/RubyMetric/chsrc/releases/tag/v0.2.5) and currently available in [`pre`](https://github.com/RubyMetric/chsrc/releases/tag/pre)

- Related https://github.com/RubyMetric/chsrc/pull/366 
- Closes #8337 

## ✅ Checklist

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
