### PR TITLE
mediainfo@26.05: Add arm64 support

### DIFF
--- a/bucket/mediainfo.json
+++ b/bucket/mediainfo.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://mediaarea.net/download/binary/mediainfo/26.05/MediaInfo_CLI_26.05_Windows_i386.zip",
             "hash": "a686129fcf2a0f8d03c93fdb6325c94e6de7b8d5a1e5bdf40bc899a94d7e785a"
+        },
+        "arm64": {
+            "url": "https://mediaarea.net/download/binary/mediainfo/26.05/MediaInfo_CLI_26.05_Windows_ARM64.zip",
+            "hash": "6b403fa1411730672adefa8d49d97cbf7163eed7fc5c1256c9a6e9f915fde1a8"
         }
     },
     "bin": "mediainfo.exe",
@@ -22,6 +26,9 @@
             },
             "32bit": {
                 "url": "https://mediaarea.net/download/binary/mediainfo/$version/MediaInfo_CLI_$version_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://mediaarea.net/download/binary/mediainfo/$version/MediaInfo_CLI_$version_Windows_ARM64.zip"
             }
         }
     }


### PR DESCRIPTION
Add arm64 support.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)