### PR TITLE
(chore): Add workaround for incorrect `$global` var in uninstaller

### DIFF
--- a/bucket/bun.json
+++ b/bucket/bun.json
@@ -69,7 +69,10 @@
         "install"
     ],
     "uninstaller": {
-        "script": "Remove-Path -Path \"$persist_dir\\bin\" -Global:$global"
+        "script": [
+            "$global = installed $app $true",
+            "Remove-Path -Path \"$persist_dir\\bin\" -Global:$global"
+        ]
     },
     "checkver": {
         "github": "https://github.com/oven-sh/bun",

--- a/bucket/busybox.json
+++ b/bucket/busybox.json
@@ -48,6 +48,7 @@
             "$process = [System.Diagnostics.Process]::Start($process_info)",
             "$stdout_content = $process.StandardOutput.ReadToEnd()",
             "$process.WaitForExit()",
+            "$global = installed $app $true",
             "rm_shim 'busybox' $(shimdir $global) $app",
             "$stdout_content -split \"`r?`n\" | Where-Object { $_ -match '^\\S' } | ForEach-Object {",
             "    rm_shim $_.Trim() $(shimdir $global) $app",

--- a/bucket/go.json
+++ b/bucket/go.json
@@ -22,7 +22,6 @@
         "script": [
             "$envgopath = \"$env:USERPROFILE\\go\"",
             "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
-            "info \"Adding '$envgopath\\bin' to PATH...\"",
             "Add-Path -Path \"$envgopath\\bin\" -Global:$global -Force"
         ]
     },
@@ -30,7 +29,7 @@
         "script": [
             "$envgopath = \"$env:USERPROFILE\\go\"",
             "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
-            "info \"Removing '$envgopath\\bin' from PATH...\"",
+            "$global = installed $app $true",
             "Remove-Path -Path \"$envgopath\\bin\" -Global:$global"
         ]
     },

--- a/bucket/jdtls.json
+++ b/bucket/jdtls.json
@@ -13,7 +13,10 @@
         "script": "shim (Get-Command 'python.exe').Source $global jdtls \"$dir\\bin\\jdtls\""
     },
     "uninstaller": {
-        "script": "rm_shim jdtls (shimdir $global) jdtls"
+        "script": [
+            "$global = installed $app $true",
+            "rm_shim jdtls (shimdir $global) jdtls"
+        ]
     },
     "checkver": {
         "url": "https://download.eclipse.org/jdtls/snapshots/latest.txt",

--- a/bucket/megacmd.json
+++ b/bucket/megacmd.json
@@ -20,6 +20,7 @@
     ],
     "uninstaller": {
         "script": [
+            "$global = installed $app $true",
             "$datapath = if ($global) { $env:APPDATA } else { $env:LOCALAPPDATA }",
             "if ((Get-Item \"$datapath\\MEGAcmd\" -ErrorAction SilentlyContinue).Attributes -band [IO.FileAttributes]::ReparsePoint) {",
             "    & \"$env:COMSPEC\" /c \"rmdir `\"$datapath\\MEGAcmd`\"\"",

--- a/bucket/nim.json
+++ b/bucket/nim.json
@@ -55,6 +55,9 @@
         "script": "Add-Path -Path \"$env:USERPROFILE\\.nimble\\bin\" -Global:$global"
     },
     "uninstaller": {
-        "script": "Remove-Path -Path \"$env:USERPROFILE\\.nimble\\bin\" -Global:$global"
+        "script": [
+            "$global = installed $app $true",
+            "Remove-Path -Path \"$env:USERPROFILE\\.nimble\\bin\" -Global:$global"
+        ]
     }
 }

--- a/bucket/stack.json
+++ b/bucket/stack.json
@@ -14,7 +14,10 @@
         "script": "Add-Path -Path \"$env:APPDATA\\local\\bin\" -Global:$global"
     },
     "uninstaller": {
-        "script": "Remove-Path -Path \"$env:APPDATA\\local\\bin\" -Global:$global"
+        "script": [
+            "$global = installed $app $true",
+            "Remove-Path -Path \"$env:APPDATA\\local\\bin\" -Global:$global"
+        ]
     },
     "checkver": {
         "github": "https://github.com/commercialhaskell/stack"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->
This PR adds a workaround for the incorrect `$global` variable in the uninstaller (https://github.com/ScoopInstaller/Scoop/pull/6454). Additionally, It removes duplicate print messages in the `go` package (#8433).
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
