### PR TITLE
maki: Add version 0.4.8

### DIFF
--- a/bucket/maki.json
+++ b/bucket/maki.json
@@ -1,7 +1,7 @@
 {
     "version": "0.4.8",
-    "description": "An efficient AI coding agent extendable by neovim like Lua plugins",
-    "homepage": "https://maki.sh/",
+    "description": "An efficient AI coding agent extendable by neovim like Lua plugins.",
+    "homepage": "https://maki.sh",
     "license": "MIT",
     "suggest": {
         "vcredist": "extras/vcredist2022"
@@ -13,12 +13,6 @@
         }
     },
     "bin": "maki.exe",
-    "shortcuts": [
-        [
-            "maki.exe",
-            "maki"
-        ]
-    ],
     "checkver": {
         "github": "https://github.com/tontinton/maki"
     },
@@ -27,6 +21,9 @@
             "64bit": {
                 "url": "https://github.com/tontinton/maki/releases/download/v$version/maki-v$version-x86_64-pc-windows-msvc.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sums.txt"
         }
     }
 }

--- a/bucket/maki.json
+++ b/bucket/maki.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.4.8",
+    "description": "An efficient AI coding agent extendable by neovim like Lua plugins",
+    "homepage": "https://maki.sh/",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tontinton/maki/releases/download/v0.4.8/maki-v0.4.8-x86_64-pc-windows-msvc.zip",
+            "hash": "8a6d82d7a61369d52cbb7e0333a21a4bc90d416da251bf65cc08072b48d15739"
+        }
+    },
+    "bin": "maki.exe",
+    "shortcuts": [
+        [
+            "maki.exe",
+            "maki"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/tontinton/maki"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tontinton/maki/releases/download/v$version/maki-v$version-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moved PR from Extras to Main. See https://github.com/ScoopInstaller/Extras/pull/18535#issuecomment-5303609035

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

### Prerequisites

- [x] I have searched all issues/PRs to ensure it has not already been reported or fixed.

### Criteria

- [x] Non-GUI tool
- [x] Reasonably well-known and widely used (e.g. if it's a GitHub project, it should have at least 500 stars and/or 150 forks)
- [x] English interface (or at least English documentation)
- [x] Latest stable version
- [x] Full version (i.e. not a trial version)
- [x] Fairly standard install (e.g. uses a version-specific download URL, no elaborate pre/post install scripts)

### Name

maki

### Description

maki - An efficient AI coding agent extendable by neovim like Lua plugins

### Homepage

https://maki.sh/

### Download Link(s)

x64: https://github.com/tontinton/maki/releases/download/v0.4.8/maki-v0.4.8-x86_64-pc-windows-msvc.zip

### Some Indication of Popularity/Repute

- 860 stars, 105 forks
- Full english documentation at https://maki.sh/docs/
- FOSS
