### PR TITLE
pkgconf@3.0.7: Fix `extract_dir`

### DIFF
--- a/bucket/pkgconf.json
+++ b/bucket/pkgconf.json
@@ -36,15 +36,15 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-$version/pkgconf-x64-$version.msi",
-                "extract_dir": "PFiles64\\pkgconf $version"
+                "extract_dir": "PFiles64\\pkgconf-$version"
             },
             "32bit": {
                 "url": "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-$version/pkgconf-x86-$version.msi",
-                "extract_dir": "PFiles\\pkgconf $version"
+                "extract_dir": "PFiles\\pkgconf-$version"
             },
             "arm64": {
                 "url": "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-$version/pkgconf-arm64-$version.msi",
-                "extract_dir": "PFiles64\\pkgconf $version"
+                "extract_dir": "PFiles64\\pkgconf-$version"
             }
         }
     }

--- a/bucket/pkgconf.json
+++ b/bucket/pkgconf.json
@@ -7,17 +7,17 @@
         "64bit": {
             "url": "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-3.0.7/pkgconf-x64-3.0.7.msi",
             "hash": "7a316dba4a4498ea952b746c82deed41c597657095a0f776b75654191b45ae44",
-            "extract_dir": "PFiles64\\pkgconf 3.0.7"
+            "extract_dir": "PFiles64\\pkgconf-3.0.7"
         },
         "32bit": {
             "url": "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-3.0.7/pkgconf-x86-3.0.7.msi",
             "hash": "5577e1cb77556d72859a474c1e91741506f3cb8d6ddb39002432b667c7a3d863",
-            "extract_dir": "PFiles\\pkgconf 3.0.7"
+            "extract_dir": "PFiles\\pkgconf-3.0.7"
         },
         "arm64": {
             "url": "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-3.0.7/pkgconf-arm64-3.0.7.msi",
             "hash": "bc690b61cf20d0f8fa81b263482c1c50afe852298301bb7f99bbead80c19f7dc",
-            "extract_dir": "PFiles64\\pkgconf 3.0.7"
+            "extract_dir": "PFiles64\\pkgconf-3.0.7"
         }
     },
     "bin": [


### PR DESCRIPTION
The name changed in https://github.com/pkgconf/pkgconf/commit/f0fa065078ba1e64dfc1a3021e1bade3129411c3

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
