### PR TITLE
uutils-coreutils-lean: Update to version 0.10.0, switch back to MSVC builds

### DIFF
--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -1,14 +1,37 @@
 {
-    "version": "0.9.0",
-    "description": "Rust implementation of GNU coreutils (binaries compiled with MSVC)",
+    "version": "0.10.0",
+    "description": "A cross-platform Rust reimplementation of GNU coreutils (binaries compiled with MSVC), with some options or behaviors potentially differing from GNU coreutils.",
     "homepage": "https://uutils.github.io/coreutils/",
-    "license": "MIT",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/uutils/coreutils/blob/HEAD/LICENSE"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/uutils/coreutils/releases/download/0.9.0/coreutils-0.9.0-x86_64-pc-windows-gnu.zip",
-            "hash": "3f84876d20b86e2b13ce4cca7d5fe220bc7773b92a3df844e70c2c9b590357d6",
-            "extract_dir": "coreutils-0.9.0-x86_64-pc-windows-gnu"
+            "url": "https://github.com/uutils/coreutils/releases/download/0.10.0/coreutils-0.10.0-x86_64-pc-windows-msvc.zip",
+            "hash": "0510b85218e416e249c3daf6ebdc2c177f4af114a9dc4a3752ceaf35bd2dc567",
+            "extract_dir": "coreutils-0.10.0-x86_64-pc-windows-msvc"
+        },
+        "32bit": {
+            "url": "https://github.com/uutils/coreutils/releases/download/0.10.0/coreutils-0.10.0-i686-pc-windows-msvc.zip",
+            "hash": "300cf7bf25e8ea16edd0caae1cd04430f33451f69764960792491d624c24b52a",
+            "extract_dir": "coreutils-0.10.0-i686-pc-windows-msvc"
+        },
+        "arm64": {
+            "url": "https://github.com/uutils/coreutils/releases/download/0.10.0/coreutils-0.10.0-aarch64-pc-windows-msvc.zip",
+            "hash": "f23cd19a54a3e0114add0e46e3518c4f526cc0445d2556366f0bf16cee759cde",
+            "extract_dir": "coreutils-0.10.0-aarch64-pc-windows-msvc"
         }
+    },
+    "installer": {
+        "script": [
+            "$ErrorActionPreference = 'Stop'",
+            "trap { throw $_ }",
+            "(Get-ChildItem -PSPath $dir -af).Where{ $_.Extension -eq '.exe' -and $_.Name -ne 'coreutils.exe' }.ForEach('Delete')"
+        ]
     },
     "bin": [
         "coreutils.exe",
@@ -23,8 +46,16 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-x86_64-pc-windows-gnu.zip",
-                "extract_dir": "coreutils-$version-x86_64-pc-windows-gnu"
+                "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "coreutils-$version-x86_64-pc-windows-msvc"
+            },
+            "32bit": {
+                "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-i686-pc-windows-msvc.zip",
+                "extract_dir": "coreutils-$version-i686-pc-windows-msvc"
+            },
+            "arm64": {
+                "url": "https://github.com/uutils/coreutils/releases/download/$version/coreutils-$version-aarch64-pc-windows-msvc.zip",
+                "extract_dir": "coreutils-$version-aarch64-pc-windows-msvc"
             }
         }
     }

--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -26,13 +26,7 @@
             "extract_dir": "coreutils-0.10.0-aarch64-pc-windows-msvc"
         }
     },
-    "installer": {
-        "script": [
-            "$ErrorActionPreference = 'Stop'",
-            "trap { throw $_ }",
-            "(Get-ChildItem -PSPath $dir -af).Where{ $_.Extension -eq '.exe' -and $_.Name -ne 'coreutils.exe' }.ForEach('Delete')"
-        ]
-    },
+    "pre_install": "Get-ChildItem \"$dir\\*\" -Include *.exe | Where-Object Name -ne 'coreutils.exe' | Remove-Item",
     "bin": [
         "coreutils.exe",
         [


### PR DESCRIPTION
`uutils/coreutils` no longer publishes a `gnu`-targeted asset. The `msvc`-targeted 64bit asset contains `coreutils.exe` *in addition to* the individual binaries. 32bit and arm64 still only have `coreutils.exe`.

This is essentially now a stripped-down version of the uutils-coreutils.json bucket, except I'm using a `Get-ChildItem -PSPath $dir -af` invocation to get the extracted files, then deleting any exe files that aren't `coreutils.exe`.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
