### PR TITLE
git: Ensure gitconfig formatting consistency

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -34,7 +34,7 @@
         "    info \"Restoring system-level config from $config_path_persisted...\"",
         "    Copy-Item -Path $config_path_persisted -Destination $config_path -Force",
         "    info \"Adjusting paths in $config_path...\"",
-        "    (Get-Content -Path $config_path -Encoding UTF8) -replace '(?<=git/)[\\d.]+(?=/)', $version | Set-Content -Path $config_path -Encoding UTF8",
+        "    [System.IO.File]::WriteAllText($config_path, ([System.IO.File]::ReadAllText($config_path) -replace '(?<=git/)[\\d.]+(?=/)', $version), [System.Text.UTF8Encoding]::new($false))",
         "}"
     ],
     "post_install": [

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -34,7 +34,8 @@
         "    info \"Restoring system-level config from $config_path_persisted...\"",
         "    Copy-Item -Path $config_path_persisted -Destination $config_path -Force",
         "    info \"Adjusting paths in $config_path...\"",
-        "    [System.IO.File]::WriteAllText($config_path, ([System.IO.File]::ReadAllText($config_path) -replace '(?<=git/)[\\d.]+(?=/)', $version), [System.Text.UTF8Encoding]::new($false))",
+        "    $content = [System.IO.File]::ReadAllText($config_path) -replace '(?<=git/)[\\d.]+(?=/)', $version",
+        "    [System.IO.File]::WriteAllText($config_path, $content, [System.Text.UTF8Encoding]::new($false))",
         "}"
     ],
     "post_install": [


### PR DESCRIPTION
Use `[System.IO.File]` instead of `Get-Content | Set-Content` in order to:

1. Avoid writing UTF-8 with BOM under Windows PowerShell 5.1.
2. Preserve original line endings.

This improves compatibility with scripts and third-party tools that parse `gitconfig`.

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
