### PR TITLE
badness: Add version 0.16.0

### DIFF
--- a/bucket/badness.json
+++ b/bucket/badness.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.16.0",
+    "description": "Language server, formatter, and linter for LaTeX.",
+    "homepage": "https://badness.dev",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jolars/badness/releases/download/v0.16.0/badness-x86_64-pc-windows-msvc.zip",
+            "hash": "38bda9eda120ec39a14047e6f5dc0bff3b22faa9aaa00cd02fa476f61db329fa"
+        },
+        "arm64": {
+            "url": "https://github.com/jolars/badness/releases/download/v0.16.0/badness-aarch64-pc-windows-msvc.zip",
+            "hash": "4c70e72d43b65ffe017844110506a69963c38c57a98694ff3b1fe7ef6c40c031"
+        }
+    },
+    "bin": "badness.exe",
+    "checkver": {
+        "github": "https://github.com/jolars/badness"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jolars/badness/releases/download/v$version/badness-x86_64-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/jolars/badness/releases/download/v$version/badness-aarch64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS",
+            "regex": "$sha256\\s+$basename"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This PR adds Badness: a formatter, linter, and language server for LaTeX. The documentation is at https://badness.dev and the repo is at https://github.com/jolars/badness.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
