### PR TITLE
hayabusa: Add version 4.0.0

### DIFF
--- a/bucket/hayabusa.json
+++ b/bucket/hayabusa.json
@@ -4,6 +4,10 @@
     "homepage": "https://github.com/Yamato-Security/hayabusa",
     "license": "AGPL-3.0-only",
     "architecture": {
+        "32bit": {
+            "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v4.0.0/hayabusa-4.0.0-win-x86.zip",
+            "hash": "6277d87f183b3c88a37cc4658aaa3e7e60799ef60cd658054651de6bf9a4c00c"
+        },
         "64bit": {
             "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v4.0.0/hayabusa-4.0.0-win-x64.zip",
             "hash": "6e173c9fd1fa8ee4d95931ea1e1997723330c4779f4f83a96dcd3f1b00d31ff5"
@@ -20,6 +24,9 @@
     },
     "autoupdate": {
         "architecture": {
+            "32bit": {
+                "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v$version/hayabusa-$version-win-x86.zip"
+            },
             "64bit": {
                 "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v$version/hayabusa-$version-win-x64.zip"
             },

--- a/bucket/hayabusa.json
+++ b/bucket/hayabusa.json
@@ -1,0 +1,31 @@
+{
+    "version": "4.0.0",
+    "description": "Sigma-based threat hunting and fast forensics timeline generator for Windows event logs.",
+    "homepage": "https://github.com/Yamato-Security/hayabusa",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v4.0.0/hayabusa-4.0.0-win-x64.zip",
+            "hash": "6e173c9fd1fa8ee4d95931ea1e1997723330c4779f4f83a96dcd3f1b00d31ff5"
+        },
+        "arm64": {
+            "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v4.0.0/hayabusa-4.0.0-win-aarch64.zip",
+            "hash": "1f8b22c9a8fb2fadff8298a630c6ba48b4ce3bb18c18b5baeb300f1d3986f4bf"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\\hayabusa-*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'hayabusa.exe'",
+    "bin": "hayabusa.exe",
+    "checkver": {
+        "github": "https://github.com/Yamato-Security/hayabusa"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v$version/hayabusa-$version-win-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Yamato-Security/hayabusa/releases/download/v$version/hayabusa-$version-win-aarch64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add hayabusa 4.0.0, a sigma-based threat hunting and fast forensics timeline generator for Windows event logs.

- SHA256 hashes computed locally from fresh downloads of both the `win-x64` and `win-aarch64` release zips
- `checkver` tracks the GitHub repo; autoupdate follows the upstream `hayabusa-$version-win-{x64,aarch64}.zip` asset naming (stable across v3.8.1 → v4.0.0)
- Each zip ships a single versioned `hayabusa-<ver>-win-<arch>.exe` at the root next to `config/` and `rules/`; `pre_install` renames it to `hayabusa.exe` (same pattern as `cc-connect`), so no `extract_dir` is needed
- License `AGPL-3.0-only` per upstream `LICENSE.txt` and README (plain AGPLv3, no "or later" statement)

Closes #7235

Test plan: hashes and zip layout verified by direct download on a Linux host; no Windows/Scoop environment at hand, relying on bucket CI for install validation.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
