### PR TITLE
uutils-findutils@0.10.0: Add missing shims

### DIFF
--- a/bucket/uutils-findutils.json
+++ b/bucket/uutils-findutils.json
@@ -14,6 +14,8 @@
     },
     "bin": [
         "find.exe",
+        "locate.exe",
+        "updatedb.exe",
         "xargs.exe"
     ],
     "checkver": {


### PR DESCRIPTION
Two of the utilities from findutils were missing. As before, `testing-commandline.exe` is not shimmed since that's just something that is build for their unit testing, it gets included for some reason. It's very tiny and doesn't warrant a `post_install` script for removal.

[*(here's a convenient download link to look at the latest findutils archive)*](https://github.com/uutils/findutils/releases/download/0.10.0/findutils-x86_64-pc-windows-msvc.zip)

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
