### PR TITLE
grpcurl@1.9.4: Add arm64 support

### DIFF
--- a/bucket/grpcurl.json
+++ b/bucket/grpcurl.json
@@ -11,6 +11,10 @@
         "32bit": {
             "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.4/grpcurl_1.9.4_windows_x86_32.zip",
             "hash": "5262c99be09e6ce4a90a423d1afd1e8972843acdda37213ca58862d7f57f68d7"
+        },
+        "arm64": {
+            "url": "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.4/grpcurl_1.9.4_windows_arm64.zip",
+            "hash": "f42f6646bc259989cc8e8b7ecb3b987456ea24dd103361bcabb61534f2c77189"
         }
     },
     "bin": "grpcurl.exe",
@@ -26,6 +30,9 @@
             },
             "32bit": {
                 "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_x86_32.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/fullstorydev/grpcurl/releases/download/v$version/grpcurl_$version_windows_arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Add arm64 option.
Relates to fullstorydev/grpcurl#542.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
