### PR TITLE
llvm-arm64: Update to version 23.1.0, fix autoupdate

### DIFF
--- a/bucket/llvm-arm64.json
+++ b/bucket/llvm-arm64.json
@@ -1,15 +1,15 @@
 {
-    "version": "22.1.8",
+    "version": "23.1.0",
     "description": "Collection of modular and reusable compiler and toolchain technologies. (arm64/aarch64 only)",
     "homepage": "https://www.llvm.org",
     "license": "NCSA",
     "architecture": {
         "arm64": {
-            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.8/LLVM-22.1.8-woa64.exe#/dl.7z",
-            "hash": "76f44ef1ba6eeb5a65904e9500f042f588fade49952778ce48f0374daa934396"
+            "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-23.1.0/LLVM-23.1.0-woa64.msi",
+            "hash": "6485e32819681cb4f5300ab8fdf8b185b7075af4a9fe2a49813556f1c5ccadff"
         }
     },
-    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe\" -Recurse",
+    "extract_dir": "LLVM",
     "env_add_path": "bin",
     "env_set": {
         "LIBCLANG_PATH": "$dir\\bin",
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "arm64": {
-                "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/LLVM-$version-woa64.exe#/dl.7z"
+                "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-$version/LLVM-$version-woa64.msi"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Follow-up to https://github.com/ScoopInstaller/Main/pull/8451. The arm64 build failed and was just re-released a few hours ago.

Upstream PR https://github.com/llvm/llvm-project/pull/200734 changed old NSIS installer to WIX msi installer.

> The NSIS based installer had a limit of 2GB, and we started going over that, so we needed to move to Wix which supports much larger installer sizes.

Closes https://github.com/ScoopInstaller/Main/issues/8450

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
