### PR TITLE
notegen: Add version 0.34.1

### DIFF
--- a/bucket/notegen.json
+++ b/bucket/notegen.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.34.1",
+    "description": "Open-source AI Markdown note-taking application for capturing first, organizing later, and syncing plain Markdown files",
+    "homepage": "https://notegen.top",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/codexu/note-gen/releases/download/note-gen-v0.34.1/NoteGen_0.34.1_x64-setup.exe",
+            "hash": "74816532e12e07808f0f10e74bd9bfadecf32db345dbdf540825d192f089382f"
+        }
+    },
+    "installer": {
+        "file": "NoteGen_0.34.1_x64-setup.exe",
+        "args": "/S"
+    },
+    "checkver": {
+        "github": "https://github.com/codexu/note-gen"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/codexu/note-gen/releases/download/note-gen-v$version/NoteGen_$version_x64-setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
NoteGen is an open-source AI Markdown note-taking application.

- Homepage: https://notegen.top
- Release: https://github.com/codexu/note-gen/releases/tag/note-gen-v0.34.1
- Uses the public Windows x64 installer from the GitHub Release.
- SHA-256 is taken from the release asset metadata.