### PR TITLE
luajit: Update to version 2.1.1785606157-1, drop 32bit support, add arm64 support

### DIFF
--- a/bucket/luajit.json
+++ b/bucket/luajit.json
@@ -23,18 +23,10 @@
     "autoupdate": {
         "architecture": {
             "arm64": {
-                "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-luajit-$version-any.pkg.tar.zst",
-                "hash": {
-                    "url": "https://packages.msys2.org/packages/mingw-w64-clang-aarch64-luajit",
-                    "regex": "SHA256:\\s*$sha256"
-                }
+                "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-luajit-$version-any.pkg.tar.zst"
             },
             "64bit": {
-                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-luajit-$version-any.pkg.tar.zst",
-                "hash": {
-                    "url": "https://packages.msys2.org/packages/mingw-w64-x86_64-luajit",
-                    "regex": "SHA256:\\s*$sha256"
-                }
+                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-luajit-$version-any.pkg.tar.zst"
             }
         }
     }

--- a/bucket/luajit.json
+++ b/bucket/luajit.json
@@ -1,18 +1,18 @@
 {
-    "version": "2.1.1779665312-1",
+    "version": "2.1.1785606157-1",
     "description": "Just-In-Time Compiler (JIT) for the Lua programming language.",
     "homepage": "https://luajit.org/luajit.html",
     "license": "MIT",
     "architecture": {
-        "64bit": {
-            "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-luajit-2.1.1779665312-1-any.pkg.tar.zst",
-            "hash": "912d359c2a0966fb503ae4c319f9d5d21826500a7377952696cd5ccf46bf7017",
-            "extract_dir": "mingw64"
+        "arm64": {
+            "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-luajit-2.1.1785606157-1-any.pkg.tar.zst",
+            "hash": "12e14ad430e5bbc722b16b15c42eca4475d6b78d29db2fb33e5a2784e9a5ec38",
+            "extract_dir": "clangarm64"
         },
-        "32bit": {
-            "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-luajit-2.1.1779665312-1-any.pkg.tar.zst",
-            "hash": "165e60fccdf1cf6752f7e06cffebca3cce32737795d494c1901263f8717c5716",
-            "extract_dir": "mingw32"
+        "64bit": {
+            "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-luajit-2.1.1785606157-1-any.pkg.tar.zst",
+            "hash": "f6a5e2195148cb41ad9d23b7b2a4ee5a620ecc9f33e680be624f94c0527603f0",
+            "extract_dir": "mingw64"
         }
     },
     "bin": "bin\\luajit.exe",
@@ -22,11 +22,19 @@
     },
     "autoupdate": {
         "architecture": {
-            "64bit": {
-                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-luajit-$version-any.pkg.tar.zst"
+            "arm64": {
+                "url": "https://mirror.msys2.org/mingw/clangarm64/mingw-w64-clang-aarch64-luajit-$version-any.pkg.tar.zst",
+                "hash": {
+                    "url": "https://packages.msys2.org/packages/mingw-w64-clang-aarch64-luajit",
+                    "regex": "SHA256:\\s*$sha256"
+                }
             },
-            "32bit": {
-                "url": "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-luajit-$version-any.pkg.tar.zst"
+            "64bit": {
+                "url": "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-luajit-$version-any.pkg.tar.zst",
+                "hash": {
+                    "url": "https://packages.msys2.org/packages/mingw-w64-x86_64-luajit",
+                    "regex": "SHA256:\\s*$sha256"
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #8443 - mingw32 build no longer published on msys2.org (https://github.com/msys2/MINGW-packages/commit/1edc149ba5be8bffc77f3ec546f5d214d10781ae), but arm64 build (`clang-aarch64`) is now provided. This PR removes the defunct 32bit build, adds the arm64 build, and pulls sha256 hashes from the package listings on msys2.org.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
