### PR TITLE
uutils-coreutils-lean@0.10.0: Improve pre_install script

### DIFF
--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -26,7 +26,7 @@
             "extract_dir": "coreutils-0.10.0-aarch64-pc-windows-msvc"
         }
     },
-    "pre_install": "Get-ChildItem \"$dir\\*\" -Include *.exe | Where-Object Name -ne 'coreutils.exe' | Remove-Item",
+    "pre_install": "Get-ChildItem -LiteralPath $dir -Filter *.exe | Where-Object Name -ne 'coreutils.exe' | Remove-Item",
     "bin": [
         "coreutils.exe",
         [

--- a/bucket/uutils-coreutils-lean.json
+++ b/bucket/uutils-coreutils-lean.json
@@ -26,7 +26,7 @@
             "extract_dir": "coreutils-0.10.0-aarch64-pc-windows-msvc"
         }
     },
-    "pre_install": "Get-ChildItem -LiteralPath $dir -Filter *.exe | Where-Object Name -ne 'coreutils.exe' | Remove-Item",
+    "pre_install": "Get-ChildItem -LiteralPath $dir -Filter '*.exe' -File | Where-Object Name -ne 'coreutils.exe' | Remove-Item",
     "bin": [
         "coreutils.exe",
         [


### PR DESCRIPTION
Relates to #8363

I'd included an install script in my last PR that the reviewer must've decided was too elaborate and it was trimmed down to:

```powershell
Get-ChildItem "$dir\*" -Include *.exe | Where-Object Name -ne 'coreutils.exe' | Remove-Item
```

But I have some issues with this. The main one being, that if for any reason `$dir` should ever be `$null` (like if there's ever a bug in a future Scoop update), this would (instead of what it was meant to do) silently delete any exe file not named `coreutils.exe` in the current working directory, which could be disasterous.

Furthermore, should `[` or `]` be in the path for any reason, those would be interpreted as wildcard characters and the command would fail.

It's also redundant, if you're going to use a wildcard for `-Path` anyway, you might as well use do `Get-ChildItem "$dir\*.exe"` and skip `-Include`/`-Filter` altogether.

Also, `-Filter` is considered superior to `-Include` [in the official documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-5.1#-filter): *"Filters are more efficient than other parameters. The provider applies the filter when the cmdlet gets the objects rather than having PowerShell filter the objects after they're retrieved."* (The caveat is that `-Filter` can only be used for the FileSystem provider, which is why it doesn't fully supersede `-Include`.)

This is the new line that prevents strange edge-cases and is more performant:

~~`Get-ChildItem -LiteralPath $dir -Filter *.exe | Where-Object Name -ne 'coreutils.exe' | Remove-Item`~~
<sub><i>coderabbitai suggested I add the `-File` parameter, and while I was at it, I also single-quoted `*.exe` for consistency's sake.</i></sub>

```powershell
Get-ChildItem -LiteralPath $dir -Filter '*.exe' -File | Where-Object Name -ne 'coreutils.exe' | Remove-Item
```

I understand I'm being picky, but I'm hoping that Scoop eventually defaults to always using the much safer `-LiteralPath` parameter for its operations.

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
