### PR TITLE
charasay: Add version 3.3.3

### DIFF
--- a/bucket/charasay.json
+++ b/bucket/charasay.json
@@ -1,0 +1,21 @@
+{
+    "version": "3.3.3",
+    "description": "The future of cowsay! Colorful characters saying something.",
+    "homepage": "https://github.com/latipun7/charasay",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/latipun7/charasay/releases/download/v3.3.3/chara-x86_64-pc-windows-gnu.zip",
+            "hash": "28266703eba30807fadaa363d7c24f0d91e4fb146d5f3884a8b6dcbbc3c81eb0"
+        }
+    },
+    "bin": "chara.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/latipun7/charasay/releases/download/v$version/chara-x86_64-pc-windows-gnu.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
Add charasay - The future of cowsay! Colorful characters saying something.

## Details
- **Homepage:** https://github.com/latipun7/charasay
- **License:** MIT
- **Binary:** `chara.exe` (portable, no install required)
- **Auto-update:** Configured via GitHub releases

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Manifest follows the [App Manifests](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests) spec
- [x] `checkver` and `autoupdate` are configured
- [x] Binary is portable (no install step needed)

/verify