### PR TITLE
just-lsp: Add version 0.5.1

### DIFF
--- a/bucket/just-lsp.json
+++ b/bucket/just-lsp.json
@@ -1,7 +1,7 @@
 {
     "version": "0.5.1",
-    "description": "A language server for just",
-    "homepage": "https://github.com/terror/just-lsp",
+    "description": "A language server for just.",
+    "homepage": "https://terror.github.io/just-lsp/",
     "license": "CC0-1.0",
     "architecture": {
         "64bit": {

--- a/bucket/just-lsp.json
+++ b/bucket/just-lsp.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.5.1",
+    "description": "A language server for just",
+    "homepage": "https://github.com/terror/just-lsp",
+    "license": "CC0-1.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/terror/just-lsp/releases/download/0.5.1/just-lsp-0.5.1-x86_64-pc-windows-msvc.zip",
+            "hash": "5deb5eca4049e1cea72866d93078fdbe1fe4a1ffd71e44d4bc63467a0069e4ed"
+        },
+        "arm64": {
+            "url": "https://github.com/terror/just-lsp/releases/download/0.5.1/just-lsp-0.5.1-aarch64-pc-windows-msvc.zip",
+            "hash": "b5b9f5f799ad7c14d9fc8d55fe9e2fed6ad2652129480a512ff828aa74f3149f"
+        }
+    },
+    "bin": "just-lsp.exe",
+    "checkver": {
+        "github": "https://github.com/terror/just-lsp"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/terror/just-lsp/releases/download/$version/just-lsp-$version-x86_64-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/terror/just-lsp/releases/download/$version/just-lsp-$version-aarch64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
+        }
+    }
+}


### PR DESCRIPTION
Add just-lsp 0.5.1, a language server for the `just` command runner.

- Hashes verified against the upstream `SHA256SUMS` for both `x86_64` and `aarch64` `windows-msvc` release zips
- `checkver` tracks the GitHub repo; autoupdate uses the upstream `$baseurl/SHA256SUMS` (same pattern as `rclone`/`lima`)
- `just-lsp.exe` ships at the zip root, so no `extract_dir` is needed

Closes #8208

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
