### PR TITLE
cliamp@2.0.1: Install zip with bundled DLLs

### DIFF
--- a/bucket/cliamp.json
+++ b/bucket/cliamp.json
@@ -5,10 +5,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bjarneo/cliamp/releases/download/v2.0.1/cliamp-windows-amd64.exe#/cliamp.exe",
-            "hash": "3e08d15c5f3e30c90c3e9b6c9ed816edd26d5f4aecac5d6429f01dcda98cb53e"
+            "url": "https://github.com/bjarneo/cliamp/releases/download/v2.0.1/cliamp-windows-amd64.zip",
+            "hash": "2b874b74caee3426cc39b55719e7cfc63a06739cd1d7f56649f31ed16cbe9f8f"
         }
     },
+    "extract_dir": "cliamp-windows-amd64",
     "bin": "cliamp.exe",
     "checkver": {
         "github": "https://github.com/bjarneo/cliamp"
@@ -16,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/bjarneo/cliamp/releases/download/v$version/cliamp-windows-amd64.exe#/cliamp.exe"
+                "url": "https://github.com/bjarneo/cliamp/releases/download/v$version/cliamp-windows-amd64.zip"
             }
         }
     }

--- a/bucket/cliamp.json
+++ b/bucket/cliamp.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/bjarneo/cliamp/releases/download/v2.0.1/cliamp-windows-amd64.zip",
-            "hash": "2b874b74caee3426cc39b55719e7cfc63a06739cd1d7f56649f31ed16cbe9f8f"
+            "hash": "2b874b74caee3426cc39b55719e7cfc63a06739cd1d7f56649f31ed16cbe9f8f",
+            "extract_dir": "cliamp-windows-amd64"
         }
     },
-    "extract_dir": "cliamp-windows-amd64",
     "bin": "cliamp.exe",
     "checkver": {
         "github": "https://github.com/bjarneo/cliamp"


### PR DESCRIPTION
Scoop is still downloading the bare `cliamp-windows-amd64.exe`, so `apps/cliamp/current` only gets the exe. Since 2.0.0 the Windows build needs the codec DLLs next to it (`libFLAC.dll`, `libmpg123-0.dll`, `libvorbis-0.dll`, `libvorbisenc-2.dll`, …). Without them you get the missing-DLL pop-ups and it won’t even start.

The zip already ships those DLLs under `cliamp-windows-amd64/`. This just points the manifest at that zip and sets `extract_dir`.

https://github.com/bjarneo/cliamp/issues/419

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <message>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
