### PR TITLE
codex@0.147.0: Switch download to package archive

### DIFF
--- a/bucket/codex.json
+++ b/bucket/codex.json
@@ -5,37 +5,17 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-x86_64-pc-windows-msvc.exe#/codex.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-command-runner-x86_64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-windows-sandbox-setup-x86_64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-x86_64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
-            ],
-            "hash": [
-                "935a1911ed2556e4ffcec995f4886ac2ac425863ba26fed264df62e30272ad9d",
-                "3a70491d8d588afa459a42816f05b8c2fdd6bddb0ef318f3dfccc963a30b420a",
-                "a4df86996dfbb218d96d73a80606d89b742dfa4ddd3470614e90dde89e3250a3",
-                "37c23a542037e1bcfd0fa7eb4a150c697229d7ff31bf675c519d5bff7226b191"
-            ]
+            "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-package-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "c156c8feb8cb20197bf74d2c6daffed1fec0a8c21a03bc2ca90d7ff81927b0c5"
         },
         "arm64": {
-            "url": [
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-aarch64-pc-windows-msvc.exe#/codex.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-command-runner-aarch64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-windows-sandbox-setup-aarch64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-aarch64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
-            ],
-            "hash": [
-                "1f0e8c2dd3c6b471e985fac76908366c1cf31155094fde606fb2d3052cf00584",
-                "d7084b87834789ecf039423f83d855d2b9186287f89f19008dc793a0e9c91568",
-                "45026d032a3fed97efe55fbc90c43848ce9434131e6e8c73a0167d7578ada897",
-                "d322d6d721cf7f7ae523bfe31a504875611ec21bbf9b2bffca4b9fd30bdb1675"
-            ]
+            "url": "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-package-aarch64-pc-windows-msvc.tar.gz",
+            "hash": "4533928d72ac4d7c19f16e8c4acdfd02dc255d2aeeb2f6d7dfd45493ec4c0806"
         }
     },
     "bin": [
         [
-            "codex.exe",
+            "bin\\codex.exe",
             "codex"
         ]
     ],
@@ -47,20 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": [
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-x86_64-pc-windows-msvc.exe#/codex.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-command-runner-x86_64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-windows-sandbox-setup-x86_64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-code-mode-host-x86_64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
-                ]
+                "url": "https://github.com/openai/codex/releases/download/rust-v$version/codex-package-x86_64-pc-windows-msvc.tar.gz"
             },
             "arm64": {
-                "url": [
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-aarch64-pc-windows-msvc.exe#/codex.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-command-runner-aarch64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-windows-sandbox-setup-aarch64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-code-mode-host-aarch64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
-                ]
+                "url": "https://github.com/openai/codex/releases/download/rust-v$version/codex-package-aarch64-pc-windows-msvc.tar.gz"
             }
         }
     }

--- a/bucket/codex.json
+++ b/bucket/codex.json
@@ -8,24 +8,28 @@
             "url": [
                 "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-x86_64-pc-windows-msvc.exe#/codex.exe",
                 "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-command-runner-x86_64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-windows-sandbox-setup-x86_64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe"
+                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-windows-sandbox-setup-x86_64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
+                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-x86_64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
             ],
             "hash": [
                 "935a1911ed2556e4ffcec995f4886ac2ac425863ba26fed264df62e30272ad9d",
                 "3a70491d8d588afa459a42816f05b8c2fdd6bddb0ef318f3dfccc963a30b420a",
-                "a4df86996dfbb218d96d73a80606d89b742dfa4ddd3470614e90dde89e3250a3"
+                "a4df86996dfbb218d96d73a80606d89b742dfa4ddd3470614e90dde89e3250a3",
+                "37c23a542037e1bcfd0fa7eb4a150c697229d7ff31bf675c519d5bff7226b191"
             ]
         },
         "arm64": {
             "url": [
                 "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-aarch64-pc-windows-msvc.exe#/codex.exe",
                 "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-command-runner-aarch64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-windows-sandbox-setup-aarch64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe"
+                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-windows-sandbox-setup-aarch64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
+                "https://github.com/openai/codex/releases/download/rust-v0.147.0/codex-code-mode-host-aarch64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
             ],
             "hash": [
                 "1f0e8c2dd3c6b471e985fac76908366c1cf31155094fde606fb2d3052cf00584",
                 "d7084b87834789ecf039423f83d855d2b9186287f89f19008dc793a0e9c91568",
-                "45026d032a3fed97efe55fbc90c43848ce9434131e6e8c73a0167d7578ada897"
+                "45026d032a3fed97efe55fbc90c43848ce9434131e6e8c73a0167d7578ada897",
+                "d322d6d721cf7f7ae523bfe31a504875611ec21bbf9b2bffca4b9fd30bdb1675"
             ]
         }
     },
@@ -46,14 +50,16 @@
                 "url": [
                     "https://github.com/openai/codex/releases/download/rust-v$version/codex-x86_64-pc-windows-msvc.exe#/codex.exe",
                     "https://github.com/openai/codex/releases/download/rust-v$version/codex-command-runner-x86_64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-windows-sandbox-setup-x86_64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe"
+                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-windows-sandbox-setup-x86_64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
+                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-code-mode-host-x86_64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
                 ]
             },
             "arm64": {
                 "url": [
                     "https://github.com/openai/codex/releases/download/rust-v$version/codex-aarch64-pc-windows-msvc.exe#/codex.exe",
                     "https://github.com/openai/codex/releases/download/rust-v$version/codex-command-runner-aarch64-pc-windows-msvc.exe#/codex-command-runner.exe",
-                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-windows-sandbox-setup-aarch64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe"
+                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-windows-sandbox-setup-aarch64-pc-windows-msvc.exe#/codex-windows-sandbox-setup.exe",
+                    "https://github.com/openai/codex/releases/download/rust-v$version/codex-code-mode-host-aarch64-pc-windows-msvc.exe#/codex-code-mode-host.exe"
                 ]
             }
         }

--- a/bucket/codex.json
+++ b/bucket/codex.json
@@ -32,6 +32,9 @@
             "arm64": {
                 "url": "https://github.com/openai/codex/releases/download/rust-v$version/codex-package-aarch64-pc-windows-msvc.tar.gz"
             }
+        },
+        "hash": {
+            "url": "$baseurl/codex-package_SHA256SUMS"
         }
     }
 }


### PR DESCRIPTION
## Summary

Switch the `codex` manifest to the official pre-built Codex package archives for Windows x86_64 and ARM64.

## Problem

Scoop-installed Codex 0.147.0 currently reports this error on startup and Code Mode fails closed:

```text
Code Mode is unavailable because failed to spawn code-mode host
C:\\Users\\<user>\\scoop\\apps\\codex\\current\\codex-code-mode-host.exe:
host executable was not found. Code mode will fail closed; enable
`features.code_mode_host` and install `codex-code-mode-host`.
```

## Why the official package archive

The official `codex-package-<target>.tar.gz` archive is the canonical Codex package and contains all required Windows runtime files in one layout:

- `bin/codex.exe`
- `bin/codex-code-mode-host.exe`
- `codex-resources/codex-command-runner.exe`
- `codex-resources/codex-windows-sandbox-setup.exe`
- `codex-path/rg.exe`
- `codex-package.json`

Codex detects this package layout from `codex-package.json`, resolves the bundled `rg.exe` from `codex-path`, and resolves the code-mode host beside the entrypoint in `bin`. This follows the package format produced and consumed by the official Codex installer.

## Changes

- Replace the individually listed Windows binaries with the official x86_64 and aarch64 package archives.
- Use the release-provided SHA-256 digests for both archives.
- Point the `codex` shim at `bin\\codex.exe` inside the extracted package.
- Use package archive URLs in both autoupdate architecture entries.

No separate `ripgrep` dependency is declared because the official package already contains its runtime `rg.exe`. No `bin` shim is added for the host. No `autoupdate.hash` section is needed because Scoop's built-in GitHub hash mode reads the release asset digest.

Evidence:

- https://github.com/openai/codex/releases/tag/rust-v0.147.0
- https://github.com/openai/codex/blob/rust-v0.147.0/scripts/codex_package/README.md
- https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/install-context/src/lib.rs

## Verification

- Downloaded both package archives and verified their SHA-256 hashes against release metadata.
- Verified both archives contain the canonical package layout and required executables.
- Verified the manifest parses as JSON and `git diff --check` passes.
- PowerShell is unavailable in this environment, so the repository PowerShell verifier could not be run locally; requesting Main's manifest verifier with `/verify`.

Relates to #8369

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
