### PR TITLE
jxl: Add version 0.12.0

### DIFF
--- a/bucket/jxl.json
+++ b/bucket/jxl.json
@@ -1,0 +1,54 @@
+{
+    "version": "0.12.0",
+    "description": "JPEG XL image format (.jxl) encode/decode tools",
+    "homepage": "https://jpeg.org/jpegxl",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/libjxl/libjxl/releases/download/v0.12.0/jxl-x64-windows-static.7z",
+            "hash": "ff147dc7ac4ce55392974ccc70f2a8a8ec0eff3ae28529b072258b66c8f01ab2",
+            "extract_dir": "x64-windows-static/bin"
+        },
+        "32bit": {
+            "url": "https://github.com/libjxl/libjxl/releases/download/v0.12.0/jxl-x86-windows-static.7z",
+            "hash": "c6f419659910a68782810a400aadaf5c1bfcbc67ea324223af09d7a7477c16cc",
+            "extract_dir": "x86-windows-static/bin"
+        }
+    },
+    "bin": [
+        "benchmark_xl.exe",
+        "butteraugli_main.exe",
+        "cjxl.exe",
+        "decode_and_encode.exe",
+        "display_to_hlg.exe",
+        "djxl_fuzzer_corpus.exe",
+        "djxl.exe",
+        "exr_to_pq.exe",
+        "generate_lut_template.exe",
+        "icc_simplify.exe",
+        "jxl_from_tree.exe",
+        "jxlinfo.exe",
+        "jxltran.exe",
+        "local_tone_map.exe",
+        "pq_to_hlg.exe",
+        "render_hlg.exe",
+        "ssimulacra_main.exe",
+        "ssimulacra2.exe",
+        "texture_to_cube.exe",
+        "tone_map.exe",
+        "xyb_range.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/libjxl/libjxl"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x64-windows-static.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/libjxl/libjxl/releases/download/v$version/jxl-x86-windows-static.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #8364

This is a copy of libjxl, but stripping all the `lib` parts, only leaving the `exe` binaries

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Two potential issues:

  - By the way, is there a way to mark this as conflicting with the other since they share the same binaries and will overwrite each other? didn't find anything in the manifest docs on conflicts (though maybe in this case it's not an issue since the binaries don't depend on the libraries? but maybe if not all binaries are included in this package, then it becomes an issue)

  - Also maybe some of the binaries are only useful for development, so should be excluded from this one (e.g., most useful ones are likely just cjxl/djxl/jxlinfo and maybe ssimulacra), but I haven't looked through all of them to determine what can be dropped, so for now left all in (also to extract only some of the binaries would require post-install script, right, there is no magic manifest field `extract_file_list`?).