### PR TITLE
go: Update URL to go.dev

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -1,7 +1,7 @@
 {
     "version": "1.26.7",
     "description": "An open source programming language that makes it easy to build simple, reliable, and efficient software.",
-    "homepage": "https://golang.org",
+    "homepage": "https://go.dev",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
@@ -39,7 +39,7 @@
         "bin\\gofmt.exe"
     ],
     "checkver": {
-        "url": "https://golang.org/dl/",
+        "url": "https://go.dev/dl/",
         "regex": "go([\\d.]+)\\.windows-"
     },
     "autoupdate": {


### PR DESCRIPTION
`golang.org` now redirects to `go.dev`.

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
