### PR TITLE
wcurl: Update to version 2026.08.30

### DIFF
--- a/bucket/wcurl.json
+++ b/bucket/wcurl.json
@@ -1,28 +1,19 @@
 {
-    "version": "2024.07.10",
+    "version": "2026.08.30",
     "homepage": "https://curl.se/wcurl/",
     "description": "A simple wrapper around curl to easily download files",
     "license": "MIT",
-    "depends": [
-        "curl",
-        "busybox"
-    ],
-    "url": "https://github.com/curl/wcurl/archive/2024.07.10.zip",
-    "hash": "67e93b65cf27eb2f3f52f0e4fb7ce104e9e93899b87495512e1d861ba998ea7d",
-    "extract_dir": "wcurl-2024.07.10",
-    "bin": [
-        [
-            "sh.exe",
-            "wcurl",
-            "$dir\\wcurl"
-        ]
-    ],
+    "suggest": {
+        "git": "git",
+        "curl": "curl"
+    },
+    "url": "https://github.com/curl/wcurl/releases/download/v2026.08.30/wcurl",
+    "hash": "739a03b12f98c8ba864b8775440a5b4e337248e4986e51528da5806387894f65",
+    "bin": "wcurl",
     "checkver": {
-        "url": "https://github.com/curl/wcurl/tags",
-        "regex": "tag/([\\d.-]+)"
+        "github": "https://github.com/curl/wcurl"
     },
     "autoupdate": {
-        "url": "https://github.com/curl/wcurl/archive/$version.zip",
-        "extract_dir": "wcurl-$version"
+        "url": "https://github.com/curl/wcurl/releases/download/v$version/wcurl"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.

  Automatic code review is supported but disabled by default in this repository.
  You may trigger AI code review by requesting `Copilot` from the Reviewers menu,
  or by commenting `@coderabbitai review`.
-->

- Fix `homepage` order
- Point `url` to the `wcurl` script instead of the entire archive.
- Move `depends` to `suggest` & remove `busybox` dependency (Scoop automatically creates a shim to bash)

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
