### PR TITLE
go: Fix first GOPATH entry parsing

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -20,14 +20,14 @@
     "extract_dir": "go",
     "installer": {
         "script": [
-            "$first_entry = ((\"$env:GOPATH;\" -split ';').Trim() -ne '')[0]",
+            "$first_entry = $env:GOPATH -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -First 1",
             "$bin_path = if ($first_entry) { Join-Path $first_entry 'bin' } else { \"$env:USERPROFILE\\go\\bin\" }",
             "Add-Path -Path $bin_path -Global:$global -Force"
         ]
     },
     "uninstaller": {
         "script": [
-            "$first_entry = ((\"$env:GOPATH;\" -split ';').Trim() -ne '')[0]",
+            "$first_entry = $env:GOPATH -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -First 1",
             "$bin_path = if ($first_entry) { Join-Path $first_entry 'bin' } else { \"$env:USERPROFILE\\go\\bin\" }",
             "$global = installed $app $true",
             "Remove-Path -Path $bin_path -Global:$global"

--- a/bucket/go.json
+++ b/bucket/go.json
@@ -20,14 +20,14 @@
     "extract_dir": "go",
     "installer": {
         "script": [
-            "$first_entry = ((\"$env:GOPATH\" -split ';').Trim() -ne '')[0]",
+            "$first_entry = ((\"$env:GOPATH;\" -split ';').Trim() -ne '')[0]",
             "$bin_path = if ($first_entry) { Join-Path $first_entry 'bin' } else { \"$env:USERPROFILE\\go\\bin\" }",
             "Add-Path -Path $bin_path -Global:$global -Force"
         ]
     },
     "uninstaller": {
         "script": [
-            "$first_entry = ((\"$env:GOPATH\" -split ';').Trim() -ne '')[0]",
+            "$first_entry = ((\"$env:GOPATH;\" -split ';').Trim() -ne '')[0]",
             "$bin_path = if ($first_entry) { Join-Path $first_entry 'bin' } else { \"$env:USERPROFILE\\go\\bin\" }",
             "$global = installed $app $true",
             "Remove-Path -Path $bin_path -Global:$global"


### PR DESCRIPTION
Relates to #8440

When there is only one entry in the `GOPATH` and no semicolon following it, `$first_entry` will be assigned the value `True`.

<!-- -->

<details>
<summary>Test</summary>

```powershell
$cases = @(
    @{ Name = 'single entry'; GOPATH = 'C:\Users\a\go'; Expected = 'C:\Users\a\go' }
    @{ Name = 'multiple entries'; GOPATH = 'C:\a;D:\b'; Expected = 'C:\a' }
    @{ Name = 'empty + spaces'; GOPATH = ' ; C:\x;  '; Expected = 'C:\x' }
    @{ Name = 'unset (empty)'; GOPATH = ''; Expected = $null }
    @{ Name = 'space only'; GOPATH = ' '; Expected = $null }
    @{ Name = 'null'; GOPATH = $null; Expected = $null }
)

function Get-FirstGopathEntry {
    $env:GOPATH -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -First 1
    # (("$env:GOPATH" -split ';').Trim() -ne '')[0]
    # (("$env:GOPATH;" -split ';').Trim() -ne '')[0]
}

$pass = 0
foreach ($c in $cases) {
    $env:GOPATH = $c.GOPATH
    $actual = Get-FirstGopathEntry
    $ok = ($null -eq $actual -and $null -eq $c.Expected) -or ($actual -eq $c.Expected)
    if ($ok) { $pass++ }
    '{0,-20} expected=[{1}] actual=[{2}] {3}' -f $c.Name, $c.Expected, $actual, $(if ($ok) { 'PASS' }else { 'FAIL' })
}
"`n$pass / $($cases.Count) passed"
Remove-Item Env:GOPATH -ErrorAction SilentlyContinue
```

</details>

<!-- -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
