### PR TITLE
dirgo: Add version 0.2.1

### DIFF
--- a/bucket/dirgo.json
+++ b/bucket/dirgo.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.1",
+  "description": "Fast, local-first directory navigation for your terminal.",
+  "homepage": "https://github.com/RudySource/Dirgo",
+  "license": "MIT OR Apache-2.0",
+  "notes": [
+    "Run 'dgo --help' to get started.",
+    "Windows supports the CLI and picker, but not parent-shell directory changes yet."
+  ],
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/RudySource/Dirgo/releases/download/v0.2.1/dirgo-v0.2.1-x86_64-pc-windows-msvc.zip",
+      "hash": "de9fa0d562d3ca9d577ede1168fdb19f00f3cf6283754aafe96f31624e66675f",
+      "extract_dir": "dirgo-v0.2.1-x86_64-pc-windows-msvc"
+    }
+  },
+  "bin": "dgo.exe",
+  "checkver": {
+    "github": "https://github.com/RudySource/Dirgo"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/RudySource/Dirgo/releases/download/v$version/dirgo-v$version-x86_64-pc-windows-msvc.zip",
+        "extract_dir": "dirgo-v$version-x86_64-pc-windows-msvc"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Dirgo 0.2.1, a fast local-first directory navigator written in Rust.\n\nUpstream: https://github.com/RudySource/Dirgo\nRelease: https://github.com/RudySource/Dirgo/releases/tag/v0.2.1\n\nValidation performed:\n- manifest JSON parsed successfully\n- release SHA-256 matched published SHA256SUMS\n- extract_dir and dgo.exe path verified\n- checkver and autoupdate configured