### PR TITLE
atac: Persist user data

### DIFF
--- a/bucket/atac.json
+++ b/bucket/atac.json
@@ -3,6 +3,7 @@
     "description": "Arguably a Terminal API Client based on well-known clients such as Postman, Insomnia, or even Bruno.",
     "homepage": "https://atac.julien-cpsn.com/",
     "license": "MIT",
+    "notes": "Collections and config live under the Scoop persist folder via ATAC_MAIN_DIR ($persist_dir).",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Julien-cpsn/ATAC/releases/download/v0.23.0/atac-v0.23.0-x86_64-pc-windows-msvc.zip",
@@ -13,6 +14,10 @@
             "hash": "056f29ba31442d4de183aaa8fd2cb38c60db879c8539c6ec9ecec48a52f5ea41"
         }
     },
+    "env_set": {
+        "ATAC_MAIN_DIR": "$persist_dir"
+    },
+    "pre_install": "if (!(Test-Path $persist_dir)) { New-Item -ItemType Directory -Path $persist_dir | Out-Null }",
     "bin": "atac.exe",
     "checkver": {
         "github": "https://github.com/Julien-cpsn/ATAC"

--- a/bucket/atac.json
+++ b/bucket/atac.json
@@ -3,7 +3,12 @@
     "description": "Arguably a Terminal API Client based on well-known clients such as Postman, Insomnia, or even Bruno.",
     "homepage": "https://atac.julien-cpsn.com/",
     "license": "MIT",
-    "notes": "Collections and config live under the Scoop persist folder via ATAC_MAIN_DIR ($persist_dir).",
+    "notes": [
+        "Scoop persists config data via env variable `ATAC_MAIN_DIR` since version 0.23.0.",
+        "You may need to move data by yourself.",
+        "Before: '$env:APPDATA\\Julien-cpsn\\ATAC\\config'",
+        "After : '$persist_dir\\config'"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/Julien-cpsn/ATAC/releases/download/v0.23.0/atac-v0.23.0-x86_64-pc-windows-msvc.zip",
@@ -15,10 +20,10 @@
         }
     },
     "env_set": {
-        "ATAC_MAIN_DIR": "$persist_dir"
+        "ATAC_MAIN_DIR": "$persist_dir\\config"
     },
-    "pre_install": "if (!(Test-Path $persist_dir)) { New-Item -ItemType Directory -Path $persist_dir | Out-Null }",
     "bin": "atac.exe",
+    "persist": "config",
     "checkver": {
         "github": "https://github.com/Julien-cpsn/ATAC"
     },


### PR DESCRIPTION
### Prerequisites

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

ATAC stores collections/config in the app directory chosen by `--directory` or `ATAC_MAIN_DIR`. The current Main manifest never sets either, so data lands outside Scoop's persist tree and is lost on upgrade.

This sets:

- `env_set.ATAC_MAIN_DIR` → `$persist_dir`
- `pre_install` to ensure the persist directory exists
- a short `notes` line for users

Version/hashes/autoupdate are unchanged.

Closes #6820

## Test Plan

- [x] Confirmed upstream CLI accepts `--directory` and `ATAC_MAIN_DIR` (`src/cli/args.rs`)
- [x] Manifest JSON still validates structurally (single-file scope)
- [ ] Windows scoop install/update smoke (maintainer CI `/verify`)
