### PR TITLE
traverse: Add version 0.1.0

### DIFF
--- a/bucket/traverse.json
+++ b/bucket/traverse.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.1.0",
+  "description": "A TUI file manager that treats Windows as a first-class citizen. Native PowerShell integration, instant filter, Git diff preview.",
+  "homepage": "https://github.com/chenyc21/traverse",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/chenyc21/traverse/releases/download/v0.1.0/traverse-windows-amd64.exe#/traverse.exe",
+      "hash": "165819420d8d1e526f24b0f7c0c70a10f75c8cccfa11e09b3cc658316b973232"
+    }
+  },
+  "bin": "traverse.exe",
+  "checkver": {
+    "github": "https://github.com/chenyc21/traverse"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/chenyc21/traverse/releases/download/v$version/traverse-windows-amd64.exe#/traverse.exe"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Add [traverse](https://github.com/chenyc21/traverse) v0.1.0 to the Scoop main bucket.

## About traverse

A TUI file manager that treats Windows as a first-class citizen:

- Native PowerShell integration (Ctrl+Z to open shell)
- Instant filter (/ to search files)
- Git diff preview
- Syntax highlighting for 8 languages
- Single binary, no dependencies

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] The manifest is valid JSON
- [x] The URL points to a release asset (not a source archive)
- [x] The hash matches the release asset