### PR TITLE
codex@0.147.0: Add ripgrep dependency

### DIFF
--- a/bucket/codex.json
+++ b/bucket/codex.json
@@ -3,6 +3,7 @@
     "description": "OpenAI's Codex AI coding assistant",
     "homepage": "https://github.com/openai/codex",
     "license": "Apache-2.0",
+    "depends": "ripgrep",
     "architecture": {
         "64bit": {
             "url": [


### PR DESCRIPTION
## Summary

Declare `ripgrep` as a runtime dependency of the `codex` manifest.

## Why `depends`

The official Codex Windows distribution bundles ripgrep as part of its runtime package:

- The official package builder documents `codex-path\\rg.exe` in the canonical package layout:
  https://github.com/openai/codex/blob/rust-v0.147.0/scripts/codex_package/README.md
- The official Windows installer validates `rg.exe` as a required package file and includes it in the expected package contents:
  https://github.com/openai/codex/releases/download/rust-v0.147.0/install.ps1
- The Codex runtime doctor checks the selected `rg` command and recommends installing ripgrep when it cannot be verified:
  https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/cli/src/doctor/runtime.rs

The Scoop manifest exposes Codex's Windows binaries individually and does not include the bundled `rg.exe`. Scoop's `depends` field automatically installs runtime dependencies, so `"depends": "ripgrep"` preserves the official installation contract and ensures `rg` is available on PATH.

This is intentionally a separate follow-up PR to the `codex-code-mode-host.exe` asset fix in #8370. It changes no URLs, hashes, autoupdate rules, `bin` entries, or `checkver` configuration.

If maintainers consider an externally installed compatible `rg` sufficient for the Scoop package contract, this can be changed to a `suggest` entry; that would be an explicit policy change because `suggest` only displays an optional recommendation and does not install the runtime automatically.

## Verification

- Verified the manifest parses as JSON and the diff contains only the single `depends` field.
- `git diff --check` passes.
- PowerShell is unavailable in this environment, so the repository PowerShell verifier could not be run locally; requesting Main's manifest verifier with `/verify`.

Relates to #8369

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
