### PR TITLE
harfbuzz@14.4.0: Add missing shims

### DIFF
--- a/bucket/harfbuzz.json
+++ b/bucket/harfbuzz.json
@@ -16,6 +16,9 @@
         }
     },
     "bin": [
+        "hb-gpu.exe",
+        "hb-info.exe",
+        "hb-raster.exe",
         "hb-shape.exe",
         "hb-subset.exe",
         "hb-view.exe"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

Closes #8470

The package https://github.com/harfbuzz/harfbuzz/releases/download/14.4.0/harfbuzz-win64-14.4.0.zip actually contains 6 executable files. Added the missing `hb-gpu.exe`, `hb-info.exe` and `hb-raster.exe`

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
