### PR TITLE
go: Handle multi-entry GOPATH

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -20,17 +20,17 @@
     "extract_dir": "go",
     "installer": {
         "script": [
-            "$envgopath = \"$env:USERPROFILE\\go\"",
-            "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
-            "Add-Path -Path \"$envgopath\\bin\" -Global:$global -Force"
+            "$first_entry = ((\"$env:GOPATH\" -split ';').Trim() -ne '')[0]",
+            "$bin_path = if ($first_entry) { Join-Path $first_entry 'bin' } else { \"$env:USERPROFILE\\go\\bin\" }",
+            "Add-Path -Path $bin_path -Global:$global -Force"
         ]
     },
     "uninstaller": {
         "script": [
-            "$envgopath = \"$env:USERPROFILE\\go\"",
-            "if ($env:GOPATH) { $envgopath = $env:GOPATH }",
+            "$first_entry = ((\"$env:GOPATH\" -split ';').Trim() -ne '')[0]",
+            "$bin_path = if ($first_entry) { Join-Path $first_entry 'bin' } else { \"$env:USERPROFILE\\go\\bin\" }",
             "$global = installed $app $true",
-            "Remove-Path -Path \"$envgopath\\bin\" -Global:$global"
+            "Remove-Path -Path $bin_path -Global:$global"
         ]
     },
     "bin": [


### PR DESCRIPTION
Follow-up to https://github.com/ScoopInstaller/Main/pull/8433

Select the first non-empty `GOPATH` entry when updating `PATH` in install and uninstall scripts to prevent malformed entries when `GOPATH` contains multiple paths.

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
