### PR TITLE
deja-vu: Add version 0.18.0

### DIFF
--- a/bucket/deja-vu.json
+++ b/bucket/deja-vu.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.18.0",
+    "description": "Persistent memory for coding agents",
+    "homepage": "https://github.com/vshulcz/deja-vu",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip",
+            "hash": "e2c5a442afb3f208aa1389be031b2ac595de3c79b1179856fb843a1f1b042391"
+        },
+        "arm64": {
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip",
+            "hash": "f814fe2117f69ae1d2cc2202e6c3d37e90ef7cde705c3e3c6de1dfdfa4743b25"
+        }
+    },
+    "bin": "deja.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/vshulcz/deja-vu/releases/download/v$version/deja-vu_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/vshulcz/deja-vu/releases/download/v$version/deja-vu_$version_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}

--- a/bucket/deja-vu.json
+++ b/bucket/deja-vu.json
@@ -1,7 +1,7 @@
 {
     "version": "0.18.0",
     "description": "Persistent memory for coding agents",
-    "homepage": "https://github.com/vshulcz/deja-vu",
+    "homepage": "https://vshulcz.github.io/deja-vu/",
     "license": "MIT",
     "architecture": {
         "64bit": {
@@ -14,7 +14,9 @@
         }
     },
     "bin": "deja.exe",
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/vshulcz/deja-vu"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Closes #8438

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

Opened against Extras first; @z-Fng closed that one as Main material and the request issue was moved here, so this is the same manifest in the right bucket.

`deja-vu` 0.18.0 — a command-line tool that searches the session transcripts coding agents already write to disk. MIT, 704 stars, and in homebrew-core.

Single `deja.exe` out of a versioned archive, no pre/post install scripts. `checkver: github`, and `autoupdate` reads hashes from the `checksums.txt` published beside every release, so bumps need no manual hashing. Both architectures are separate builds — the hashes differ.

I could not run `scoop` or `checkver` locally: this was prepared on macOS. What I did verify is that both architecture hashes match the sha256 in the release's own `checksums.txt`, that they differ from one another, and that both archive URLs return 200.
