### PR TITLE
d2: Update GitHub repository URLs

### DIFF
--- a/bucket/d2.json
+++ b/bucket/d2.json
@@ -5,26 +5,26 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/terrastruct/d2/releases/download/v0.7.1/d2-v0.7.1-windows-amd64.tar.gz",
+            "url": "https://github.com/d2lang/d2/releases/download/v0.7.1/d2-v0.7.1-windows-amd64.tar.gz",
             "hash": "d289c2866221c618c9fc6efcd416ee8c16e122bd0100761aea51001e3c958f57"
         },
         "arm64": {
-            "url": "https://github.com/terrastruct/d2/releases/download/v0.7.1/d2-v0.7.1-windows-arm64.tar.gz",
+            "url": "https://github.com/d2lang/d2/releases/download/v0.7.1/d2-v0.7.1-windows-arm64.tar.gz",
             "hash": "c7ebdc7b2f6df513b715d431762105386f7c702b0b2dddff2a500a032b1bba67"
         }
     },
     "extract_dir": "d2-v0.7.1",
     "bin": "bin\\d2.exe",
     "checkver": {
-        "github": "https://github.com/terrastruct/d2"
+        "github": "https://github.com/d2lang/d2"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/terrastruct/d2/releases/download/v$version/d2-v$version-windows-amd64.tar.gz"
+                "url": "https://github.com/d2lang/d2/releases/download/v$version/d2-v$version-windows-amd64.tar.gz"
             },
             "arm64": {
-                "url": "https://github.com/terrastruct/d2/releases/download/v$version/d2-v$version-windows-arm64.tar.gz"
+                "url": "https://github.com/d2lang/d2/releases/download/v$version/d2-v$version-windows-arm64.tar.gz"
             }
         },
         "extract_dir": "d2-v$version"


### PR DESCRIPTION
Closes #8352

## Summary

- update the D2 v0.7.1 release asset URLs from `terrastruct/d2` to the canonical `d2lang/d2` repository
- update the `checkver.github` URL and both `autoupdate` templates to the canonical repository
- preserve the manifest version, hashes, archive names, extraction directory, and binary layout

## Impact

Scoop will fetch D2 releases and future version checks from the project's current GitHub organization. The downloaded v0.7.1 assets are unchanged, so existing installations and package contents are unaffected.

## Validation

- parsed `bucket/d2.json` with `jq`
- downloaded both Windows v0.7.1 archives from `d2lang/d2` and verified their SHA-256 values match the existing manifest hashes
- inspected both archives and confirmed `d2-v0.7.1/bin/d2.exe` is unchanged
- confirmed the latest GitHub release is still `v0.7.1` and the autoupdate templates resolve to the same asset names
- ran `git diff --check`
- Scoop's PowerShell test suite was not available on this macOS host; the upstream Windows CI remains authoritative

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
