### PR TITLE
uutils-coreutils@0.10.0: Add shim for `timeout`

### DIFF
--- a/bucket/uutils-coreutils.json
+++ b/bucket/uutils-coreutils.json
@@ -86,6 +86,7 @@
                 "tail.exe",
                 "tee.exe",
                 "test.exe",
+                "timeout.exe",
                 "touch.exe",
                 "tr.exe",
                 "true.exe",
@@ -466,6 +467,11 @@
                     "coreutils.exe",
                     "test",
                     "test"
+                ],
+                [
+                    "coreutils.exe",
+                    "timeout",
+                    "timeout"
                 ],
                 [
                     "coreutils.exe",
@@ -903,6 +909,11 @@
                     "coreutils.exe",
                     "test",
                     "test"
+                ],
+                [
+                    "coreutils.exe",
+                    "timeout",
+                    "timeout"
                 ],
                 [
                     "coreutils.exe",


### PR DESCRIPTION
uutils coreutils 0.10.0 now has a Windows implementation for `timeout`, so it has been included.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

---

As an aside to anyone who reviews this: I'm thinking of doing a PR that changes the `uutils.exe` shim here to `uutils-coreutils.exe` (it made sense back when coreutils was pretty much all uutils put out but now they have several things, it's like having a `microsoft.exe` shim).

Similarly, I want to make the uutils shim in the microsoft implementation of coreutils named `microsoft-coreutils.exe` instead of `uutils.exe` (I think this was the result of a copy-and-paste).

Let me know if you think this is a good idea.